### PR TITLE
Add diagnostic boot screen on button hold

### DIFF
--- a/firmware/bodn/diag.py
+++ b/firmware/bodn/diag.py
@@ -1,0 +1,82 @@
+# bodn/diag.py — gather system diagnostic information
+#
+# Returns a list of (label, value) tuples suitable for display.
+# Used by boot.py (pre-framework) and ui/diag.py (Screen subclass).
+
+import gc
+import time
+
+
+def gather(ip="0.0.0.0", boot_results=None, boot_steps=None):
+    """Collect system diagnostics. Returns list of (label, value) pairs."""
+    info = []
+
+    # Platform and MicroPython version
+    import sys
+
+    ver = sys.version
+    info.append(("uPy", ver.split(";")[0] if ";" in ver else ver[:20]))
+    info.append(("Platform", sys.platform))
+
+    # CPU frequency
+    try:
+        from machine import freq as _cpu_freq
+
+        info.append(("CPU", "{} MHz".format(_cpu_freq() // 1_000_000)))
+    except Exception:
+        pass
+
+    # Memory
+    gc.collect()
+    free = gc.mem_free()
+    alloc = gc.mem_alloc()
+    info.append(("RAM free", "{} KB".format(free // 1024)))
+    info.append(("RAM used", "{} KB".format(alloc // 1024)))
+
+    # Flash filesystem
+    try:
+        import os
+
+        st = os.statvfs("/")
+        fs_total = st[0] * st[2] // 1024
+        fs_free = st[0] * st[3] // 1024
+        info.append(("Flash", "{}/{} KB".format(fs_free, fs_total)))
+    except Exception:
+        pass
+
+    # WiFi MAC
+    try:
+        import network
+
+        mac = network.WLAN(network.STA_IF).config("mac")
+        mac_str = ":".join("{:02X}".format(b) for b in mac)
+        info.append(("MAC", mac_str))
+    except Exception:
+        pass
+
+    # IP
+    info.append(("IP", ip))
+
+    # Battery
+    try:
+        from bodn.battery import read as bat_read
+
+        pct, chg = bat_read()
+        info.append(("Battery", "{}%{}".format(pct, " CHG" if chg else "")))
+    except Exception:
+        pass
+
+    # NTP / time
+    t = time.localtime()
+    if t[0] >= 2024:
+        info.append(("Time", "{:02d}:{:02d}:{:02d}".format(t[3], t[4], t[5])))
+
+    # Boot results
+    if boot_results and boot_steps:
+        summary = " ".join(
+            "{}:{}".format(boot_steps[i][0], boot_results[i] or "?")
+            for i in range(len(boot_steps))
+        )
+        info.append(("Boot", summary))
+
+    return info

--- a/firmware/bodn/ui/diag.py
+++ b/firmware/bodn/ui/diag.py
@@ -1,0 +1,56 @@
+# bodn/ui/diag.py — diagnostic info screen (reachable from settings menu)
+
+from bodn.ui.screen import Screen
+from bodn.ui.widgets import draw_centered
+
+
+class DiagScreen(Screen):
+    """Full-screen diagnostic info. Any button or encoder press dismisses."""
+
+    def __init__(self):
+        self._manager = None
+        self._dirty = True
+        self._info = None
+
+    def enter(self, manager):
+        self._manager = manager
+        self._dirty = True
+        # Gather info on entry so RAM measurement reflects runtime state
+        from bodn.diag import gather
+
+        self._info = gather()
+
+    def needs_redraw(self):
+        return self._dirty
+
+    def update(self, inp, frame):
+        # Dismiss on any button or encoder button press
+        if inp.any_btn_pressed():
+            self._dismiss()
+            return
+        for i in range(len(inp.enc_btn_pressed)):
+            if inp.enc_btn_pressed[i]:
+                self._dismiss()
+                return
+
+    def _dismiss(self):
+        if self._manager:
+            self._manager.pop()
+
+    def render(self, tft, theme, frame):
+        self._dirty = False
+        tft.fill(theme.BLACK)
+
+        draw_centered(tft, "~ Diagnostics ~", 4, theme.AMBER, theme.width)
+
+        line_h = 14
+        y = 22
+        for label, val in self._info:
+            tft.text(label, 4, y, theme.AMBER)
+            vx = min(80, (len(label) + 1) * 8 + 4)
+            tft.text(str(val), vx, y, theme.WHITE)
+            y += line_h
+
+        draw_centered(
+            tft, "Press any button", theme.height - 16, theme.CYAN, theme.width
+        )

--- a/firmware/bodn/ui/settings.py
+++ b/firmware/bodn/ui/settings.py
@@ -15,6 +15,7 @@ _ITEMS = [
     ("leds", "LEDs", "bool"),
     ("debug_input", "Debug log", "bool"),
     ("debug_perf", "Perf stats", "bool"),
+    ("diag", "Diagnostics", "action"),
     ("back", "< Back", "action"),
 ]
 
@@ -56,6 +57,12 @@ class SettingsScreen(Screen):
         if key == "back":
             if self._manager:
                 self._manager.pop()
+            return
+        if key == "diag":
+            if self._manager:
+                from bodn.ui.diag import DiagScreen
+
+                self._manager.push(DiagScreen())
             return
         if key == "wifi":
             if self._wifi_ctrl.is_active():

--- a/firmware/boot.py
+++ b/firmware/boot.py
@@ -237,75 +237,9 @@ _show_progress(4, STEPS[3][1], STEPS[3][2], detail="IP: " + ip, detail_col=COL_W
 
 # --- Diagnostic boot screen (hold NAV encoder button to activate) ---
 if _diag_requested and tft:
-    _diag_info = []
+    from bodn.diag import gather as _diag_gather
 
-    # Platform and MicroPython version
-    import sys
-
-    _diag_info.append(
-        ("uPy", sys.version.split(";")[0] if ";" in sys.version else sys.version[:20])
-    )
-    _diag_info.append(("Platform", sys.platform))
-
-    # CPU frequency
-    try:
-        from machine import freq as _cpu_freq
-
-        _diag_info.append(("CPU", "{} MHz".format(_cpu_freq() // 1_000_000)))
-    except Exception:
-        pass
-
-    # Memory
-    gc.collect()
-    _free = gc.mem_free()
-    _alloc = gc.mem_alloc()
-    _diag_info.append(("RAM free", "{} KB".format(_free // 1024)))
-    _diag_info.append(("RAM used", "{} KB".format(_alloc // 1024)))
-
-    # Flash filesystem
-    try:
-        import os
-
-        _st = os.statvfs("/")
-        _fs_total = _st[0] * _st[2] // 1024
-        _fs_free = _st[0] * _st[3] // 1024
-        _diag_info.append(("Flash", "{}/{} KB".format(_fs_free, _fs_total)))
-    except Exception:
-        pass
-
-    # WiFi MAC
-    try:
-        import network
-
-        _mac = network.WLAN(network.STA_IF).config("mac")
-        _mac_str = ":".join("{:02X}".format(b) for b in _mac)
-        _diag_info.append(("MAC", _mac_str))
-    except Exception:
-        pass
-
-    # IP
-    _diag_info.append(("IP", ip))
-
-    # Battery
-    try:
-        from bodn.battery import read as _bat_read
-
-        _pct, _chg = _bat_read()
-        _bat_str = "{}%{}".format(_pct, " CHG" if _chg else "")
-        _diag_info.append(("Battery", _bat_str))
-    except Exception:
-        pass
-
-    # NTP / time
-    if _results[2] == "ok":
-        _t = time.localtime()
-        _diag_info.append(("Time", "{:02d}:{:02d}:{:02d}".format(_t[3], _t[4], _t[5])))
-
-    # Boot results
-    _step_summary = " ".join(
-        "{}:{}".format(STEPS[i][0], _results[i] or "?") for i in range(len(STEPS))
-    )
-    _diag_info.append(("Boot", _step_summary))
+    _diag_info = _diag_gather(ip=ip, boot_results=_results, boot_steps=STEPS)
 
     # --- Draw diagnostic screen ---
     tft.fill(COL_BLACK)
@@ -318,22 +252,29 @@ if _diag_requested and tft:
 
     for _label, _val in _diag_info:
         tft.text(_label, 4, _y, COL_AMBER)
-        # Value starts after label column (max ~9 chars label + colon)
         _vx = min(80, (len(_label) + 1) * 8 + 4)
         tft.text(str(_val), _vx, _y, COL_WHITE)
         _y += _line_h
 
     # Hint at bottom
-    _hint = "Release to continue"
+    _hint = "Press any button"
     _hx = (tft.width - len(_hint) * 8) // 2
     tft.text(_hint, _hx, tft.height - 16, COL_CYAN)
     tft.show()
 
-    # Wait for button release
-    _diag_btn = Pin(config.ENC1_SW, Pin.IN, Pin.PULL_UP)
-    while _diag_btn.value() == 0:
+    # Wait for any encoder button press (MCP23017 not available yet)
+    _enc_btns = [
+        Pin(config.ENC1_SW, Pin.IN, Pin.PULL_UP),
+        Pin(config.ENC2_SW, Pin.IN, Pin.PULL_UP),
+        Pin(config.ENC3_SW, Pin.IN, Pin.PULL_UP),
+    ]
+    # First wait for the held button to be released
+    while _enc_btns[0].value() == 0:
         time.sleep_ms(50)
-    _diag_btn = None
+    # Then wait for any encoder button press to dismiss
+    while all(b.value() == 1 for b in _enc_btns):
+        time.sleep_ms(50)
+    _enc_btns = None
 
     print("BOOT [DIAG] screen shown")
 


### PR DESCRIPTION
## Summary
- Hold the **NAV encoder button** (left knob) during power-on to enter a diagnostic boot screen
- Displays: MicroPython version, CPU freq, RAM free/used, flash usage, WiFi MAC/IP, battery level, time, boot step results
- Boot diag screen waits for release, then dismisses on any encoder button press
- Diagnostic info gathering extracted to `bodn/diag.py` for reuse
- Added `DiagScreen` UI screen (`bodn/ui/diag.py`) — dismisses on any button/encoder press
- Added **Diagnostics** menu item to Settings screen, launching the same DiagScreen

## Test plan
- [ ] Boot normally (no button held) — verify no change to boot behaviour
- [ ] Hold NAV encoder knob during reset — verify diagnostic screen appears
- [ ] Release, then press any encoder button — verify boot continues to home screen
- [ ] Navigate to Settings → Diagnostics — verify same info screen appears
- [ ] Press any button/encoder to dismiss the settings DiagScreen
- [ ] Test in Wokwi simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)