### PR TITLE
Add DST-aware timezone support

### DIFF
--- a/firmware/bodn/lang/en.py
+++ b/firmware/bodn/lang/en.py
@@ -32,6 +32,7 @@ STRINGS = {
     "settings_diag": "Diagnostics",
     "settings_sleep": "Sleep timer",
     "settings_encoder": "Sensitivity",
+    "settings_tz": "Timezone",
     "settings_admin": "Show admin URL",
     "admin_back": "Press to go back",
     "settings_standby": "Standby now",

--- a/firmware/bodn/lang/sv.py
+++ b/firmware/bodn/lang/sv.py
@@ -32,6 +32,7 @@ STRINGS = {
     "settings_diag": "Diagnostik",
     "settings_sleep": "Vilotimer",
     "settings_encoder": "Känslighet",
+    "settings_tz": "Tidszon",
     "settings_admin": "Visa admin-URL",
     "admin_back": "Tryck för att gå tillbaka",
     "settings_standby": "Viloläge nu",

--- a/firmware/bodn/storage.py
+++ b/firmware/bodn/storage.py
@@ -29,6 +29,7 @@ DEFAULT_SETTINGS = {
     "debug_input": False,
     "language": "sv",
     "sleep_timeout_s": 300,
+    "tz_offset": 1,
 }
 
 # Keep 7 days of session history

--- a/firmware/bodn/ui/settings.py
+++ b/firmware/bodn/ui/settings.py
@@ -14,6 +14,7 @@ _ITEMS = [
     ("sessions_enabled", "settings_sessions", "bool"),
     ("sleep_timeout_s", "settings_sleep", "cycle"),
     ("encoder_sensitivity", "settings_encoder", "cycle"),
+    ("tz_offset", "settings_tz", "cycle"),
     ("audio_enabled", "settings_audio", "bool"),
     ("volume", "settings_volume", "cycle"),
     ("wifi", "settings_wifi", "bool"),
@@ -29,6 +30,7 @@ _ITEMS = [
 
 _SLEEP_OPTIONS = [0, 60, 120, 300, 600]
 _VOLUME_OPTIONS = [10, 25, 50, 75, 100]
+_TZ_OPTIONS = list(range(-12, 15))  # UTC-12 .. UTC+14
 
 
 class SettingsScreen(Screen):
@@ -75,6 +77,9 @@ class SettingsScreen(Screen):
             return t("sens_" + config.ENCODER_SENS_LABELS[idx])
         if key == "volume":
             return "{}%".format(self._settings.get("volume", 30))
+        if key == "tz_offset":
+            off = self._settings.get("tz_offset", 1)
+            return "UTC{:+d}".format(off)
         if key in ("debug_input", "debug_perf", "sessions_enabled", "audio_enabled"):
             return self._settings.get(key, key in ("sessions_enabled", "audio_enabled"))
         return False
@@ -142,6 +147,22 @@ class SettingsScreen(Screen):
                     idx = i
                     break
             self._settings["volume"] = _VOLUME_OPTIONS[(idx + 1) % len(_VOLUME_OPTIONS)]
+            try:
+                from bodn.storage import save_settings
+
+                save_settings(self._settings)
+            except Exception:
+                pass
+            self._dirty = True
+            return
+        if key == "tz_offset":
+            cur = self._settings.get("tz_offset", 1)
+            idx = 13  # default index for UTC+1
+            for i in range(len(_TZ_OPTIONS)):
+                if _TZ_OPTIONS[i] == cur:
+                    idx = i
+                    break
+            self._settings["tz_offset"] = _TZ_OPTIONS[(idx + 1) % len(_TZ_OPTIONS)]
             try:
                 from bodn.storage import save_settings
 

--- a/firmware/bodn/web_ui.py
+++ b/firmware/bodn/web_ui.py
@@ -139,6 +139,7 @@ th{color:#aaa}
 <div class="field"><label>Quiet start (HH:MM, empty=off)</label><input class="input-field" type="text" id="quiet_start" placeholder="21:00"></div>
 <div class="field"><label>Quiet end (HH:MM)</label><input class="input-field" type="text" id="quiet_end" placeholder="07:00"></div>
 <div class="field"><label>Device language</label><select id="language" class="input-field"><option value="sv">Svenska</option><option value="en">English</option></select></div>
+<div class="field"><label>Timezone (UTC offset, DST added automatically)</label><select id="tz_offset" class="input-field"></select></div>
 <h3 style="margin-top:16px;color:#e94560;font-size:0.95em">Audio</h3>
 <div class="field"><label>Sound enabled</label><select id="audio_enabled" class="input-field"><option value="true">On</option><option value="false">Off</option></select></div>
 <div class="field"><label>Volume <span class="rv" id="rv-vol">30%</span></label><input type="range" id="volume" min="0" max="100" step="5" value="30" oninput="updRv(this,'rv-vol','%')"></div>
@@ -259,12 +260,16 @@ sa.style.background=sev?'#e94560':'#f39c12';sa.style.color=sev?'#fff':'#000';}
 async function loadSettings(){
 try{
 var r=await fetch('/api/settings');var d=await r.json();
+// Build timezone select options
+var tzEl=document.getElementById('tz_offset');
+if(tzEl&&!tzEl.options.length){for(var o=-12;o<=14;o++){var op=document.createElement('option');op.value=o;op.textContent='UTC'+(o>=0?'+':'')+o;tzEl.appendChild(op);}}
 ['max_session_min','max_sessions_day','break_min','volume'].forEach(function(k){
 var el=document.getElementById(k);if(el&&d[k]!=null)el.value=d[k];
 });
 ['quiet_start','quiet_end','wifi_ssid','wifi_pass','wifi_mode','ui_pin','ota_token','language','hostname'].forEach(function(k){
 var el=document.getElementById(k);if(el&&d[k]!=null)el.value=d[k]||'';
 });
+if(tzEl&&d.tz_offset!=null)tzEl.value=d.tz_offset;
 var se=document.getElementById('sessions-enabled');if(se)se.checked=d.sessions_enabled!==false;
 var ae=document.getElementById('audio_enabled');if(ae)ae.value=d.audio_enabled===false?'false':'true';
 updRv(document.getElementById('max_session_min'),'rv-sess',' min');
@@ -309,6 +314,7 @@ var v=document.getElementById(k).value.trim();
 body[k]=v||null;
 });
 var langEl=document.getElementById('language');if(langEl)body.language=langEl.value;
+var tzEl2=document.getElementById('tz_offset');if(tzEl2)body.tz_offset=parseInt(tzEl2.value);
 var aeEl=document.getElementById('audio_enabled');if(aeEl)body.audio_enabled=aeEl.value==='true';
 var volEl=document.getElementById('volume');if(volEl)body.volume=parseInt(volEl.value);
 // Collect hidden modes

--- a/firmware/boot.py
+++ b/firmware/boot.py
@@ -313,10 +313,50 @@ time.sleep(0.5)
 # --- Step 2: NTP sync ---
 _show_progress(2, STEPS[2][1], STEPS[2][2])
 
+
+def _last_sunday_of(year, month):
+    """Return day-of-month of last Sunday in the given month."""
+    import time
+
+    days_in_month = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    if month == 2 and (year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)):
+        days_in_month[2] = 29
+    last = days_in_month[month]
+    t = time.mktime((year, month, last, 0, 0, 0, 0, 0))
+    wd = time.localtime(t)[6]  # 0=Mon..6=Sun
+    return last - (wd + 1) % 7
+
+
+def _is_eu_dst(year, month, day, hour):
+    """Return True if EU summer time (DST) is active for the given UTC time."""
+    if month < 3 or month > 10:
+        return False
+    if 3 < month < 10:
+        return True
+    ds = _last_sunday_of(year, 3)
+    de = _last_sunday_of(year, 10)
+    if month == 3:
+        return day > ds or (day == ds and hour >= 1)
+    # month == 10: DST ends at 01:00 UTC on last Sunday
+    return not (day > de or (day == de and hour >= 1))
+
+
 try:
     import ntptime
+    import machine
 
     ntptime.settime()
+    # Adjust RTC from UTC to local time (EU DST rules)
+    import time as _t
+
+    _utc = _t.localtime()
+    _base = settings.get("tz_offset", 1)
+    _dst = _is_eu_dst(_utc[0], _utc[1], _utc[2], _utc[3])
+    _off = (_base + (1 if _dst else 0)) * 3600
+    _local = _t.localtime(_t.mktime(_utc) + _off)
+    machine.RTC().datetime(
+        (_local[0], _local[1], _local[2], _local[6], _local[3], _local[4], _local[5], 0)
+    )
     _results[2] = "ok"
 except Exception:
     _results[2] = "warn"


### PR DESCRIPTION
## Summary

- After NTP sync, computes EU DST (last Sunday of March/October at 01:00 UTC) and sets the RTC to local time — no more manual DST adjustment
- Adds `tz_offset` setting (UTC hour offset, default 1 for CET/Sweden) to on-device settings screen and parental web UI
- DST is applied automatically on top of the base offset; changing timezone persists to flash

## Test plan

- [ ] Boot with WiFi connected — verify clock shows correct local time (including current DST state)
- [ ] Change `tz_offset` on device settings screen (cycle through values, confirm it saves)
- [ ] Change timezone in web UI Limits tab → Save → verify it persists after reboot
- [ ] Test DST boundary: set clock to March last Sunday 00:59 UTC, confirm UTC+1; at 01:00 UTC, confirm UTC+2

🤖 Generated with [Claude Code](https://claude.com/claude-code)