### PR TITLE
Graceful degradation for missing MCP23017

### DIFF
--- a/firmware/bodn/diag.py
+++ b/firmware/bodn/diag.py
@@ -6,6 +6,15 @@
 import gc
 import time
 
+# Hardware status — set once by main.py after create_hardware().
+_hw_status = {}
+
+
+def set_hw_status(status):
+    """Store hardware detection results for the diagnostic screen."""
+    global _hw_status
+    _hw_status = status
+
 
 def gather(ip="0.0.0.0", boot_results=None, boot_steps=None):
     """Collect system diagnostics. Returns list of (label, value) pairs."""
@@ -78,5 +87,12 @@ def gather(ip="0.0.0.0", boot_results=None, boot_steps=None):
             for i in range(len(boot_steps))
         )
         info.append(("Boot", summary))
+
+    # Hardware detection (set by main.py after create_hardware)
+    if _hw_status:
+        parts = []
+        for name, ok in sorted(_hw_status.items()):
+            parts.append("{}:{}".format(name.upper(), "ok" if ok else "--"))
+        info.append(("Hardware", " ".join(parts)))
 
     return info

--- a/firmware/bodn/power.py
+++ b/firmware/bodn/power.py
@@ -99,21 +99,20 @@ class PowerManager:
         from bodn import config
 
         # Enable MCP23017 interrupts (any button/toggle change pulls INT low)
-        self._mcp.enable_interrupts()
+        if self._mcp:
+            self._mcp.enable_interrupts()
 
-        # Wake sources: MCP INT + encoder buttons (all active-low)
-        wake_pins = [
-            config.MCP_INT_PIN,
-            config.ENC1_SW,
-            config.ENC2_SW,
-            config.ENC3_SW,
-        ]
+        # Wake sources: encoder buttons (all active-low) + MCP INT if present
+        wake_pins = [config.ENC1_SW, config.ENC2_SW, config.ENC3_SW]
+        if self._mcp:
+            wake_pins.append(config.MCP_INT_PIN)
         for pin_num in wake_pins:
             p = Pin(pin_num, Pin.IN, Pin.PULL_UP)
             esp32.gpio_wakeup(p, esp32.WAKEUP_ANY_LOW)
 
         # Clear pending MCP interrupts before sleeping
-        self._mcp.clear_interrupts()
+        if self._mcp:
+            self._mcp.clear_interrupts()
 
         print("POWER: entering light sleep")
         machine.lightsleep()
@@ -125,8 +124,9 @@ class PowerManager:
         from bodn import config
 
         # Clear MCP23017 interrupt state and disable interrupts
-        self._mcp.clear_interrupts()
-        self._mcp.disable_interrupts()
+        if self._mcp:
+            self._mcp.clear_interrupts()
+            self._mcp.disable_interrupts()
 
         # Wake displays (SLPOUT)
         self._tft._cmd(0x11)
@@ -139,6 +139,8 @@ class PowerManager:
 
     def master_switch_off(self):
         """Return True if the master switch is in the OFF position (high = off)."""
+        if not self._mcp:
+            return False  # assume device ON when MCP is absent
         from bodn import config
 
         self._mcp.refresh()
@@ -163,5 +165,6 @@ class PowerManager:
             if not self.master_switch_off():
                 break
             # Still off — clear interrupts and sleep again
-            self._mcp.clear_interrupts()
+            if self._mcp:
+                self._mcp.clear_interrupts()
         self.post_wake()

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -35,7 +35,15 @@ N_LEDS = const(108)  # config.NEOPIXEL_COUNT
 
 
 def create_hardware():
-    """Initialise all hardware peripherals. Returns (tft, tft2, buttons, switches, encoders, np, mcp, i2s_out)."""
+    """Initialise all hardware peripherals.
+
+    Returns (tft, tft2, buttons, switches, encoders, np, mcp, hw_status).
+    Components that fail to initialise degrade gracefully:
+    - MCP23017 missing → buttons/switches are empty lists, mcp is None.
+    - SPI displays can't be probed (push-only) so are always assumed present.
+    """
+    hw_status = {"mcp": False}
+
     spi = SPI(
         2,
         baudrate=26_000_000,
@@ -74,10 +82,18 @@ def create_hardware():
     )
 
     # MCP23017 GPIO expander for buttons and toggles (I2C)
-    i2c = SoftI2C(scl=Pin(config.I2C_SCL), sda=Pin(config.I2C_SDA), freq=400_000)
-    mcp = MCP23017(i2c, config.MCP23017_ADDR)
-    buttons = [mcp.pin(p) for p in config.MCP_BTN_PINS]
-    switches = [mcp.pin(p) for p in config.MCP_SW_PINS]
+    mcp = None
+    buttons = []
+    switches = []
+    try:
+        i2c = SoftI2C(scl=Pin(config.I2C_SCL), sda=Pin(config.I2C_SDA), freq=400_000)
+        mcp = MCP23017(i2c, config.MCP23017_ADDR)
+        buttons = [mcp.pin(p) for p in config.MCP_BTN_PINS]
+        switches = [mcp.pin(p) for p in config.MCP_SW_PINS]
+        hw_status["mcp"] = True
+    except Exception as e:
+        print("MCP23017 not found, buttons/switches disabled:", e)
+
     np = neopixel.NeoPixel(Pin(config.NEOPIXEL_PIN, Pin.OUT), N_LEDS, timing=1)
     encoders = [
         Encoder(
@@ -104,7 +120,7 @@ def create_hardware():
     ]
     encoders[config.ENC_B].value = ENC_STEPS // 4  # speed default
 
-    return tft, tft2, buttons, switches, encoders, np, mcp
+    return tft, tft2, buttons, switches, encoders, np, mcp, hw_status
 
 
 def create_ui(
@@ -353,7 +369,12 @@ async def main():
     except Exception as e:
         print("Web server failed to start:", e)
 
-    tft, tft2, buttons, switches, encoders, np, mcp = create_hardware()
+    tft, tft2, buttons, switches, encoders, np, mcp, hw_status = create_hardware()
+
+    # Publish hardware status for diagnostics
+    from bodn.diag import set_hw_status
+
+    set_hw_status(hw_status)
     manager, secondary, inp = create_ui(
         session_mgr,
         settings,


### PR DESCRIPTION
## Summary
- **MCP23017 init wrapped in try/except** — if the I2C expander isn't found, `mcp=None`, `buttons=[]`, `switches=[]`. Device boots with encoder-only navigation.
- **PowerManager guarded** — all 6 `self._mcp.*` calls protected. `master_switch_off()` returns False (device ON) when absent. MCP_INT_PIN wake source excluded dynamically.
- **Diagnostic screen shows hardware status** — `gather()` appends a `Hardware` line (e.g. `MCP:ok` or `MCP:--`), extensible for future components.

No changes needed to `InputState` — it already handles empty button/switch lists. SPI displays and NeoPixels are inherently safe (push-only, no ACK).

## Test plan
- [x] All 300 existing tests pass
- [ ] With MCP23017 present: boots normally, diag shows `MCP:ok`, all buttons work
- [ ] Without MCP23017: boots, diag shows `MCP:--`, encoders work, buttons disabled
- [ ] Sleep/wake cycle without MCP: no crash, encoder buttons still wake device

🤖 Generated with [Claude Code](https://claude.com/claude-code)