### PR TITLE
feat: persist boot log to flash and expose via web UI

### DIFF
--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -468,6 +468,14 @@ async def _handle_request(reader, writer, session_mgr, settings):
             settings["debug_input"] = not cur
             await _send_json(writer, {"debug_input": settings["debug_input"]})
 
+        elif method == "GET" and path == "/api/boot-log":
+            try:
+                with open("/data/boot_log.json") as f:
+                    raw = f.read()
+                await _send(writer, 200, "application/json", raw)
+            except OSError:
+                await _send_json(writer, {"error": "no boot log yet"})
+
         elif method == "GET" and path == "/api/files":
             # List files for dev UI
             file_list = []

--- a/firmware/bodn/web_ui.py
+++ b/firmware/bodn/web_ui.py
@@ -185,6 +185,8 @@ th{color:#aaa}
 <div id="debug" class="panel">
 <div class="toggle"><input type="checkbox" id="dbg-serial" onchange="toggleDebug()"><label>Log inputs to serial (~2x/sec)</label></div>
 <p style="font-size:0.75em;color:#666;margin-top:8px">Prints button, switch, and encoder state to the serial console.</p>
+<h3 style="margin:16px 0 6px;color:#e94560;font-size:0.9em">Last boot</h3>
+<div id="boot-log"><p style="font-size:0.8em;color:#666">Open this tab to load.</p></div>
 </div>
 
 <div id="wifi" class="panel">
@@ -204,6 +206,7 @@ document.getElementById(id).classList.add('active');
 el.classList.add('active');
 if(id==='history')loadHistory();
 if(id==='stats')loadStats();
+if(id==='debug')loadBootLog();
 }
 function updRv(el,id,suf){document.getElementById(id).textContent=el.value+suf}
 function badgeClass(s){
@@ -432,6 +435,28 @@ try{
 var r=await fetch('/api/settings');var d=await r.json();
 document.getElementById('dbg-serial').checked=!!d.debug_input;
 }catch(e){}
+}
+async function loadBootLog(){
+var el=document.getElementById('boot-log');
+try{
+var r=await fetch('/api/boot-log');var d=await r.json();
+if(d.error){el.innerHTML='<p style="font-size:0.8em;color:#666">'+d.error+'</p>';return;}
+var col={'ok':'#27ae60','warn':'#f39c12','fail':'#e94560','skip':'#555'};
+var html='<div style="display:flex;gap:6px;flex-wrap:wrap;margin:8px 0">';
+(d.steps||[]).forEach(function(s){
+var c=col[s.result]||'#555';
+html+='<span style="padding:3px 8px;border-radius:10px;font-size:0.78em;font-weight:bold;background:'+c+'33;color:'+c+';border:1px solid '+c+'">'+s.key+' '+s.result+'</span>';
+});
+html+='</div><table style="width:100%;border-collapse:collapse;font-size:0.8em;margin-top:4px"><tbody>';
+if(d.ts){var dt=new Date(d.ts*1000);html+='<tr><td style="color:#aaa;padding:3px 6px;width:80px">Time</td><td style="padding:3px 6px">'+dt.toLocaleString()+'</td></tr>';}
+if(d.ip)html+='<tr><td style="color:#aaa;padding:3px 6px">IP</td><td style="padding:3px 6px">'+d.ip+'</td></tr>';
+if(d.bat)html+='<tr><td style="color:#aaa;padding:3px 6px">Battery</td><td style="padding:3px 6px">'+d.bat+'</td></tr>';
+if(d.free_kb!=null)html+='<tr><td style="color:#aaa;padding:3px 6px">Free RAM</td><td style="padding:3px 6px">'+d.free_kb+' KB</td></tr>';
+if(d.i2c&&d.i2c.length)html+='<tr><td style="color:#aaa;padding:3px 6px">I2C</td><td style="padding:3px 6px">'+d.i2c.join(', ')+'</td></tr>';
+if(d.hw){var hws=[];for(var k in d.hw){hws.push('<span style="color:'+(d.hw[k]?'#27ae60':'#e94560')+'">'+k+':'+(d.hw[k]?'\u2713':'\u2717')+'</span>')}html+='<tr><td style="color:#aaa;padding:3px 6px">Hardware</td><td style="padding:3px 6px">'+hws.join('&nbsp;&nbsp;')+'</td></tr>';}
+html+='</tbody></table>';
+el.innerHTML=html;
+}catch(e){el.innerHTML='<p style="font-size:0.8em;color:#e94560">Failed to load boot log.</p>';}
 }
 var hnEl=document.getElementById('hostname');
 if(hnEl)hnEl.addEventListener('input',function(){document.getElementById('hostname-preview').textContent=this.value.trim()||'bodn'});

--- a/firmware/boot.py
+++ b/firmware/boot.py
@@ -543,3 +543,23 @@ spi = None
 np = None
 gc.collect()
 print("BOOT done, free={}".format(gc.mem_free()))
+
+# --- Persist boot log for web UI inspection ---
+try:
+    import json as _json
+
+    _boot_log = {
+        "ts": time.time(),
+        "steps": [
+            {"key": STEPS[i][0], "result": _results[i] or "skip"}
+            for i in range(len(STEPS))
+        ],
+        "ip": ip,
+        "bat": _bat_detail,
+        "free_kb": gc.mem_free() // 1024,
+    }
+    with open("/data/boot_log.json", "w") as _f:
+        _json.dump(_boot_log, _f)
+    del _json, _boot_log
+except Exception as _e:
+    print("boot log:", _e)

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -97,6 +97,7 @@ def create_hardware():
     # I2C bus scan — show all devices for diagnostics
     i2c_devs = i2c.scan()
     print("I2C scan: [{}]".format(", ".join("0x{:02X}".format(a) for a in i2c_devs)))
+    hw_status["i2c"] = ["0x{:02X}".format(a) for a in i2c_devs]
 
     # MCP1 — MCP23017 GPIO expander for buttons, toggles, and arcade switches
     mcp = None
@@ -825,6 +826,24 @@ async def main():
     from bodn.diag import set_hw_status
 
     set_hw_status(hw_status)
+
+    # Update boot log with hardware initialisation results
+    try:
+        import json as _json
+
+        try:
+            with open("/data/boot_log.json") as _f:
+                _boot_log = _json.load(_f)
+        except Exception:
+            _boot_log = {}
+        _boot_log["i2c"] = hw_status.get("i2c", [])
+        _boot_log["hw"] = {k: v for k, v in hw_status.items() if k != "i2c"}
+        with open("/data/boot_log.json", "w") as _f:
+            _json.dump(_boot_log, _f)
+        del _boot_log, _json
+    except Exception as _e:
+        print("boot log hw update:", _e)
+
     manager, secondary, inp = create_ui(
         session_mgr,
         settings,


### PR DESCRIPTION
Captures boot step results, IP, battery voltage, and free RAM in
/data/boot_log.json at the end of boot.py. main.py appends the I2C
bus scan and hardware init status (mcp, pca, temp, audio) once
create_hardware() completes.

A new GET /api/boot-log endpoint (PIN-protected) serves the JSON file
directly. The Debug tab gains a "Last boot" section that renders the
data as coloured step badges and a compact info table, loaded on first
tab open.

https://claude.ai/code/session_016e1uRSW53TRe7zeKD9zAJf