### PR TITLE
Add encoder velocity tracking and accumulator helper

### DIFF
--- a/firmware/bodn/ui/input.py
+++ b/firmware/bodn/ui/input.py
@@ -1,6 +1,54 @@
 # bodn/ui/input.py — unified input state with debouncing
 
+from micropython import const
+
 from bodn.debounce import Debouncer
+
+_VELOCITY_TIMEOUT_MS = const(200)  # velocity decays to 0 after this idle time
+
+
+class EncoderAccumulator:
+    """Accumulates raw encoder detents into logical units with velocity scaling.
+
+    Consumers instantiate with their own settings. Call update() each frame
+    with the raw delta and velocity from InputState.
+
+    Args:
+        detents_per_unit: raw detent clicks needed for one logical unit.
+        fast_threshold: velocity (steps/s) above which fast_multiplier applies.
+        fast_multiplier: detent scaling factor at high velocity.
+    """
+
+    def __init__(self, detents_per_unit=3, fast_threshold=400, fast_multiplier=2):
+        self._dpu = detents_per_unit
+        self._fast_thresh = fast_threshold
+        self._fast_mult = fast_multiplier
+        self._accum = 0
+
+    def update(self, delta, velocity):
+        """Feed raw delta and velocity, returns logical units to move."""
+        if delta == 0:
+            return 0
+        if velocity >= self._fast_thresh:
+            self._accum += delta * self._fast_mult
+        else:
+            self._accum += delta
+        # Truncate toward zero: extract whole units, keep remainder
+        a = self._accum
+        dpu = self._dpu
+        if a >= dpu:
+            units = a // dpu
+            self._accum = a - units * dpu
+            return units
+        if a <= -dpu:
+            units = -((-a) // dpu)
+            self._accum = a - units * dpu
+            return units
+        return 0
+
+    def reset(self):
+        """Clear accumulated detents (e.g. on screen transition)."""
+        self._accum = 0
 
 
 class InputState:
@@ -32,12 +80,14 @@ class InputState:
         self.sw = [False] * len(switches)
         self.enc_pos = [0] * n_enc
         self.enc_delta = [0] * n_enc
+        self.enc_velocity = [0] * n_enc  # steps/second per encoder
         self.enc_btn_held = [False] * n_enc
         self.enc_btn_pressed = [False] * n_enc
 
         self._prev_btn = [False] * n_btn
         self._prev_enc_pos = [0] * n_enc
         self._prev_enc_btn = [False] * n_enc
+        self._enc_last_step_ms = [0] * n_enc
 
     def scan(self):
         """Read all inputs. Call once per frame."""
@@ -69,17 +119,29 @@ class InputState:
         encoders = self._encoders
         enc_pos = self.enc_pos
         enc_delta = self.enc_delta
+        enc_velocity = self.enc_velocity
         prev_enc_pos = self._prev_enc_pos
         enc_btn_held = self.enc_btn_held
         enc_btn_pressed = self.enc_btn_pressed
         prev_enc_btn = self._prev_enc_btn
         enc_btn_deb = self._enc_btn_deb
+        enc_last_step = self._enc_last_step_ms
 
         for i, enc in enumerate(encoders):
             pos = enc.value
             enc_pos[i] = pos
-            enc_delta[i] = pos - prev_enc_pos[i]
+            d = pos - prev_enc_pos[i]
+            enc_delta[i] = d
             prev_enc_pos[i] = pos
+
+            if d != 0:
+                elapsed = now - enc_last_step[i]
+                if elapsed > 0:
+                    # steps/second: abs(delta) * 1000 / elapsed
+                    enc_velocity[i] = abs(d) * 1000 // elapsed
+                enc_last_step[i] = now
+            elif now - enc_last_step[i] > _VELOCITY_TIMEOUT_MS:
+                enc_velocity[i] = 0
 
             p_btn = prev_enc_btn[i]
             cur_btn = enc_btn_deb[i].update(enc.sw.value(), now)

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,6 +1,6 @@
 """Tests for InputState — debouncing, edge detection, encoder tracking."""
 
-from bodn.ui.input import InputState
+from bodn.ui.input import EncoderAccumulator, InputState
 
 
 class FakePin:
@@ -202,3 +202,149 @@ def test_switch_states():
     sws[0]._val = 1
     inp.scan()
     assert not inp.sw[0]
+
+
+# --- Encoder velocity tracking ---
+
+
+def test_enc_velocity_computed_on_step():
+    inp, _, _, encs, t = make_input()
+    t[0] = 0
+    inp.scan()
+
+    # Move 1 step after 50ms → 1000/50 = 20 steps/s
+    encs[0].value = 1
+    t[0] = 50
+    inp.scan()
+    assert inp.enc_velocity[0] == 20
+
+
+def test_enc_velocity_fast_spin():
+    inp, _, _, encs, t = make_input()
+    t[0] = 0
+    inp.scan()
+
+    # Move 3 steps in 10ms → 3000/10 = 300 steps/s
+    encs[0].value = 3
+    t[0] = 10
+    inp.scan()
+    assert inp.enc_velocity[0] == 300
+
+
+def test_enc_velocity_decays_after_timeout():
+    inp, _, _, encs, t = make_input()
+    t[0] = 0
+    inp.scan()
+
+    encs[0].value = 1
+    t[0] = 50
+    inp.scan()
+    assert inp.enc_velocity[0] > 0
+
+    # No movement for 201ms → velocity should decay to 0
+    t[0] = 251
+    inp.scan()
+    assert inp.enc_velocity[0] == 0
+
+
+def test_enc_velocity_persists_within_timeout():
+    inp, _, _, encs, t = make_input()
+    t[0] = 0
+    inp.scan()
+
+    encs[0].value = 1
+    t[0] = 50
+    inp.scan()
+    vel = inp.enc_velocity[0]
+    assert vel > 0
+
+    # No movement but within 200ms timeout → velocity stays
+    t[0] = 200
+    inp.scan()
+    assert inp.enc_velocity[0] == vel
+
+
+def test_enc_velocity_independent_per_encoder():
+    inp, _, _, encs, t = make_input()
+    t[0] = 0
+    inp.scan()
+
+    encs[0].value = 1
+    t[0] = 100
+    inp.scan()
+    assert inp.enc_velocity[0] == 10
+    assert inp.enc_velocity[1] == 0
+
+    encs[1].value = 2
+    t[0] = 110
+    inp.scan()
+    assert inp.enc_velocity[1] == 2 * 1000 // 110  # 2 steps since t=0 (init)
+
+
+# --- EncoderAccumulator ---
+
+
+def test_accumulator_basic_accumulation():
+    acc = EncoderAccumulator(detents_per_unit=3)
+    # 1 detent → not enough
+    assert acc.update(1, 0) == 0
+    # 2nd detent → not enough
+    assert acc.update(1, 0) == 0
+    # 3rd detent → triggers 1 unit
+    assert acc.update(1, 0) == 1
+
+
+def test_accumulator_negative_direction():
+    acc = EncoderAccumulator(detents_per_unit=3)
+    assert acc.update(-1, 0) == 0
+    assert acc.update(-1, 0) == 0
+    assert acc.update(-1, 0) == -1
+
+
+def test_accumulator_fast_velocity_multiplier():
+    acc = EncoderAccumulator(detents_per_unit=3, fast_threshold=400, fast_multiplier=3)
+    # 1 detent at high velocity → 1*3 = 3 effective → 1 unit immediately
+    assert acc.update(1, 500) == 1
+
+
+def test_accumulator_slow_velocity_no_multiplier():
+    acc = EncoderAccumulator(detents_per_unit=3, fast_threshold=400, fast_multiplier=3)
+    # 1 detent at slow velocity → 1 effective → not enough
+    assert acc.update(1, 100) == 0
+    assert acc.update(1, 100) == 0
+    assert acc.update(1, 100) == 1
+
+
+def test_accumulator_remainder_carries():
+    acc = EncoderAccumulator(detents_per_unit=3)
+    # 5 detents at once → 1 unit with 2 remainder
+    assert acc.update(5, 0) == 1
+    # 1 more → remainder 2 + 1 = 3 → another unit
+    assert acc.update(1, 0) == 1
+
+
+def test_accumulator_zero_delta_returns_zero():
+    acc = EncoderAccumulator(detents_per_unit=3)
+    assert acc.update(0, 0) == 0
+    assert acc.update(0, 500) == 0
+
+
+def test_accumulator_reset():
+    acc = EncoderAccumulator(detents_per_unit=3)
+    acc.update(2, 0)  # accumulate 2
+    acc.reset()
+    # After reset, need full 3 detents again
+    assert acc.update(1, 0) == 0
+    assert acc.update(1, 0) == 0
+    assert acc.update(1, 0) == 1
+
+
+def test_accumulator_direction_change():
+    acc = EncoderAccumulator(detents_per_unit=3)
+    acc.update(2, 0)  # accumulate +2
+    # Reverse direction: +2 + (-2) = 0
+    acc.update(-2, 0)
+    # Now 3 forward should trigger
+    assert acc.update(1, 0) == 0
+    assert acc.update(1, 0) == 0
+    assert acc.update(1, 0) == 1


### PR DESCRIPTION
## Summary

- Track encoder velocity (steps/second) in `InputState.scan()` — decays to 0 after 200ms idle
- Add `EncoderAccumulator` helper: converts raw detents into logical units with configurable detents-per-unit and velocity-based scaling
- 13 new tests covering velocity computation, decay, accumulation, direction changes, and reset

Closes #33

## Test plan

- [x] All 262 tests pass (`uv run pytest`)
- [ ] Deploy to device and verify `enc_velocity` values via REPL
- [ ] Test `EncoderAccumulator` in a screen to validate feel (detents-per-unit tuning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)