### PR TITLE
Parental controls: session limits, web UI, OTA, stats

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,6 +35,12 @@
 - [x] Wokwi port forwarding (device:80 → localhost:8080)
 - [x] Convert main loop to uasyncio (web server + UI run concurrently)
 - [x] Session-aware LED animations (amber warnings, fade-off wind-down, dark sleep)
+- [x] PIN protection for web UI
+- [x] OTA firmware updates with bearer token auth
+- [x] Per-mode time limits (v2 — infrastructure ready, modes use when Milestone 3 arrives)
+- [x] Session recording to flash (date, start time, duration, mode, end reason)
+- [x] Usage statistics over time (v3 — daily totals, mode breakdown, 7-day history)
+- [x] Suggested limits based on actual usage patterns (v3)
 
 ## Milestone 5: Quality-of-life
 

--- a/firmware/bodn/session.py
+++ b/firmware/bodn/session.py
@@ -10,31 +10,62 @@ SLEEPING = "SLEEPING"
 COOLDOWN = "COOLDOWN"
 LOCKDOWN = "LOCKDOWN"
 
+# Known play modes (new modes added here as Milestone 3 progresses)
+MODE_FREE_PLAY = "free_play"
+MODE_SOUND_MIXER = "sound_mixer"
+MODE_RECORDER = "recorder"
+MODE_SEQUENCER = "sequencer"
+ALL_MODES = [MODE_FREE_PLAY, MODE_SOUND_MIXER, MODE_RECORDER, MODE_SEQUENCER]
+
 
 class SessionManager:
     """Manages play session timing and limits.
 
     Pure logic — inject get_time (returns epoch seconds) and
     get_date (returns "YYYY-MM-DD" string) for testability.
+    Optional on_session_end callback receives a session record dict.
     """
 
-    def __init__(self, settings, get_time, get_date):
+    def __init__(self, settings, get_time, get_date, on_session_end=None):
         self.settings = settings
         self._get_time = get_time
         self._get_date = get_date
+        self._on_session_end = on_session_end
         self.state = IDLE
         self._session_start = 0
         self._sleep_start = 0
         self._sessions_today = 0
         self._today = ""
+        self._mode = MODE_FREE_PLAY
+        self._end_reason = ""
+
+    @property
+    def mode(self):
+        return self._mode
+
+    def set_mode(self, mode):
+        """Set the current play mode. Affects per-mode time limits."""
+        self._mode = mode
+
+    def _session_limit_s(self):
+        """Return session limit in seconds for the current mode."""
+        mode_limits = self.settings.get("mode_limits", {})
+        mode_limit = mode_limits.get(self._mode)
+        if mode_limit is not None:
+            if mode_limit == 0:
+                return 0  # unlimited
+            return mode_limit * 60
+        return self.settings["max_session_min"] * 60
 
     @property
     def time_remaining_s(self):
         """Seconds remaining in current session, or 0 if not playing."""
         if self.state not in (PLAYING, WARN_5, WARN_2):
             return 0
+        limit = self._session_limit_s()
+        if limit == 0:
+            return 9999  # unlimited — always plenty of time
         elapsed = self._get_time() - self._session_start
-        limit = self.settings["max_session_min"] * 60
         return max(0, limit - elapsed)
 
     @property
@@ -56,17 +87,33 @@ class SessionManager:
         qe = self.settings.get("quiet_end")
         if qs is None or qe is None:
             return False
-        # quiet_start/end are "HH:MM" strings
         now_s = self._get_time()
-        # Extract hour:minute from epoch — caller provides localtime-aware get_time
         h = (now_s % 86400) // 3600
         m = (now_s % 3600) // 60
         now_hm = "{:02d}:{:02d}".format(h, m)
         if qs <= qe:
             return qs <= now_hm < qe
         else:
-            # Wraps midnight: e.g. 21:00 → 07:00
             return now_hm >= qs or now_hm < qe
+
+    def _record_session(self, reason):
+        """Record a completed session via the callback."""
+        self._sessions_today += 1
+        if self._on_session_end:
+            now = self._get_time()
+            duration_s = now - self._session_start
+            # Format start time as HH:MM
+            start_h = (self._session_start % 86400) // 3600
+            start_m = (self._session_start % 3600) // 60
+            record = {
+                "date": self._get_date(),
+                "start_time": "{:02d}:{:02d}".format(start_h, start_m),
+                "duration_s": duration_s,
+                "duration_min": round(duration_s / 60, 1),
+                "mode": self._mode,
+                "end_reason": reason,
+            }
+            self._on_session_end(record)
 
     def tick(self):
         """Call every frame. Returns current state string."""
@@ -118,14 +165,12 @@ class SessionManager:
                 self._sleep_start = now
 
         elif self.state == WINDDOWN:
-            # 30-second wind-down animation, then sleep
             if now - self._sleep_start >= 30:
                 self.state = SLEEPING
                 self._sleep_start = now
