### PR TITLE
Add partial SPI push via show_rect() for both displays

### DIFF
--- a/firmware/bodn/ui/pause.py
+++ b/firmware/bodn/ui/pause.py
@@ -118,7 +118,7 @@ class PauseMenu(Screen):
                 tft = self._manager.tft
                 theme = self._manager.theme
                 draw_hold_bar(tft, theme, self._hold.progress, theme.width)
-                self._manager.request_show()
+                self._manager.request_show(0, 0, theme.width, _HOLD_BAR_H)
                 self._bar_visible = True
         elif was_holding and self._manager:
             # Just released — clear the bar strip
@@ -127,7 +127,7 @@ class PauseMenu(Screen):
                 tft = self._manager.tft
                 theme = self._manager.theme
                 tft.fill_rect(0, 0, theme.width, _HOLD_BAR_H, theme.BLACK)
-                self._manager.request_show()
+                self._manager.request_show(0, 0, theme.width, _HOLD_BAR_H)
                 self._bar_visible = False
 
         return None

--- a/firmware/bodn/ui/screen.py
+++ b/firmware/bodn/ui/screen.py
@@ -54,6 +54,7 @@ class ScreenManager:
         self._frame = 0
         self._dirty = True  # full clear needed on first frame / transitions
         self._show_needed = False  # framebuffer changed, just push SPI (no re-render)
+        self._dirty_rect = None  # (x, y, w, h) bounding box for partial push
         # Perf counters (enabled via debug_perf setting)
         self.debug_perf = False
         self._perf_total = 0
@@ -69,14 +70,36 @@ class ScreenManager:
         """Mark the display as needing a full redraw on the next tick."""
         self._dirty = True
 
