### PR TITLE
Add no-battery detection for USB-only operation

### DIFF
--- a/firmware/bodn/battery.py
+++ b/firmware/bodn/battery.py
@@ -7,6 +7,13 @@
 #
 # ADC attenuation: ATTN_2_5DB gives ~0–1.25 V full scale, which covers the
 # divided LiPo range of 0.73 V (3.0 V empty) to 1.02 V (4.2 V full).
+#
+# No-battery detection:
+#   When USB-powered with no LiPo attached, the BAT_SENS divider floats and
+#   produces noisy / very low readings.  We detect this by checking both that
+#   USB power is present AND the voltage is below the plausible LiPo minimum
+#   (< 2.5 V, well below the 3.0 V "empty" threshold).  In this state read()
+#   returns (None, True) so the UI can hide the battery indicator.
 
 import time
 from micropython import const
@@ -24,12 +31,16 @@ _VBAT_FULL_MV = const(4200)  # LiPo 100 %
 _VBAT_EMPTY_MV = const(3000)  # LiPo 0 %
 _VBAT_RANGE_MV = const(1200)  # 4200 - 3000
 
+# Below this voltage (mV) with USB power present → no battery connected.
+# A real LiPo never drops below ~2.8 V under load; 2500 mV gives margin.
+_NO_BAT_THRESH_MV = const(2500)
+
 _SAMPLES = const(4)  # ADC readings to average per measurement
 _CACHE_MS = const(30_000)  # re-read at most once every 30 s
 
 _adc = None
 _pwr_pin = None
-_cached_pct = 0
+_cached_pct = None  # None means no battery detected
 _cached_charging = False
 _next_read_ms = 0
 
@@ -44,9 +55,9 @@ def _init():
 
 
 def read():
-    """Return (percent: int, charging: bool).
+    """Return (percent, charging).
 
-    percent  — battery charge level 0–100.
+    percent  — battery charge level 0–100, or None if no battery detected.
     charging — True when USB / charger power is detected.
 
     Results are cached for 30 s to avoid hammering the ADC.
@@ -63,12 +74,18 @@ def read():
         raw += _adc.read()
     raw //= _SAMPLES
     v_bat_mv = raw * _VBAT_MV_NUM // _ADC_MAX
-    pct = (v_bat_mv - _VBAT_EMPTY_MV) * 100 // _VBAT_RANGE_MV
-    pct = max(0, min(100, pct))
 
     # PWR_SENS is high-Z (reads high via internal pull-down on the board)
     # when on battery, and driven low when USB power / charger is active.
     charging = _pwr_pin.value() == 0
+
+    # No-battery heuristic: USB powered but divider reads below plausible
+    # LiPo voltage → the BAT pin is floating (no cell attached).
+    if charging and v_bat_mv < _NO_BAT_THRESH_MV:
+        pct = None
+    else:
+        pct = (v_bat_mv - _VBAT_EMPTY_MV) * 100 // _VBAT_RANGE_MV
+        pct = max(0, min(100, pct))
 
     _cached_pct = pct
     _cached_charging = charging

--- a/firmware/bodn/diag.py
+++ b/firmware/bodn/diag.py
@@ -71,7 +71,10 @@ def gather(ip="0.0.0.0", boot_results=None, boot_steps=None):
         from bodn.battery import read as bat_read
 
         pct, chg = bat_read()
-        info.append(("Battery", "{}%{}".format(pct, " CHG" if chg else "")))
+        if pct is None:
+            info.append(("Battery", "N/A (USB)"))
+        else:
+            info.append(("Battery", "{}%{}".format(pct, " CHG" if chg else "")))
     except Exception:
         pass
 

--- a/firmware/bodn/ui/ambient.py
+++ b/firmware/bodn/ui/ambient.py
@@ -92,6 +92,7 @@ class StatusStrip(Screen):
 
         # Battery (cached — at most one ADC read per call, refresh every 30 s)
         bat_pct, charging = battery.read()
+        # bat_pct is None when no battery detected — still track for changes
         if bat_pct != self._prev_bat_pct or charging != self._prev_charging:
             self._prev_bat_pct = bat_pct
             self._prev_charging = charging