-                self._sessions_today += 1
+                self._record_session("normal")
 
         elif self.state == SLEEPING:
-            # Transition to cooldown immediately — sleeping is a brief visual state
             self.state = COOLDOWN
             self._sleep_start = now
 
@@ -136,7 +181,7 @@ class SessionManager:
 
         return self.state
 
-    def try_wake(self):
+    def try_wake(self, mode=None):
         """Attempt to start a new session. Returns True if allowed."""
         self._reset_day_if_needed()
 
@@ -154,11 +199,12 @@ class SessionManager:
 
         self.state = PLAYING
         self._session_start = self._get_time()
+        self._mode = mode or MODE_FREE_PLAY
         return True
 
     def force_sleep(self):
         """Immediately end current session (for lockdown toggle)."""
         if self.state in (PLAYING, WARN_5, WARN_2):
-            self._sessions_today += 1
+            self._record_session("force_sleep")
         self.state = SLEEPING
         self._sleep_start = self._get_time()

--- a/firmware/bodn/storage.py
+++ b/firmware/bodn/storage.py
@@ -22,6 +22,7 @@ DEFAULT_SETTINGS = {
     "wifi_mode": "ap",
     "ui_pin": "",
     "ota_token": "",
+    "mode_limits": {},
 }
 
 # Keep 7 days of session history
@@ -91,6 +92,94 @@ def save_session(session):
 
 
 def sessions_today(date_str):
-    """Count sessions for a given date string (YYYY-MM-DD)."""
+    """Return sessions for a given date string (YYYY-MM-DD)."""
     sessions = load_sessions()
     return [s for s in sessions if s.get("date") == date_str]
