### PR TITLE
Unify brightness control with EncoderAccumulator

### DIFF
--- a/firmware/bodn/ui/demo.py
+++ b/firmware/bodn/ui/demo.py
@@ -3,6 +3,7 @@
 from micropython import const
 from bodn import config
 from bodn.ui.screen import Screen
+from bodn.ui.input import BrightnessControl
 from bodn.ui.widgets import draw_progress_bar, draw_button_grid, draw_centered
 from bodn.ui.pause import PauseMenu
 from bodn.patterns import PATTERNS, PATTERN_NAMES, N_LEDS, ZONE_LID_RING, _BLACK
@@ -36,10 +37,10 @@ class DemoScreen(Screen):
     happens on NeoPixel-write frames (every 3rd frame).
     """
 
-    def __init__(self, np, overlay, enc_steps=20, settings=None):
+    def __init__(self, np, overlay, settings=None):
         self._np = np
         self._overlay = overlay
-        self._enc_steps = enc_steps
+        self._brightness = BrightnessControl()
         self._active_pattern = 0
         self._manager = None
         self._pause = PauseMenu(settings=settings)
@@ -52,6 +53,7 @@ class DemoScreen(Screen):
     def enter(self, manager):
         self._manager = manager
         self._pause.set_manager(manager)
+        self._brightness.reset()
         self._dirty = True
 
     def needs_redraw(self):
@@ -79,8 +81,14 @@ class DemoScreen(Screen):
             self._active_pattern = (self._active_pattern + 1) % len(PATTERNS)
             self._dirty = True
 
-        # Detect input changes for display redraw
-        for i in range(3):
+        # Update brightness from encoder A (velocity-aware)
+        prev_bri = self._brightness.value
+        self._brightness.update(inp.enc_delta[ENC_A], inp.enc_velocity[ENC_A])
+        if self._brightness.value != prev_bri:
+            self._dirty = True
+
+        # Detect encoder changes for display redraw
+        for i in (NAV, ENC_B):
             if inp.enc_pos[i] != self._prev_enc[i]:
                 self._prev_enc[i] = inp.enc_pos[i]
                 self._dirty = True
@@ -95,9 +103,8 @@ class DemoScreen(Screen):
 
         # Only compute and write LEDs on NeoPixel-write frames
         if frame % 3 == 0:
-            enc_pos = inp.enc_pos
-            brightness = min(255, max(10, enc_pos[ENC_A] * 255 // self._enc_steps))
-            speed = max(1, enc_pos[ENC_B])
+            brightness = self._brightness.value
+            speed = max(1, inp.enc_pos[ENC_B])
 
             _name, pat_fn = PATTERNS[self._active_pattern]
 
@@ -175,13 +182,13 @@ class DemoScreen(Screen):
 
     def _render_landscape(self, tft, theme, frame):
         """Split layout: pattern name + buttons left, encoder bars + toggles right."""
-        inp_enc = [0, 0, 0]
         sw = [False] * 4
         held = [False] * 8
+        enc_spd = 0
         if self._manager:
-            inp_enc = self._manager.inp.enc_pos
             sw = self._manager.inp.sw
             held = self._manager.inp.btn_held
+            enc_spd = self._manager.inp.enc_pos[ENC_B]
 
         mid_x = theme.width // 2
 
@@ -229,17 +236,17 @@ class DemoScreen(Screen):
         draw_centered(tft, t("home_title"), 6, theme.WHITE, theme.width)
 
         bar_info = [
-            (t("demo_bri"), theme.CYAN, inp_enc[ENC_A]),
-            (t("demo_spd"), theme.ORANGE, inp_enc[ENC_B]),
+            (t("demo_bri"), theme.CYAN, self._brightness.value, 255),
+            (t("demo_spd"), theme.ORANGE, enc_spd, 20),
         ]
-        for i, (label, colour_565, val) in enumerate(bar_info):
+        for i, (label, colour_565, val, max_val) in enumerate(bar_info):
             y = 40 + i * 28
             tft.text(label, rx, y, colour_565)
             bar_x = rx + 32
             bar_w = rw - 32
             tft.rect(bar_x, y, bar_w, 14, theme.WHITE)
             draw_progress_bar(
-                tft, bar_x, y, bar_w, 14, val, self._enc_steps, colour_565, theme.BLACK
+                tft, bar_x, y, bar_w, 14, val, max_val, colour_565, theme.BLACK
             )
 
         # Back hint
@@ -247,13 +254,13 @@ class DemoScreen(Screen):
 
     def _render_portrait(self, tft, theme, frame):
         """Stacked layout for portrait displays."""
-        inp_enc = [0, 0, 0]
         sw = [False] * 4
         held = [False] * 8
+        enc_spd = 0
         if self._manager:
-            inp_enc = self._manager.inp.enc_pos
             sw = self._manager.inp.sw
             held = self._manager.inp.btn_held
+            enc_spd = self._manager.inp.enc_pos[ENC_B]
 
         tft.text(t("home_title"), 32, 3, theme.WHITE)
 
@@ -262,15 +269,13 @@ class DemoScreen(Screen):
         tft.text(PATTERN_NAMES[self._active_pattern], 4, 18, theme.BLACK)
 
         bar_info = [
-            (t("demo_bri"), theme.CYAN, inp_enc[ENC_A]),
-            (t("demo_spd"), theme.ORANGE, inp_enc[ENC_B]),
+            (t("demo_bri"), theme.CYAN, self._brightness.value, 255),
+            (t("demo_spd"), theme.ORANGE, enc_spd, 20),
         ]
-        for i, (label, colour_565, val) in enumerate(bar_info):
+        for i, (label, colour_565, val, max_val) in enumerate(bar_info):
             y = 32 + i * 16
             tft.rect(24, y, 96, 10, theme.WHITE)
-            draw_progress_bar(
-                tft, 24, y, 96, 10, val, self._enc_steps, colour_565, theme.BLACK
-            )
+            draw_progress_bar(tft, 24, y, 96, 10, val, max_val, colour_565, theme.BLACK)
             tft.text(label, 0, y + 1, colour_565)
 
         tft.text(t("demo_toggles"), 0, 70, theme.WHITE)

--- a/firmware/bodn/ui/flode.py
+++ b/firmware/bodn/ui/flode.py
@@ -5,7 +5,7 @@ from bodn import config
 from bodn.ui.screen import Screen
 from bodn.ui.widgets import draw_centered
 from bodn.ui.pause import PauseMenu
-from bodn.ui.input import EncoderAccumulator
+from bodn.ui.input import BrightnessControl, EncoderAccumulator
 from bodn.i18n import t
 from bodn.flode_rules import FlodeEngine, PLAYING, COMPLETE, CELEBRATE
 from bodn.patterns import N_LEDS, zone_fill, zone_pulse, zone_clear, ZONE_LID_RING
@@ -81,7 +81,8 @@ class FlodeScreen(Screen):
 
         self._engine = FlodeEngine(rand_fn=_rand)
 
-        # Encoder accumulators
+        # Brightness and encoder accumulators
+        self._brightness = BrightnessControl()
         self._select_acc = EncoderAccumulator(
             detents_per_unit=2, fast_threshold=300, fast_multiplier=2
         )
@@ -105,6 +106,7 @@ class FlodeScreen(Screen):
     def enter(self, manager):
         self._manager = manager
         self._pause.set_manager(manager)
+        self._brightness.reset()
         # Seed RNG from a somewhat unpredictable source
         import time
 
@@ -280,16 +282,22 @@ class FlodeScreen(Screen):
         if self._tick_anim():
             self._dirty = True
 
+        # Update brightness from encoder A (velocity-aware)
+        prev_bri = self._brightness.value
+        self._brightness.update(inp.enc_delta[ENC_A], inp.enc_velocity[ENC_A])
+        if self._brightness.value != prev_bri:
+            self._leds_dirty = True
+
         # Update LEDs on state change
         if self._leds_dirty:
             self._leds_dirty = False
-            self._update_leds(inp, frame)
+            self._update_leds(frame)
 
-    def _update_leds(self, inp, frame):
+    def _update_leds(self, frame):
         """Write LED state based on game state."""
         np = self._np
         eng = self._engine
-        brightness = min(255, max(10, inp.enc_pos[config.ENC_A] * 255 // 20))
+        brightness = self._brightness.value
         lid_bright = min(brightness, config.NEOPIXEL_LID_BRIGHTNESS)
 
         if eng.state == CELEBRATE:

--- a/firmware/bodn/ui/input.py
+++ b/firmware/bodn/ui/input.py
@@ -51,6 +51,47 @@ class EncoderAccumulator:
         self._accum = 0
 
 
+class BrightnessControl:
+    """Velocity-aware brightness from encoder delta.
+
+    Wraps EncoderAccumulator to produce a clamped brightness value.
+    Slow turns give fine adjustment; fast spins jump to extremes.
+
+    Args:
+        initial: starting brightness (0–255).
+        minimum: floor brightness (default 10, never fully off).
+        maximum: ceiling brightness (default 255).
+        step: brightness change per logical encoder unit.
+    """
+
+    def __init__(self, initial=128, minimum=10, maximum=255, step=20):
+        self._acc = EncoderAccumulator(
+            detents_per_unit=3, fast_threshold=400, fast_multiplier=3
+        )
+        self._value = initial
+        self._min = minimum
+        self._max = maximum
+        self._step = step
+
+    @property
+    def value(self):
+        return self._value
+
+    def update(self, delta, velocity):
+        """Feed encoder delta and velocity; returns current brightness."""
+        units = self._acc.update(delta, velocity)
+        if units:
+            v = self._value + units * self._step
+            self._value = min(self._max, max(self._min, v))
+        return self._value
+
+    def reset(self, value=None):
+        """Reset accumulator; optionally set a new brightness value."""
+        self._acc.reset()
+        if value is not None:
+            self._value = value
+
+
 class InputState:
     """Wraps buttons, switches and encoders into a single scannable state.
 

