### PR TITLE
Fix Flöde and RuleFollow crashes

### DIFF
--- a/firmware/bodn/patterns.py
+++ b/firmware/bodn/patterns.py
@@ -184,10 +184,15 @@ def pattern_fill(frame, speed, colour, bright):
 # --- Zone-aware helpers ---
 
 
-def zone_fill(zone, colour):
-    """Fill a zone with a solid colour. zone = (start, count)."""
+def zone_fill(zone, colour, bright=255):
+    """Fill a zone with a solid colour, optionally scaled by brightness."""
     buf = _led_buf
     start, count = zone
+    if bright < 255:
+        r = colour[0] * bright // 255
+        g = colour[1] * bright // 255
+        b = colour[2] * bright // 255
+        colour = (r, g, b)
     for i in range(start, start + count):
         buf[i] = colour
 

--- a/firmware/bodn/ui/theme.py
+++ b/firmware/bodn/ui/theme.py
@@ -13,6 +13,7 @@ class Theme:
     def __init__(self, width, height, rgb_fn):
         self.width = width
         self.height = height
+        self.rgb = rgb_fn
 
         # Semantic colours (RGB565, byte-swapped)
         self.BLACK = rgb_fn(0, 0, 0)


### PR DESCRIPTION
## Summary
- **`zone_fill()` missing brightness parameter**: Both Flöde and RuleFollow called `zone_fill(zone, colour, brightness)` but the function only accepted 2 args. Added optional `bright=255` parameter with RGB scaling.
- **`theme.rgb` not exposed**: `Theme.__init__` used `rgb_fn` locally without storing it. Both game modes call `theme.rgb()` to convert RGB tuples to RGB565 for custom colours. Now stored as `self.rgb`.

Both bugs caused crashes on the first tick, swallowed by the main loop's `try/except`, resulting in a black/unresponsive display.

## Test plan
- [x] All 300 existing tests pass
- [ ] Launch Flöde from home screen — game renders correctly
- [ ] Launch RuleFollow — game renders correctly
- [ ] Pause and resume both game modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)