+
+
+def compute_stats(sessions):
+    """Compute usage statistics from a list of session records.
+
+    Returns a dict with aggregated stats for display in the web UI.
+    """
+    if not sessions:
+        return {
+            "total_days": 0,
+            "total_sessions": 0,
+            "total_play_min": 0,
+            "avg_session_min": 0,
+            "avg_sessions_per_day": 0,
+            "avg_daily_play_min": 0,
+            "mode_breakdown": {},
+            "daily_totals": [],
+            "suggestions": {},
+        }
+
+    total_sessions = len(sessions)
+    total_play_s = sum(s.get("duration_s", 0) for s in sessions)
+
+    # Group by date
+    by_date = {}
+    for s in sessions:
+        d = s.get("date", "")
+        if d not in by_date:
+            by_date[d] = []
+        by_date[d].append(s)
+
+    total_days = max(1, len(by_date))
+    avg_session_s = total_play_s / max(1, total_sessions)
+    avg_sessions_per_day = total_sessions / total_days
+    avg_daily_play_s = total_play_s / total_days
+
+    # Mode breakdown
+    mode_play = {}
+    for s in sessions:
+        mode = s.get("mode", "free_play")
+        mode_play[mode] = mode_play.get(mode, 0) + s.get("duration_s", 0)
+    mode_breakdown = {}
+    for mode, secs in mode_play.items():
+        mode_breakdown[mode] = round(secs / 60, 1)
+
+    # Daily totals (for chart)
+    daily_totals = []
+    for d in sorted(by_date.keys()):
+        day_s = sum(s.get("duration_s", 0) for s in by_date[d])
+        daily_totals.append({"date": d, "play_min": round(day_s / 60, 1), "sessions": len(by_date[d])})
+
+    # Suggestions
+    suggestions = _compute_suggestions(avg_session_s, avg_sessions_per_day, avg_daily_play_s)
+
+    return {
+        "total_days": total_days,
+        "total_sessions": total_sessions,
+        "total_play_min": round(total_play_s / 60, 1),
+        "avg_session_min": round(avg_session_s / 60, 1),
+        "avg_sessions_per_day": round(avg_sessions_per_day, 1),
+        "avg_daily_play_min": round(avg_daily_play_s / 60, 1),
+        "mode_breakdown": mode_breakdown,
+        "daily_totals": daily_totals,
+        "suggestions": suggestions,
+    }
+
+
+def _compute_suggestions(avg_session_s, avg_sessions_per_day, avg_daily_play_s):
+    """Suggest limits based on usage patterns. Conservative for a 4-year-old."""
+    avg_session_min = avg_session_s / 60
+
+    # Round average session up to nearest 5 min, minimum 5
+    suggested_session = max(5, ((int(avg_session_min) + 4) // 5) * 5)
+
+    # Round average sessions/day up, minimum 1
+    suggested_max_sessions = max(1, int(avg_sessions_per_day + 0.9))
+
+    # Flag if daily play exceeds 60 min
+    avg_daily_min = avg_daily_play_s / 60
+    note = None
+    if avg_daily_min > 60:
+        note = "Average daily play time is {:.0f} min. Consider shorter sessions.".format(avg_daily_min)
+
+    return {
+        "max_session_min": suggested_session,
+        "max_sessions_day": suggested_max_sessions,
+        "note": note,
+    }

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -156,6 +156,7 @@ async def _handle_request(reader, writer, session_mgr, settings):
                 "sessions_today": session_mgr.sessions_today,
                 "sessions_remaining": session_mgr.sessions_remaining,
                 "max_session_s": settings["max_session_min"] * 60,
+                "mode": session_mgr.mode,
             }
             await _send_json(writer, data)
 
@@ -174,15 +175,21 @@ async def _handle_request(reader, writer, session_mgr, settings):
             await _send_json(writer, {"ok": True, "lockdown": settings["lockdown"]})
 
         elif method == "GET" and path == "/api/history":
-            import time as time_mod
-
-            try:
-                t = time_mod.localtime()
-                today = "{:04d}-{:02d}-{:02d}".format(t[0], t[1], t[2])
-            except Exception:
-                today = "2026-01-01"
-            sessions = storage.sessions_today(today)
+            sessions = storage.load_sessions()
             await _send_json(writer, sessions)
+
+        elif method == "GET" and path == "/api/stats":
+            sessions = storage.load_sessions()
+            stats = storage.compute_stats(sessions)
+            await _send_json(writer, stats)
+
+        elif method == "GET" and path == "/api/modes":
+            from bodn.session import ALL_MODES
+            mode_limits = settings.get("mode_limits", {})
+            modes = []
+            for m in ALL_MODES:
+                modes.append({"name": m, "limit_min": mode_limits.get(m)})
+            await _send_json(writer, modes)
 
         elif method == "POST" and path == "/api/wifi":
             if body:

--- a/firmware/bodn/web_ui.py
+++ b/firmware/bodn/web_ui.py
@@ -82,6 +82,21 @@ th{color:#aaa}
 .msg{text-align:center;padding:8px;margin:8px 0;border-radius:6px;display:none}
 .msg.ok{display:block;background:#27ae60;color:#fff}
 .msg.err{display:block;background:#e94560;color:#fff}
+.bar-chart{margin:12px 0}
+.bar-row{display:flex;align-items:center;gap:8px;margin:4px 0;font-size:0.85em}
+.bar-row .bar-label{width:70px;color:#aaa;text-align:right}
+.bar-row .bar-fill{height:16px;background:#e94560;border-radius:3px;min-width:2px}
+.bar-row .bar-val{color:#e0e0e0;font-size:0.8em}
+.stat-card{background:#16213e;border-radius:8px;padding:12px;margin:8px 0;text-align:center}
+.stat-card .val{font-size:1.5em;font-weight:bold;color:#e94560}
+.stat-card .lbl{font-size:0.75em;color:#aaa;margin-top:2px}
+.stats-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+.suggest-box{background:#1a3a1a;border:1px solid #27ae60;border-radius:8px;padding:12px;margin:12px 0}
+.suggest-box .title{color:#27ae60;font-weight:bold;margin-bottom:6px}
+.mode-row{display:flex;align-items:center;gap:8px;margin:8px 0}
+.mode-row label{flex:1;font-size:0.85em;color:#aaa}
+.mode-row input{width:70px;padding:6px;background:#16213e;border:1px solid #333;color:#e0e0e0;border-radius:6px;text-align:center}
+.mode-row .hint{font-size:0.7em;color:#666}
 </style>
 </head>
 <body>
@@ -90,6 +105,7 @@ th{color:#aaa}
 <button class="tab active" onclick="show('dash')">Dashboard</button>
 <button class="tab" onclick="show('limits')">Limits</button>
 <button class="tab" onclick="show('history')">History</button>
+<button class="tab" onclick="show('stats')">Stats</button>
 <button class="tab" onclick="show('wifi')">WiFi</button>
 <button class="tab" onclick="show('security')">Security</button>
 </div>
@@ -109,12 +125,33 @@ th{color:#aaa}
 <div class="field"><label>Break between sessions <span class="rv" id="rv-brk">15 min</span></label><input type="range" id="break_min" min="1" max="60" value="15" oninput="updRv(this,'rv-brk',' min')"></div>
 <div class="field"><label>Quiet start (HH:MM, empty=off)</label><input class="input-field" type="text" id="quiet_start" placeholder="21:00"></div>
 <div class="field"><label>Quiet end (HH:MM)</label><input class="input-field" type="text" id="quiet_end" placeholder="07:00"></div>
+<h3 style="margin-top:16px;color:#e94560;font-size:0.95em">Per-mode limits</h3>
+<p style="font-size:0.75em;color:#666;margin:4px 0">Minutes per session. Empty = use global. 0 = unlimited.</p>
+<div id="mode-limits"></div>
 <button class="btn btn-save" onclick="saveSettings()">Save</button>
 <div id="limits-msg" class="msg"></div>
 </div>
 
 <div id="history" class="panel">
-<table><thead><tr><th>Date</th><th>Start</th><th>Duration</th></tr></thead><tbody id="hist-body"></tbody></table>
+<table><thead><tr><th>Date</th><th>Start</th><th>Duration</th><th>Mode</th></tr></thead><tbody id="hist-body"></tbody></table>
+</div>
+
+<div id="stats" class="panel">
+<div class="stats-grid">
+<div class="stat-card"><div class="val" id="st-avg-sess">--</div><div class="lbl">Avg session</div></div>
+<div class="stat-card"><div class="val" id="st-avg-day">--</div><div class="lbl">Avg daily</div></div>
+<div class="stat-card"><div class="val" id="st-total-sess">--</div><div class="lbl">Total sessions</div></div>
+<div class="stat-card"><div class="val" id="st-days">--</div><div class="lbl">Days tracked</div></div>
+</div>
+<h3 style="margin:12px 0 4px;font-size:0.9em;color:#aaa">Daily play time</h3>
+<div id="daily-chart" class="bar-chart"></div>
+<h3 style="margin:12px 0 4px;font-size:0.9em;color:#aaa">Time by mode</h3>
+<div id="mode-chart" class="bar-chart"></div>
+<div id="suggest-box" class="suggest-box" style="display:none">
+<div class="title">Suggested limits</div>
+<div id="suggest-text"></div>
+<button class="btn btn-primary" onclick="applySuggestions()" style="margin-top:8px">Apply suggestions</button>
+</div>
 </div>
 
 <div id="security" class="panel">
@@ -139,6 +176,7 @@ document.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));
 document.getElementById(id).classList.add('active');
 event.target.classList.add('active');
 if(id==='history')loadHistory();
+if(id==='stats')loadStats();
 }
 function updRv(el,id,suf){document.getElementById(id).textContent=el.value+suf}
 function badgeClass(s){
@@ -179,6 +217,18 @@ var el=document.getElementById(k);if(el&&d[k]!=null)el.value=d[k]||'';
 updRv(document.getElementById('max_session_min'),'rv-sess',' min');
 updRv(document.getElementById('max_sessions_day'),'rv-maxs','');
 updRv(document.getElementById('break_min'),'rv-brk',' min');
+// Load mode limits
+var ml=d.mode_limits||{};
+var mc=document.getElementById('mode-limits');
+if(mc){mc.innerHTML='';
+var modes=['free_play','sound_mixer','recorder','sequencer'];
+var names={'free_play':'Free Play','sound_mixer':'Sound Mixer','recorder':'Recorder','sequencer':'Sequencer'};
+modes.forEach(function(m){
+var row=document.createElement('div');row.className='mode-row';
+var v=ml[m];var val=(v!=null&&v!==undefined)?v:'';
+row.innerHTML='<label>'+names[m]+'</label><input type="number" min="0" id="ml_'+m+'" value="'+val+'" placeholder="--"><span class="hint">min</span>';
+mc.appendChild(row);
+});}
 }catch(e){}
 }
 async function saveSettings(){
@@ -190,6 +240,12 @@ body[k]=parseInt(document.getElementById(k).value);
 var v=document.getElementById(k).value.trim();
 body[k]=v||null;
 });
+var ml={};
+['free_play','sound_mixer','recorder','sequencer'].forEach(function(m){
+var el=document.getElementById('ml_'+m);
+if(el&&el.value!=='')ml[m]=parseInt(el.value);
+});
+body.mode_limits=ml;
 var r=await fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
 var msg=document.getElementById('limits-msg');
 msg.className=r.ok?'msg ok':'msg err';
@@ -204,13 +260,55 @@ async function loadHistory(){
 try{
 var r=await fetch('/api/history');var d=await r.json();
 var tb=document.getElementById('hist-body');tb.innerHTML='';
+d.reverse();
 d.forEach(function(s){
 var tr=document.createElement('tr');
-tr.innerHTML='<td>'+s.date+'</td><td>'+(s.start_time||'--')+'</td><td>'+(s.duration_min||'--')+' min</td>';
+var mn={'free_play':'Free','sound_mixer':'Mixer','recorder':'Rec','sequencer':'Seq'};
+tr.innerHTML='<td>'+s.date+'</td><td>'+(s.start_time||'--')+'</td><td>'+(s.duration_min||'--')+' min</td><td>'+(mn[s.mode]||s.mode||'--')+'</td>';
 tb.appendChild(tr);
 });
-if(!d.length)tb.innerHTML='<tr><td colspan="3" style="text-align:center;color:#aaa">No sessions yet</td></tr>';
+if(!d.length)tb.innerHTML='<tr><td colspan="4" style="text-align:center;color:#aaa">No sessions yet</td></tr>';
 }catch(e){}
+}
+var _suggestions={};
+async function loadStats(){
+try{
+var r=await fetch('/api/stats');var d=await r.json();
+document.getElementById('st-avg-sess').textContent=d.avg_session_min+' min';
+document.getElementById('st-avg-day').textContent=d.avg_daily_play_min+' min';
+document.getElementById('st-total-sess').textContent=d.total_sessions;
+document.getElementById('st-days').textContent=d.total_days;
+// Daily chart
+var dc=document.getElementById('daily-chart');dc.innerHTML='';
+var maxM=0;(d.daily_totals||[]).forEach(function(t){if(t.play_min>maxM)maxM=t.play_min});
+(d.daily_totals||[]).forEach(function(t){
+var pct=maxM>0?Math.round(t.play_min*100/maxM):0;
+dc.innerHTML+='<div class="bar-row"><span class="bar-label">'+t.date.slice(5)+'</span><div class="bar-fill" style="width:'+pct+'%"></div><span class="bar-val">'+t.play_min+'m / '+t.sessions+'x</span></div>';
+});
+// Mode chart
+var mc=document.getElementById('mode-chart');mc.innerHTML='';
+var mb=d.mode_breakdown||{};var maxMo=0;for(var k in mb)if(mb[k]>maxMo)maxMo=mb[k];
+var names={'free_play':'Free Play','sound_mixer':'Sound Mixer','recorder':'Recorder','sequencer':'Sequencer'};
+for(var k in mb){
+var pct=maxMo>0?Math.round(mb[k]*100/maxMo):0;
+mc.innerHTML+='<div class="bar-row"><span class="bar-label">'+(names[k]||k)+'</span><div class="bar-fill" style="width:'+pct+'%;background:#2980b9"></div><span class="bar-val">'+mb[k]+' min</span></div>';
+}
+// Suggestions
+var sg=d.suggestions||{};_suggestions=sg;
+var sb=document.getElementById('suggest-box');
+var st=document.getElementById('suggest-text');
+if(d.total_sessions>0){
+sb.style.display='block';
+st.innerHTML='Session: <b>'+sg.max_session_min+' min</b>, Max/day: <b>'+sg.max_sessions_day+'</b>';
+if(sg.note)st.innerHTML+='<br><span style="color:#f39c12;font-size:0.85em">'+sg.note+'</span>';
+}else{sb.style.display='none'}
+}catch(e){}
+}
+async function applySuggestions(){
+if(!_suggestions.max_session_min)return;
+var body={max_session_min:_suggestions.max_session_min,max_sessions_day:_suggestions.max_sessions_day};
+await fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+loadSettings();loadStats();
 }
 async function saveSecurity(){
 var body={ui_pin:document.getElementById('ui_pin').value.trim(),

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -12,6 +12,7 @@ from bodn import config
 from bodn.encoder import Encoder
 from bodn.session import SessionManager, PLAYING, WARN_5, WARN_2, WINDDOWN, SLEEPING, COOLDOWN, LOCKDOWN, IDLE
 from bodn.web import start_server
+from bodn import storage
 from st7735 import ST7735
 
 # RGB565 colours (byte-swapped for framebuf)
@@ -492,7 +493,13 @@ async def main():
         t = time.localtime()
         return "{:04d}-{:02d}-{:02d}".format(t[0], t[1], t[2])
 
-    session_mgr = SessionManager(settings, get_time, get_date)
+    def on_session_end(record):
+        try:
+            storage.save_session(record)
+        except Exception as e:
+            print("Failed to save session:", e)
+
+    session_mgr = SessionManager(settings, get_time, get_date, on_session_end=on_session_end)
 
     # Start web server (non-fatal — box works without networking)
     _server = None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10,11 +10,13 @@ from bodn.session import (
     SLEEPING,
     COOLDOWN,
     LOCKDOWN,
+    MODE_FREE_PLAY,
+    MODE_SOUND_MIXER,
 )
 from bodn.storage import DEFAULT_SETTINGS
 
 
-def make_session(settings=None, start_time=0):
+def make_session(settings=None, start_time=0, on_session_end=None):
     """Create a SessionManager with controllable time."""
     _now = [start_time]
     _date = ["2026-03-19"]
@@ -29,7 +31,7 @@ def make_session(settings=None, start_time=0):
     if settings:
         s.update(settings)
 
-    mgr = SessionManager(s, get_time, get_date)
+    mgr = SessionManager(s, get_time, get_date, on_session_end=on_session_end)
     return mgr, _now, _date
 
 
@@ -55,42 +57,36 @@ class TestBasicFlow:
         mgr.try_wake()
         assert mgr.state == PLAYING
 
-        # Advance to 5-min warning (5 min remaining = 300s from end)
-        now[0] = 300  # 5 min in, 5 min left
+        now[0] = 300
         mgr.tick()
         assert mgr.state == WARN_5
 
-        # Advance to 2-min warning
-        now[0] = 480  # 8 min in, 2 min left
+        now[0] = 480
         mgr.tick()
         assert mgr.state == WARN_2
 
-        # Session expires
-        now[0] = 600  # 10 min in
+        now[0] = 600
         mgr.tick()
         assert mgr.state == WINDDOWN
 
-        # Wind-down lasts 30s
         now[0] = 630
         mgr.tick()
         assert mgr.state == SLEEPING
 
-        # Sleeping transitions to cooldown
         mgr.tick()
         assert mgr.state == COOLDOWN
 
-        # Cooldown for break_min (1 min)
-        now[0] = 690  # 60s after sleep start
+        now[0] = 690
         mgr.tick()
         assert mgr.state == IDLE
 
     def test_sessions_today_increments(self):
         mgr, now, _ = make_session({"max_session_min": 1, "break_min": 0})
         mgr.try_wake()
-        now[0] = 60  # session expires
-        mgr.tick()  # → WINDDOWN
+        now[0] = 60
+        mgr.tick()  # WINDDOWN
         now[0] = 90
-        mgr.tick()  # → SLEEPING
+        mgr.tick()  # SLEEPING
         assert mgr.sessions_today == 1
 
 
@@ -105,7 +101,7 @@ class TestLimits:
             mgr.tick()  # SLEEPING
             mgr.tick()  # COOLDOWN
             now[0] += 1
-            mgr.tick()  # IDLE (break_min=0)
+            mgr.tick()  # IDLE
 
         assert mgr.sessions_today == 2
         assert not mgr.try_wake()
@@ -140,21 +136,18 @@ class TestLockdown:
 
 class TestQuietHours:
     def test_quiet_hours_triggers_sleep(self):
-        # quiet_start=21:00, quiet_end=07:00, time = 22:00 (79200s into day)
         mgr, now, _ = make_session({"quiet_start": "21:00", "quiet_end": "07:00"})
-        now[0] = 79200  # 22:00
-        mgr.try_wake()  # should fail — quiet hours
-        # Actually try_wake checks quiet hours
+        now[0] = 79200
         assert not mgr.try_wake()
 
     def test_quiet_hours_same_day(self):
         mgr, now, _ = make_session({"quiet_start": "13:00", "quiet_end": "15:00"})
-        now[0] = 50400  # 14:00
+        now[0] = 50400
         assert not mgr.try_wake()
 
     def test_outside_quiet_hours_ok(self):
         mgr, now, _ = make_session({"quiet_start": "21:00", "quiet_end": "07:00"})
-        now[0] = 36000  # 10:00
+        now[0] = 36000
         assert mgr.try_wake()
 
 
@@ -163,16 +156,15 @@ class TestDayRollover:
         mgr, now, date = make_session({"max_session_min": 1, "max_sessions_day": 1, "break_min": 0})
         mgr.try_wake()
         now[0] = 60
-        mgr.tick()  # WINDDOWN
+        mgr.tick()
         now[0] = 90
-        mgr.tick()  # SLEEPING
-        mgr.tick()  # COOLDOWN
+        mgr.tick()
+        mgr.tick()
         now[0] = 91
-        mgr.tick()  # IDLE
+        mgr.tick()
         assert mgr.sessions_today == 1
         assert not mgr.try_wake()
 
-        # New day
         date[0] = "2026-03-20"
         mgr.tick()
         assert mgr.sessions_today == 0
@@ -183,8 +175,8 @@ class TestSettingsChangeMidSession:
     def test_shorter_limit_ends_session_early(self):
         mgr, now, _ = make_session({"max_session_min": 20})
         mgr.try_wake()
-        now[0] = 300  # 5 min in
-        mgr.settings["max_session_min"] = 5  # now limit is 5 min = 300s
+        now[0] = 300
+        mgr.settings["max_session_min"] = 5
         mgr.tick()
         assert mgr.state == WINDDOWN
 
@@ -204,3 +196,126 @@ class TestForceSleep:
         mgr.force_sleep()
         assert mgr.state == SLEEPING
         assert mgr.sessions_today == 1
+
+
+class TestModeLimits:
+    def test_default_mode_is_free_play(self):
+        mgr, _, _ = make_session()
+        assert mgr.mode == MODE_FREE_PLAY
+
+    def test_wake_with_mode(self):
+        mgr, _, _ = make_session()
+        mgr.try_wake(mode=MODE_SOUND_MIXER)
+        assert mgr.mode == MODE_SOUND_MIXER
+
+    def test_per_mode_limit_shorter(self):
+        mgr, now, _ = make_session({
+            "max_session_min": 20,
+            "mode_limits": {"sound_mixer": 5},
+        })
+        mgr.try_wake(mode=MODE_SOUND_MIXER)
+        assert mgr.time_remaining_s == 300  # 5 min
+
+    def test_per_mode_limit_falls_back_to_global(self):
+        mgr, now, _ = make_session({
+            "max_session_min": 10,
+            "mode_limits": {"sound_mixer": 5},
+        })
+        mgr.try_wake(mode=MODE_FREE_PLAY)
+        assert mgr.time_remaining_s == 600  # 10 min (global)
+
+    def test_per_mode_limit_zero_is_unlimited(self):
+        mgr, now, _ = make_session({
+            "max_session_min": 10,
+            "mode_limits": {"free_play": 0},
+        })
+        mgr.try_wake(mode=MODE_FREE_PLAY)
+        assert mgr.time_remaining_s == 9999  # unlimited
+
+    def test_unlimited_mode_never_warns(self):
+        mgr, now, _ = make_session({
+            "max_session_min": 10,
+            "mode_limits": {"free_play": 0},
+        })
+        mgr.try_wake(mode=MODE_FREE_PLAY)
+        now[0] = 3600  # 1 hour in
+        mgr.tick()
+        assert mgr.state == PLAYING  # still playing, no warning
+
+    def test_set_mode_changes_limit(self):
+        mgr, now, _ = make_session({
+            "max_session_min": 20,
+            "mode_limits": {"sound_mixer": 3},
+        })
+        mgr.try_wake()
+        assert mgr.time_remaining_s == 1200  # 20 min global
+        mgr.set_mode(MODE_SOUND_MIXER)
+        assert mgr.time_remaining_s == 180  # 3 min
+
+
+class TestSessionCallback:
+    def test_callback_fires_on_normal_end(self):
+        records = []
+        mgr, now, _ = make_session(
+            {"max_session_min": 1, "break_min": 0},
+            on_session_end=lambda r: records.append(r),
+        )
+        mgr.try_wake()
+        now[0] = 60
+        mgr.tick()  # WINDDOWN
+        now[0] = 90
+        mgr.tick()  # SLEEPING — callback fires here
+        assert len(records) == 1
+        assert records[0]["end_reason"] == "normal"
+        assert records[0]["mode"] == MODE_FREE_PLAY
+        assert records[0]["date"] == "2026-03-19"
+        assert records[0]["duration_s"] == 90
+
+    def test_callback_fires_on_force_sleep(self):
+        records = []
+        mgr, now, _ = make_session(
+            on_session_end=lambda r: records.append(r),
+        )
+        mgr.try_wake()
+        now[0] = 120
+        mgr.force_sleep()
+        assert len(records) == 1
+        assert records[0]["end_reason"] == "force_sleep"
+        assert records[0]["duration_s"] == 120
+
+    def test_callback_includes_mode(self):
+        records = []
+        mgr, now, _ = make_session(
+            {"max_session_min": 1},
+            on_session_end=lambda r: records.append(r),
+        )
+        mgr.try_wake(mode=MODE_SOUND_MIXER)
+        now[0] = 60
+        mgr.tick()  # WINDDOWN
+        now[0] = 90
+        mgr.tick()  # SLEEPING
+        assert records[0]["mode"] == MODE_SOUND_MIXER
+
+    def test_no_callback_if_none(self):
+        """No crash when on_session_end is not set."""
+        mgr, now, _ = make_session({"max_session_min": 1})
+        mgr.try_wake()
+        now[0] = 60
+        mgr.tick()
+        now[0] = 90
+        mgr.tick()
+        assert mgr.sessions_today == 1
+
+    def test_callback_has_start_time(self):
+        records = []
+        mgr, now, _ = make_session(
+            {"max_session_min": 1},
+            start_time=3600,  # 01:00:00
+            on_session_end=lambda r: records.append(r),
+        )
+        mgr.try_wake()
+        now[0] = 3660
+        mgr.tick()
+        now[0] = 3690
+        mgr.tick()
+        assert records[0]["start_time"] == "01:00"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -11,6 +11,7 @@ from bodn.storage import (
     load_sessions,
     save_session,
     sessions_today,
+    compute_stats,
     SETTINGS_PATH,
     SESSIONS_PATH,
 )
@@ -91,3 +92,79 @@ class TestAtomicWrite:
         save_settings({"test": True})
         tmp_file = str(tmp_data_dir / "settings.json.tmp")
         assert not os.path.exists(tmp_file)
+
+
+class TestModeLimits:
+    def test_default_has_empty_mode_limits(self):
+        settings = load_settings()
+        assert settings["mode_limits"] == {}
+
+    def test_save_and_load_mode_limits(self):
+        settings = dict(DEFAULT_SETTINGS)
+        settings["mode_limits"] = {"sound_mixer": 5, "recorder": 10}
+        save_settings(settings)
+        loaded = load_settings()
+        assert loaded["mode_limits"]["sound_mixer"] == 5
+        assert loaded["mode_limits"]["recorder"] == 10
+
+
+class TestComputeStats:
+    def test_empty_sessions(self):
+        stats = compute_stats([])
+        assert stats["total_sessions"] == 0
+        assert stats["total_play_min"] == 0
+        assert stats["suggestions"] == {}
+
+    def test_basic_stats(self):
+        sessions = [
+            {"date": "2026-03-19", "duration_s": 600, "mode": "free_play"},
+            {"date": "2026-03-19", "duration_s": 900, "mode": "sound_mixer"},
+            {"date": "2026-03-20", "duration_s": 1200, "mode": "free_play"},
+        ]
+        stats = compute_stats(sessions)
+        assert stats["total_sessions"] == 3
+        assert stats["total_play_min"] == 45.0  # (600+900+1200)/60
+        assert stats["total_days"] == 2
+        assert stats["avg_sessions_per_day"] == 1.5
+        assert stats["mode_breakdown"]["free_play"] == 30.0
+        assert stats["mode_breakdown"]["sound_mixer"] == 15.0
+
+    def test_daily_totals(self):
+        sessions = [
+            {"date": "2026-03-19", "duration_s": 600, "mode": "free_play"},
+            {"date": "2026-03-19", "duration_s": 600, "mode": "free_play"},
+            {"date": "2026-03-20", "duration_s": 300, "mode": "free_play"},
+        ]
+        stats = compute_stats(sessions)
+        daily = stats["daily_totals"]
+        assert len(daily) == 2
+        assert daily[0]["date"] == "2026-03-19"
+        assert daily[0]["play_min"] == 20.0
+        assert daily[0]["sessions"] == 2
+
+    def test_suggestions_round_up(self):
+        sessions = [
+            {"date": "2026-03-19", "duration_s": 720, "mode": "free_play"},  # 12 min
+            {"date": "2026-03-20", "duration_s": 480, "mode": "free_play"},  # 8 min
+        ]
+        stats = compute_stats(sessions)
+        # avg session = 10 min → suggest 10
+        assert stats["suggestions"]["max_session_min"] == 10
+        assert stats["suggestions"]["max_sessions_day"] == 1
+
+    def test_suggestions_high_usage_note(self):
+        sessions = [
+            {"date": "2026-03-19", "duration_s": 3600, "mode": "free_play"},  # 60 min
+            {"date": "2026-03-19", "duration_s": 600, "mode": "free_play"},   # 10 min
+        ]
+        stats = compute_stats(sessions)
+        assert stats["suggestions"]["note"] is not None
+        assert "70 min" in stats["suggestions"]["note"]
+
+    def test_suggestions_minimum_values(self):
+        sessions = [
+            {"date": "2026-03-19", "duration_s": 60, "mode": "free_play"},  # 1 min
+        ]
+        stats = compute_stats(sessions)
+        assert stats["suggestions"]["max_session_min"] >= 5  # minimum 5
+        assert stats["suggestions"]["max_sessions_day"] >= 1


### PR DESCRIPTION
## Summary

Implements all three versions of issue #8 (parental controls via Wi-Fi web UI):

**v1 — Core parental controls** (committed to main earlier, included in diff)
- Session state machine: IDLE → PLAYING → WARN_5 → WARN_2 → WINDDOWN → SLEEP → COOLDOWN
- Web UI (dark theme, mobile-friendly): Dashboard, Limits, History, WiFi, Security tabs
- Settings: session length, max sessions/day, break duration, quiet hours, lockdown
- WiFi (STA/AP with Wokwi-GUEST auto-detection), NTP sync
- Async architecture: uasyncio event loop runs web server alongside UI
- OTA firmware push over WiFi (`tools/ota-push.py`)
- Web UI PIN protection + OTA bearer token auth

**v2 — Per-mode time limits**
- `SessionManager.set_mode()` tracks active play mode
- `mode_limits` setting: per-mode minutes (empty = global default, 0 = unlimited)
- Infrastructure ready for Milestone 3 modes (sound mixer, recorder, sequencer)

**v3 — Usage statistics and suggested limits**
- Session recording to flash (date, start time, duration, mode, end reason)
- `compute_stats()`: daily totals, mode breakdown, averages over 7-day window
- Stats tab with bar charts and stat cards
- Suggested limits heuristic with one-click "Apply" button
- Flags excessive daily play (>60 min average)

## Test plan

- [x] `uv run pytest` — 57 tests pass (20 new: mode limits, session callbacks, stats computation)
- [ ] Deploy to Wokwi: verify boot screen shows IP + NTP OK, playground UI runs
- [ ] Open web UI at `http://localhost:9080` (requires Wokwi Private Gateway)
- [ ] Set session length to 1 min → watch wind-down → sleep → cooldown cycle
- [ ] Set per-mode limit for "Sound Mixer" to 3 min → verify shorter limit applies
- [ ] Check History tab shows recorded sessions with mode and duration
- [ ] Check Stats tab shows daily chart, mode breakdown, and suggestions
- [ ] Set a PIN in Security tab → verify login screen appears
- [ ] `uv run python tools/ota-push.py --wokwi` → verify files upload successfully

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)