--- a/firmware/bodn/ui/mystery.py
+++ b/firmware/bodn/ui/mystery.py
@@ -3,6 +3,7 @@
 from micropython import const
 from bodn import config
 from bodn.ui.screen import Screen
+from bodn.ui.input import BrightnessControl
 from bodn.ui.widgets import draw_centered, draw_button_grid
 from bodn.ui.pause import PauseMenu
 from bodn.mystery_rules import MysteryEngine, OUT_IDLE, OUT_MIX, OUT_MAGIC
@@ -28,6 +29,7 @@ class MysteryScreen(Screen):
         self._secondary = secondary_screen
         self._on_exit = on_exit
         self._engine = MysteryEngine()
+        self._brightness = BrightnessControl()
         self._manager = None
         self._pause = PauseMenu(settings=settings)
         self._prev_out_type = OUT_IDLE
@@ -37,6 +39,7 @@ class MysteryScreen(Screen):
     def enter(self, manager):
         self._manager = manager
         self._pause.set_manager(manager)
+        self._brightness.reset()
         self._dirty = True
 
     def exit(self):
@@ -102,10 +105,18 @@ class MysteryScreen(Screen):
             self._dirty = True
             self._leds_dirty = True
 
+        # Update brightness from encoder A (velocity-aware)
+        prev_bri = self._brightness.value
+        self._brightness.update(
+            inp.enc_delta[config.ENC_A], inp.enc_velocity[config.ENC_A]
+        )
+        if self._brightness.value != prev_bri:
+            self._leds_dirty = True
+
         # Write LEDs only when state changes (static patterns, no animation)
         if self._leds_dirty:
             self._leds_dirty = False