-    def request_show(self):
-        """Request a show() on the next tick without a full re-render.
+    def invalidate_rect(self, x, y, w, h):
+        """Mark a rectangle as needing a push on the next tick.
+
+        Multiple calls are merged into the bounding-box union. Does NOT
+        trigger a re-render — only a show_rect() push. Use after direct
+        framebuffer writes (progress bars, timers, etc.).
+        """
+        if self._dirty_rect is None:
+            self._dirty_rect = (x, y, w, h)
+        else:
+            ox, oy, ow, oh = self._dirty_rect
+            nx = min(ox, x)
+            ny = min(oy, y)
+            nx2 = max(ox + ow, x + w)
+            ny2 = max(oy + oh, y + h)
+            self._dirty_rect = (nx, ny, nx2 - nx, ny2 - ny)
+
+    def request_show(self, x=None, y=None, w=None, h=None):
+        """Request a push on the next tick without a full re-render.
+
+        With x/y/w/h: only that rectangle is pushed (show_rect).
+        Without arguments: the full buffer is pushed (show).
 
         Use this after writing directly to the framebuffer (e.g. a small
-        partial update like a progress bar). The ScreenManager will call
-        tft.show() but will NOT re-render the active screen or overlay.
+        partial update like a progress bar). The ScreenManager will NOT
+        re-render the active screen or overlay.
         """
         self._show_needed = True
+        if x is not None:
+            self.invalidate_rect(x, y, w, h)
 
     def push(self, screen):
         """Push a screen onto the stack."""
@@ -138,7 +161,12 @@ class ScreenManager:
             # (e.g. partial framebuffer update like a progress bar).
             if self._show_needed:
                 self._show_needed = False
-                self.tft.show()
+                dirty_rect = self._dirty_rect
+                self._dirty_rect = None
+                if dirty_rect is not None:
+                    self.tft.show_rect(*dirty_rect)
+                else:
+                    self.tft.show()
                 if self.debug_perf:
                     self._perf_total += 1
                     self._perf_drawn += 1
@@ -150,6 +178,7 @@ class ScreenManager:
 
         # Full render path
         self._show_needed = False
+        self._dirty_rect = None
 
         # Clear on screen transitions
         if self._dirty:

--- a/firmware/bodn/ui/secondary.py
+++ b/firmware/bodn/ui/secondary.py
@@ -129,4 +129,9 @@ class SecondaryDisplay:
             redraw = True
 
         if redraw:
-            self.tft.show()
+            if content_needs and not status_needs:
+                self.tft.show_rect(0, 0, self.content_w, CONTENT_H)
+            elif status_needs and not content_needs:
+                self.tft.show_rect(0, STATUS_Y, self.content_w, STATUS_H)
+            else:
+                self.tft.show()

--- a/firmware/st7735.py
+++ b/firmware/st7735.py
@@ -98,6 +98,56 @@ class ST7735(framebuf.FrameBuffer):
         self.spi.write(self._buf)
         self.cs.value(1)
 
+    def show_rect(self, x, y, w, h):
+        """Push a sub-rectangle of the framebuffer to the display.
+
+        Falls back to show() when the region covers more than half the screen.
+        Coordinates are in logical (post-rotation) framebuffer space.
+        """
+        # Clamp to screen bounds
+        if x < 0:
+            w += x
+            x = 0
+        if y < 0:
+            h += y
+            y = 0
+        if x + w > self.width:
+            w = self.width - x
+        if y + h > self.height:
+            h = self.height - y
+        if w <= 0 or h <= 0:
+            return
+        # Fallback for large regions
+        if w * h > self.width * self.height // 2:
+            self.show()
+            return
+        # Set address window
+        x0 = self._col_offset + x
+        x1 = x0 + w - 1
+        y0 = self._row_offset + y
+        y1 = y0 + h - 1
+        self._cmd(_CASET, bytes([x0 >> 8, x0 & 0xFF, x1 >> 8, x1 & 0xFF]))
+        self._cmd(_RASET, bytes([y0 >> 8, y0 & 0xFF, y1 >> 8, y1 & 0xFF]))
+        # Begin RAMWR
+        self.cs.value(0)
+        self.dc.value(0)
+        self.spi.write(bytes([_RAMWR]))
+        self.dc.value(1)
+        # Push pixel data from framebuffer
+        mv = memoryview(self._buf)
+        stride = self.width * 2
+        if w == self.width:
+            # Full-width: contiguous slice, single write
+            start = y * stride
+            self.spi.write(mv[start : start + h * stride])
+        else:
+            # Partial-width: one write per row
+            row_bytes = w * 2
+            for row in range(h):
+                start = (y + row) * stride + x * 2
+                self.spi.write(mv[start : start + row_bytes])
+        self.cs.value(1)
+
     @staticmethod
     def rgb(r, g, b):
         """Convert 8-bit RGB to byte-swapped RGB565 for framebuf."""

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -15,6 +15,9 @@ class FakeTft:
     def show(self):
         self.calls.append(("show",))
 
+    def show_rect(self, x, y, w, h):
+        self.calls.append(("show_rect", x, y, w, h))
+
     def text(self, *a, **kw):
         pass
 
@@ -186,3 +189,71 @@ def test_pop_marks_revealed_screen_dirty():
     assert bottom._dirty
     mgr.tick()  # should render bottom
     assert bottom.renders == 2
+
+
+# --- invalidate_rect / request_show partial-push tests ---
+
+
+def test_request_show_no_args_calls_full_show():
+    """request_show() without args triggers tft.show() on next tick."""
+    mgr = make_manager()
+    s = SpyScreen()
+    s.needs_redraw = lambda: False
+    mgr.push(s)
+    mgr.tick()  # consume initial dirty render
+    mgr.tft.calls.clear()
+
+    mgr.request_show()
+    mgr.tick()
+
+    assert ("show",) in mgr.tft.calls
+    assert not any(c[0] == "show_rect" for c in mgr.tft.calls)
+
+
+def test_request_show_with_rect_calls_show_rect():
+    """request_show(x, y, w, h) triggers tft.show_rect() on next tick."""
+    mgr = make_manager()
+    s = SpyScreen()
+    s.needs_redraw = lambda: False
+    mgr.push(s)
+    mgr.tick()
+    mgr.tft.calls.clear()
+
+    mgr.request_show(0, 0, 32, 4)
+    mgr.tick()
+
+    assert ("show_rect", 0, 0, 32, 4) in mgr.tft.calls
+    assert ("show",) not in mgr.tft.calls
+
+
+def test_invalidate_rect_merges_bounding_box():
+    """Multiple invalidate_rect calls are merged into their bounding box."""
+    mgr = make_manager()
+    mgr.invalidate_rect(10, 20, 30, 5)
+    mgr.invalidate_rect(5, 18, 10, 10)
+    # Union: x=5, y=18, x2=max(40,15)=40, y2=max(25,28)=28 → w=35, h=10
+    assert mgr._dirty_rect == (5, 18, 35, 10)
+
+
+def test_dirty_rect_cleared_after_partial_push():
+    """_dirty_rect is reset to None after the push tick."""
+    mgr = make_manager()
+    s = SpyScreen()
+    s.needs_redraw = lambda: False
+    mgr.push(s)
+    mgr.tick()
+
+    mgr.request_show(0, 0, 10, 10)
+    assert mgr._dirty_rect == (0, 0, 10, 10)
+    mgr.tick()
+    assert mgr._dirty_rect is None
+
+
+def test_dirty_rect_cleared_on_full_render():
+    """_dirty_rect is also cleared when a full render happens."""
+    mgr = make_manager()
+    mgr.invalidate_rect(5, 5, 20, 20)
+    s = SpyScreen()
+    mgr.push(s)
+    mgr.tick()
+    assert mgr._dirty_rect is None

--- a/tests/test_secondary.py
+++ b/tests/test_secondary.py
@@ -18,6 +18,9 @@ class FakeTft:
     def show(self):
         self.calls.append(("show",))
 
+    def show_rect(self, x, y, w, h):
+        self.calls.append(("show_rect", x, y, w, h))
+
     def text(self, *a, **kw):
         pass
 
@@ -307,3 +310,66 @@ def test_catface_all_emotions_render():
         cat.set_emotion(emotion)
         cat._dirty = True
         cat.render(tft, theme, 1)
+
+
+# --- Zone-aware partial push tests ---
+
+
+def test_status_only_update_uses_show_rect():
+    """When only the status strip changes, show_rect is used for just that zone."""
+    d = make_display()
+    content = SpyScreen()
+    status = SpyScreen()
+    d.set_content(content)
+    d.set_status(status)
+    d.tick()  # consume transitions
+    d.tft.calls.clear()
+
+    # Only status dirty
+    status._dirty = True
+    d.tick()
+
+    show_rects = [c for c in d.tft.calls if c[0] == "show_rect"]
+    full_shows = [c for c in d.tft.calls if c[0] == "show"]
+    assert ("show_rect", 0, STATUS_Y, 128, STATUS_H) in show_rects
+    assert len(full_shows) == 0
+
+
+def test_content_only_update_uses_show_rect():
+    """When only the content zone changes, show_rect is used for just that zone."""
+    d = make_display()
+    content = SpyScreen()
+    status = SpyScreen()
+    d.set_content(content)
+    d.set_status(status)
+    d.tick()  # consume transitions
+    d.tft.calls.clear()
+
+    # Only content dirty
+    content._dirty = True
+    d.tick()
+
+    show_rects = [c for c in d.tft.calls if c[0] == "show_rect"]
+    full_shows = [c for c in d.tft.calls if c[0] == "show"]
+    assert ("show_rect", 0, 0, 128, CONTENT_H) in show_rects
+    assert len(full_shows) == 0
+
+
+def test_both_zones_dirty_uses_full_show():
+    """When both zones need redraw, a single full show() is used."""
+    d = make_display()
+    content = SpyScreen()
+    status = SpyScreen()
+    d.set_content(content)
+    d.set_status(status)
+    d.tick()  # consume transitions
+    d.tft.calls.clear()
+
+    content._dirty = True
+    status._dirty = True
+    d.tick()
+
+    show_rects = [c for c in d.tft.calls if c[0] == "show_rect"]
+    full_shows = [c for c in d.tft.calls if c[0] == "show"]
+    assert len(show_rects) == 0
+    assert len(full_shows) == 1


### PR DESCRIPTION
Closes #17.

## Summary

- **`st7735.py`**: `show_rect(x, y, w, h)` sets a CASET/RASET address window then pushes only those pixels. Full-width rects use a single contiguous `spi.write()`. Partial-width rects go row-by-row via `memoryview` (zero-copy). Auto-fallback to `show()` when rect exceeds 50% of screen. Works for both ILI9341 and ST7735.
- **`screen.py`**: Adds `_dirty_rect` bounding-box state, `invalidate_rect(x, y, w, h)` (merges into bbox union), and `request_show(x, y, w, h)` for partial pushes. Backward-compatible — `request_show()` without args still does a full push.
- **`pause.py`**: Hold bar uses `request_show(0, 0, width, 4)` as first adopter (~60× speedup for that update path).
- **`secondary.py`**: Zone-aware push — status-only dirty → `show_rect(0, 128, 128, 32)`; content-only dirty → `show_rect(0, 0, 128, 128)`; both dirty → `show()`.

### Expected impact

| Update | Before | After | Speedup |
|---|---|---|---|
| Hold bar (320×4) | 150 KB, ~47 ms | 2.5 KB, ~0.8 ms | ~60× |
| Secondary clock tick (128×32) | 40 KB, ~12 ms | 8 KB, ~3 ms | ~5× |
| Full screen | 150 KB, ~47 ms | 150 KB, ~47 ms | 1× |

## Test plan

- [x] `uv run pytest` — 158 tests pass (8 new tests added)
- [ ] Flash to device and verify hold bar animates smoothly
- [ ] Verify secondary display clock updates without flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)