@@ -157,29 +158,30 @@ class StatusStrip(Screen):
             x_right = w - len(label) * 8 - 2
             tft.text(label, x_right, 2, color)
 
-        # Battery icon — row 2, always visible
-        if bat_pct >= 50:
-            bat_color = theme.GREEN
-        elif bat_pct >= 20:
-            bat_color = theme.AMBER
-        else:
-            bat_color = theme.RED
-        icon_w, icon_h = 20, 10
-        icon_x = w - icon_w - 2
-        icon_y = 18
-        draw_battery_icon(
-            tft,
-            icon_x,
-            icon_y,
-            icon_w,
-            icon_h,
-            bat_pct,
-            bat_color,
-            theme.BLACK,
-            theme.WHITE,
-        )
-        if charging:
-            tft.text("+", icon_x + icon_w // 2 - 4, icon_y + 1, theme.YELLOW)
+        # Battery icon — row 2 (hidden when no battery detected)
+        if bat_pct is not None:
+            if bat_pct >= 50:
+                bat_color = theme.GREEN
+            elif bat_pct >= 20:
+                bat_color = theme.AMBER
+            else:
+                bat_color = theme.RED
+            icon_w, icon_h = 20, 10
+            icon_x = w - icon_w - 2
+            icon_y = 18
+            draw_battery_icon(
+                tft,
+                icon_x,
+                icon_y,
+                icon_w,
+                icon_h,
+                bat_pct,
+                bat_color,
+                theme.BLACK,
+                theme.WHITE,
+            )
+            if charging:
+                tft.text("+", icon_x + icon_w // 2 - 4, icon_y + 1, theme.YELLOW)
 
     def _render_vertical(self, tft, theme):
         """Landscape layout: 32×128 vertical strip."""
@@ -245,26 +247,27 @@ class StatusStrip(Screen):
             lx = (w - len(label) * 8) // 2
             tft.text(label, max(0, lx), y_session, color)
 
-        # Bottom: battery icon
-        if bat_pct >= 50:
-            bat_color = theme.GREEN
-        elif bat_pct >= 20:
-            bat_color = theme.AMBER
-        else:
-            bat_color = theme.RED
-        icon_w, icon_h = 20, 10
-        icon_x = (w - icon_w) // 2
-        icon_y = h - icon_h - 4
-        draw_battery_icon(
-            tft,
-            icon_x,
-            icon_y,
-            icon_w,
-            icon_h,
-            bat_pct,
-            bat_color,
-            theme.BLACK,
-            theme.WHITE,
-        )
-        if charging:
-            tft.text("+", icon_x + icon_w // 2 - 4, icon_y + 1, theme.YELLOW)
+        # Bottom: battery icon (hidden when no battery detected)
+        if bat_pct is not None:
+            if bat_pct >= 50:
+                bat_color = theme.GREEN
+            elif bat_pct >= 20:
+                bat_color = theme.AMBER
+            else:
+                bat_color = theme.RED
+            icon_w, icon_h = 20, 10
+            icon_x = (w - icon_w) // 2
+            icon_y = h - icon_h - 4
+            draw_battery_icon(
+                tft,
+                icon_x,
+                icon_y,
+                icon_w,
+                icon_h,
+                bat_pct,
+                bat_color,
+                theme.BLACK,
+                theme.WHITE,
+            )
+            if charging:
+                tft.text("+", icon_x + icon_w // 2 - 4, icon_y + 1, theme.YELLOW)


### PR DESCRIPTION
## Summary
- Detect missing LiPo when USB-powered by checking if BAT_SENS reads below 2.5V (a real LiPo never drops below ~2.8V)
- `battery.read()` returns `(None, True)` instead of a bogus percentage when no battery is connected
- Status strip hides the battery icon entirely when `pct is None` (both portrait and landscape layouts)
- Diagnostics screen shows `"N/A (USB)"` instead of a misleading percentage

## Test plan
- [ ] Run `uv run pytest` — all 357 tests pass
- [ ] On device with battery: verify battery icon and percentage still display correctly
- [ ] On device without battery (USB only): verify battery icon is hidden, diag shows "N/A (USB)"
- [ ] On Wokwi (no battery simulation): verify no crash and icon is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)