-            brightness = min(255, max(10, inp.enc_pos[config.ENC_A] * 255 // 20))
+            brightness = self._brightness.value
             lid_bright = min(brightness, config.NEOPIXEL_LID_BRIGHTNESS)
 
             # Sticks: game feedback (engine writes indices 0–15)

--- a/firmware/bodn/ui/rulefollow.py
+++ b/firmware/bodn/ui/rulefollow.py
@@ -3,6 +3,7 @@
 from micropython import const
 from bodn import config
 from bodn.ui.screen import Screen
+from bodn.ui.input import BrightnessControl
 from bodn.ui.widgets import draw_centered, draw_button_grid
 from bodn.ui.pause import PauseMenu
 from bodn.i18n import t
@@ -72,6 +73,7 @@ class RuleFollowScreen(Screen):
         self._secondary = secondary_screen
         self._on_exit = on_exit
         self._engine = RuleFollowEngine()
+        self._brightness = BrightnessControl()
         self._manager = None
         self._pause = PauseMenu(settings=settings)
         self._prev_state = None
@@ -82,6 +84,7 @@ class RuleFollowScreen(Screen):
         self._manager = manager
         self._pause.set_manager(manager)
         self._engine.reset()
+        self._brightness.reset()
         self._dirty = True
 
     def exit(self):
@@ -132,10 +135,18 @@ class RuleFollowScreen(Screen):
             self._dirty = True
             self._leds_dirty = True
 
+        # Update brightness from encoder A (velocity-aware)
+        prev_bri = self._brightness.value
+        self._brightness.update(
+            inp.enc_delta[config.ENC_A], inp.enc_velocity[config.ENC_A]
+        )
+        if self._brightness.value != prev_bri:
+            self._leds_dirty = True
+
         # Write LEDs only when state changes
         if self._leds_dirty:
             self._leds_dirty = False
-            brightness = min(255, max(10, inp.enc_pos[config.ENC_A] * 255 // 20))
+            brightness = self._brightness.value
             lid_bright = min(brightness, config.NEOPIXEL_LID_BRIGHTNESS)
 
             # Sticks: game feedback

--- a/firmware/bodn/ui/simon.py
+++ b/firmware/bodn/ui/simon.py
@@ -3,6 +3,7 @@
 from micropython import const
 from bodn import config
 from bodn.ui.screen import Screen
+from bodn.ui.input import BrightnessControl
 from bodn.ui.widgets import draw_centered, draw_button_grid
 from bodn.ui.pause import PauseMenu
 from bodn.i18n import t
@@ -45,6 +46,7 @@ class SimonScreen(Screen):
         self._secondary = secondary_screen
         self._on_exit = on_exit
         self._engine = SimonEngine()
+        self._brightness = BrightnessControl()
         self._manager = None
         self._pause = PauseMenu(settings=settings)
         self._prev_state = None
@@ -56,6 +58,7 @@ class SimonScreen(Screen):
         self._manager = manager
         self._pause.set_manager(manager)
         self._engine.reset()
+        self._brightness.reset()
         self._dirty = True
 
     def exit(self):
@@ -106,10 +109,18 @@ class SimonScreen(Screen):
             self._dirty = True
             self._leds_dirty = True
 
+        # Update brightness from encoder A (velocity-aware)
+        prev_bri = self._brightness.value
+        self._brightness.update(
+            inp.enc_delta[config.ENC_A], inp.enc_velocity[config.ENC_A]
+        )
+        if self._brightness.value != prev_bri:
+            self._leds_dirty = True
+
         # Write LEDs only when state changes (static patterns, no animation)
         if self._leds_dirty:
             self._leds_dirty = False
-            brightness = min(255, max(10, inp.enc_pos[config.ENC_A] * 255 // 20))
+            brightness = self._brightness.value
             lid_bright = min(brightness, config.NEOPIXEL_LID_BRIGHTNESS)
 
             # Sticks: game feedback (engine writes indices 0–15)

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -91,8 +91,8 @@ def create_hardware():
             config.ENC2_CLK,
             config.ENC2_DT,
             config.ENC2_SW,
-            min_val=0,
-            max_val=ENC_STEPS,
+            min_val=-10000,
+            max_val=10000,
         ),
         Encoder(
             config.ENC3_CLK,
@@ -102,7 +102,6 @@ def create_hardware():
             max_val=ENC_STEPS,
         ),
     ]
-    encoders[config.ENC_A].value = ENC_STEPS // 2  # brightness default
     encoders[config.ENC_B].value = ENC_STEPS // 4  # speed default
 
     return tft, tft2, buttons, switches, encoders, np, mcp
@@ -198,7 +197,7 @@ def create_ui(
         "flode": _make_flode,
         "demo": lambda: (
             _reset_secondary(),
-            DemoScreen(np, overlay, enc_steps=ENC_STEPS, settings=settings),
+            DemoScreen(np, overlay, settings=settings),
         )[1],
         "clock": lambda: (_reset_secondary(), ClockScreen(settings=settings))[1],
         "settings": _make_settings,

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,6 +1,6 @@
 """Tests for InputState — debouncing, edge detection, encoder tracking."""
 
-from bodn.ui.input import EncoderAccumulator, InputState
+from bodn.ui.input import BrightnessControl, EncoderAccumulator, InputState
 
 
 class FakePin:
@@ -348,3 +348,71 @@ def test_accumulator_direction_change():
     assert acc.update(1, 0) == 0
     assert acc.update(1, 0) == 0
     assert acc.update(1, 0) == 1
+
+
+# --- BrightnessControl ---
+
+
+def test_brightness_initial_value():
+    bc = BrightnessControl(initial=128)
+    assert bc.value == 128
+
+
+def test_brightness_slow_turn_fine_adjustment():
+    bc = BrightnessControl(initial=128, step=20)
+    # 3 slow detents (below fast threshold) → 1 unit → +20 brightness
+    bc.update(1, 100)
+    bc.update(1, 100)
+    assert bc.value == 128  # not yet
+    bc.update(1, 100)
+    assert bc.value == 148  # +20
+
+
+def test_brightness_fast_spin_big_jump():
+    bc = BrightnessControl(initial=128, step=20)
+    # 1 detent at high velocity → multiplied by 3 → 1 unit → +20
+    bc.update(1, 500)
+    assert bc.value == 148
+
+
+def test_brightness_clamps_to_max():
+    bc = BrightnessControl(initial=240, step=20)
+    bc.update(1, 500)  # +20 → 260, clamped to 255
+    assert bc.value == 255
+
+
+def test_brightness_clamps_to_min():
+    bc = BrightnessControl(initial=20, step=20)
+    bc.update(-1, 500)  # -20 → 0, clamped to 10
+    assert bc.value == 10
+
+
+def test_brightness_reset_clears_accumulator():
+    bc = BrightnessControl(initial=128, step=20)
+    bc.update(1, 100)  # accumulate 1 detent
+    bc.reset(value=200)
+    assert bc.value == 200
+    # After reset, need full 3 detents again
+    assert bc.update(1, 100) == 200
+    assert bc.update(1, 100) == 200
+    bc.update(1, 100)
+    assert bc.value == 220
+
+
+def test_brightness_decrease_direction():
+    bc = BrightnessControl(initial=128, step=20)
+    bc.update(-1, 100)
+    bc.update(-1, 100)
+    bc.update(-1, 100)
+    assert bc.value == 108
+
+
+def test_brightness_consistent_across_instances():
+    """All instances with same params produce identical behavior."""
+    controls = [BrightnessControl() for _ in range(4)]
+    deltas = [(1, 100), (1, 100), (1, 100), (-1, 500), (1, 500)]
+    for d, v in deltas:
+        for bc in controls:
+            bc.update(d, v)
+    values = [bc.value for bc in controls]
+    assert len(set(values)) == 1  # all identical


### PR DESCRIPTION
## Summary

Closes #40

- Add `BrightnessControl` helper wrapping `EncoderAccumulator` with velocity-aware brightness mapping (slow turn = fine adjustment, fast spin = jump to min/max)
- Replace duplicated `enc_pos[ENC_A] * 255 // 20` pattern across all 5 game screens (demo, mystery, simon, rulefollow, flöde) with shared `BrightnessControl`
- Unclamped ENC_A encoder so deltas flow through to the accumulator instead of being lost at limits

## Test plan

- [x] 8 new unit tests for `BrightnessControl` (initial value, slow/fast turns, clamping, reset, direction, consistency)
- [x] All 308 tests pass
- [x] Lint clean
- [ ] Verify on device/Wokwi: brightness feels identical across all modes
- [ ] Slow turn gives ~5-10 brightness levels per full knob rotation
- [ ] Fast spin reaches 0 or 255 within ~2 quick spins

🤖 Generated with [Claude Code](https://claude.com/claude-code)