### PR TITLE
feat: metronome, overlay fix, settings perf, FTP & boot reliability

### DIFF
--- a/firmware/bodn/ftp.py
+++ b/firmware/bodn/ftp.py
@@ -20,8 +20,10 @@ except ImportError:
     network = None
 
 OTA_STAGE = "/.ota"
-_DATA_PORT = 50100
+_DATA_PORT_BASE = 50100
+_DATA_PORT_RANGE = 10  # rotate through 50100–50109 to avoid TIME_WAIT
 _server = None
+_data_port_idx = 0
 
 
 def _get_ip():
@@ -94,6 +96,7 @@ class _FTPSession:
     # ------------------------------------------------------------------ PASV
 
     async def _cmd_PASV(self, _):
+        global _data_port_idx
         # Close any previous data server that was never used
         if self._data_srv is not None:
             try:
@@ -111,10 +114,13 @@ class _FTPSession:
             self._data_w = w
             self._data_ready.set()
 
-        self._data_srv = await asyncio.start_server(_on_data, "0.0.0.0", _DATA_PORT)
+        # Rotate through a small port range to avoid TIME_WAIT collisions
+        port = _DATA_PORT_BASE + _data_port_idx
+        _data_port_idx = (_data_port_idx + 1) % _DATA_PORT_RANGE
+        self._data_srv = await asyncio.start_server(_on_data, "0.0.0.0", port)
         ip = _get_ip()
         h = ip.replace(".", ",")
-        ph, pl = _DATA_PORT >> 8, _DATA_PORT & 0xFF
+        ph, pl = port >> 8, port & 0xFF
         await self._send("227 Entering Passive Mode ({},{},{})\r\n".format(h, ph, pl))
 
     async def _get_data(self):
@@ -335,12 +341,15 @@ class _FTPSession:
         try:
             with open(tmp, "wb") as f:
                 while True:
-                    chunk = await dr.read(512)
+                    chunk = await dr.read(1024)
                     if not chunk:
                         break
                     f.write(chunk)
+                    # Yield to the async loop so TCP can breathe during
+                    # long flash writes — without this, large files stall.
+                    await asyncio.sleep_ms(0)
             try:
-                dr.close()
+                dw.close()  # close writer to release the socket (reader.close won't)
             except Exception:
                 pass
             try:
@@ -350,6 +359,10 @@ class _FTPSession:
             os.rename(tmp, real)
             await self._send("226 Transfer complete\r\n")
         except Exception as e:
+            try:
+                dw.close()
+            except Exception:
+                pass
             try:
                 os.remove(tmp)
             except OSError:

--- a/firmware/bodn/lang/en.py
+++ b/firmware/bodn/lang/en.py
@@ -221,6 +221,8 @@ STRINGS = {
     "seq_steps": "{} steps",
     "seq_press_start": "Press!",
     "seq_cleared": "Cleared!",
+    "seq_metronome_on": "Metro ON",
+    "seq_metronome_off": "Metro OFF",
     # Boot screen
     "boot_cfg": "Waking up...",
     "boot_sd": "Checking SD card...",

--- a/firmware/bodn/lang/sv.py
+++ b/firmware/bodn/lang/sv.py
@@ -221,6 +221,8 @@ STRINGS = {
     "seq_steps": "{} steg",
     "seq_press_start": "Tryck!",
     "seq_cleared": "Rensat!",
+    "seq_metronome_on": "Metro PÅ",
+    "seq_metronome_off": "Metro AV",
     # Boot screen
     "boot_cfg": "Vaknar...",
     "boot_sd": "Kollar SD-kort...",

--- a/firmware/bodn/sequencer_rules.py
+++ b/firmware/bodn/sequencer_rules.py
@@ -49,6 +49,7 @@ class SequencerEngine:
         self._frac = 0.0
         self.step_advanced = False
         self.dirty_steps = set()
+        self.metronome = False
         self._recompute_timing()
 
     # ------------------------------------------------------------------
@@ -168,6 +169,19 @@ class SequencerEngine:
         self.step = self.step % n
         self._ms_accum = 0
         self._recompute_timing()
+
+    def toggle_metronome(self):
+        """Toggle metronome on/off. Returns new state."""
+        self.metronome = not self.metronome
+        return self.metronome
+
+    def is_downbeat(self, step):
+        """Return True if step is a downbeat (beat 1 of a bar = step 0 or 8)."""
+        return step % 8 == 0
+
+    def is_beat(self, step):
+        """Return True if step falls on a quarter-note beat (every 2 steps)."""
+        return step % 2 == 0
 
     def clear_all(self):
         """Zero all grid data and reset the playhead."""

--- a/firmware/bodn/ui/screen.py
+++ b/firmware/bodn/ui/screen.py
@@ -67,6 +67,7 @@ class ScreenManager:
         self._dirty = True  # full clear needed on first frame / transitions
         self._show_needed = False  # framebuffer changed, just push SPI (no re-render)
         self._dirty_rect = None  # (x, y, w, h) bounding box for partial push
+        self._prev_takes_over = False  # track overlay takeover transitions
         self._frames_skipped = 0  # consecutive render skips (for diagnostics)
         # Perf counters (enabled via debug_perf setting)
         self.debug_perf = False
@@ -203,6 +204,16 @@ class ScreenManager:
         """
         active = self.active
 
+        # Detect overlay takeover transitions: when the overlay stops taking
+        # over, the framebuffer still has stale overlay content. Force a full
+        # clear so the active screen repaints from scratch.
+        takes_over = self._overlay and getattr(self._overlay, "takes_over", False)
+        if self._prev_takes_over and not takes_over:
+            self._dirty = True
+            if active and hasattr(active, "_dirty"):
+                active._dirty = True
+        self._prev_takes_over = takes_over
+
         # Check if anything needs drawing
         screen_dirty = self._dirty
         if not screen_dirty and active:
@@ -280,6 +291,14 @@ class ScreenManager:
 
         if self._overlay:
             self._overlay.update(self.inp, self._frame)
+
+        # Detect overlay takeover transitions (see render_and_show)
+        takes_over = self._overlay and getattr(self._overlay, "takes_over", False)
+        if self._prev_takes_over and not takes_over:
+            self._dirty = True
+            if active and hasattr(active, "_dirty"):
+                active._dirty = True
+        self._prev_takes_over = takes_over
 
         # Check if anything needs drawing
         screen_dirty = self._dirty

--- a/firmware/bodn/ui/sequencer.py
+++ b/firmware/bodn/ui/sequencer.py
@@ -2,7 +2,7 @@
 #
 # Live-jam step sequencer: press arcade buttons (percussion) or mini buttons
 # (melody) while the loop plays. Presses quantize to the nearest step.
-# sw[0] toggles play/pause, sw[1] toggles 8/16 steps.
+# sw[0] toggles play/pause, sw[1] toggles 8/16 steps, sw[2] toggles metronome.
 
 try:
     import time
@@ -37,6 +37,11 @@ ENC_A = const(1)  # config.ENC_A — BPM control
 
 # Preview voice for button feedback — separate from clock voices (0-5)
 _PREVIEW_VOICE = const(6)
+# Dedicated voice for metronome clicks — won't steal from preview or clock
+_METRO_VOICE = const(7)
+# Metronome click frequencies (Hz)
+_METRO_HI = const(1200)  # downbeat accent
+_METRO_LO = const(800)  # other beats
 
 # Drum sample names on SD — index matches arcade button hardware index
 _DRUM_NAMES = ["hihat", "snare", "kick", "tom", "crash"]
@@ -86,6 +91,7 @@ class SequencerScreen(Screen):
         self._prev_step = -1
         self._prev_sw0 = None
         self._prev_sw1 = None
+        self._prev_sw2 = None
         self._last_ms = 0
         self._dirty = True
         self._full_clear = True
@@ -121,6 +127,10 @@ class SequencerScreen(Screen):
         sw = manager.inp.sw
         self._prev_sw0 = sw[0] if len(sw) > 0 else False
         self._prev_sw1 = sw[1] if len(sw) > 1 else False
+        self._prev_sw2 = sw[2] if len(sw) > 2 else False
+        # Initialise metronome from outer toggle position
+        if len(sw) > 2 and sw[2]:
+            self._engine.metronome = True
 
         # Preload drum samples into PSRAM (skip if already loaded by factory)
         if self._drum_bufs is None:
@@ -229,6 +239,13 @@ class SequencerScreen(Screen):
             self._full_clear = True
         self._prev_sw1 = sw1
 
+        # sw[2] → metronome on/off (outer left toggle)
+        sw2 = sw[2] if len(sw) > 2 else False
+        if self._prev_sw2 is not None and sw2 != self._prev_sw2:
+            eng.toggle_metronome()
+            self._dirty = True
+        self._prev_sw2 = sw2
+
         # --- Encoder A: BPM ---
         enc_delta = inp.enc_delta[ENC_A]
         if enc_delta:
@@ -292,13 +309,20 @@ class SequencerScreen(Screen):
             if eng.step_advanced:
                 self._trigger_step_sounds(eng.step)
 
+        # --- Metronome click on beat ---
+        if eng.metronome and eng.state == PLAYING and eng.step_advanced:
+            if eng.is_beat(eng.step):
+                self._play_metronome(eng.is_downbeat(eng.step))
+
         # --- Playhead movement (marker-only redraw) ---
         if eng.step != self._prev_step:
             self._marker_dirty = True
 
         # --- Update secondary display ---
         if self._secondary:
-            self._secondary.update_state(eng.bpm, eng.state == PLAYING, eng.n_steps)
+            self._secondary.update_state(
+                eng.bpm, eng.state == PLAYING, eng.n_steps, eng.metronome
+            )
 
         # Arcade LEDs: flash on step hit, glow if track has notes, off otherwise
         arc = self._arcade
@@ -367,6 +391,13 @@ class SequencerScreen(Screen):
         if _has_clock:
             _audiomix.clock_preview(5)  # suppress clock trigger for melody
         self._audio.tone(freq, 150, "sine", voice=_PREVIEW_VOICE)
+
+    def _play_metronome(self, downbeat):
+        """Play a short metronome click. Accented on downbeats."""
+        if not self._audio:
+            return
+        freq = _METRO_HI if downbeat else _METRO_LO
+        self._audio.tone(freq, 30, "square", voice=_METRO_VOICE)
 
     def _trigger_step_sounds(self, step):
         """Trigger all active sounds at a grid step (called on step tick)."""

--- a/firmware/bodn/ui/sequencer_secondary.py
+++ b/firmware/bodn/ui/sequencer_secondary.py
@@ -15,17 +15,24 @@ class SequencerSecondary(Screen):
         self._bpm = 90
         self._playing = False
         self._n_steps = 8
+        self._metronome = False
         self._dirty = True
 
     def enter(self, display):
         self._dirty = True
 
-    def update_state(self, bpm, playing, n_steps):
+    def update_state(self, bpm, playing, n_steps, metronome=False):
         """Called by SequencerScreen each frame when values change."""
-        if bpm != self._bpm or playing != self._playing or n_steps != self._n_steps:
+        if (
+            bpm != self._bpm
+            or playing != self._playing
+            or n_steps != self._n_steps
+            or metronome != self._metronome
+        ):
             self._bpm = bpm
             self._playing = playing
             self._n_steps = n_steps
+            self._metronome = metronome
             self._dirty = True
 
     def needs_redraw(self):
@@ -49,5 +56,11 @@ class SequencerSecondary(Screen):
             label = t("seq_paused")
         draw_centered(tft, label, 68, color, w, scale=2)
 
+        # Metronome indicator
+        if self._metronome:
+            draw_centered(tft, t("seq_metronome_on"), 88, theme.WHITE, w)
+        else:
+            draw_centered(tft, t("seq_metronome_off"), 88, theme.DIM, w)
+
         # Step count
-        draw_centered(tft, t("seq_steps", self._n_steps), 96, theme.MUTED, w)
+        draw_centered(tft, t("seq_steps", self._n_steps), 108, theme.MUTED, w)

--- a/firmware/bodn/ui/settings.py
+++ b/firmware/bodn/ui/settings.py
@@ -3,7 +3,7 @@
 from micropython import const
 from bodn import config
 from bodn.ui.screen import Screen
-from bodn.ui.widgets import draw_centered
+from bodn.ui.widgets import draw_centered, draw_label, make_label_sprite, blit_sprite
 from bodn.i18n import t, get_language, set_language, available
 
 NAV = const(0)  # config.ENC_NAV
@@ -53,6 +53,17 @@ class SettingsScreen(Screen):
     def enter(self, manager):
         self._manager = manager
         self._dirty = True
+        self._full_clear = True
+        self._prev_index = -1
+        self._prev_scroll = -1
+
+        # Pre-render sprites for scaled / extended-char text
+        theme = manager.theme
+        self._title_sprite = make_label_sprite(
+            t("settings_title"), theme.WHITE, scale=2
+        )
+        self._on_sprite = make_label_sprite(t("on"), theme.BLACK)
+        self._off_sprite = make_label_sprite(t("off"), theme.BLACK)
 
     def needs_redraw(self):
         return self._dirty
@@ -238,60 +249,84 @@ class SettingsScreen(Screen):
 
     def render(self, tft, theme, frame):
         self._dirty = False
-        tft.fill(theme.BLACK)
 
         w = theme.width
         h = theme.height
         landscape = w > h
-
-        # Title
         title_h = 28 if landscape else 24
-        draw_centered(tft, t("settings_title"), 8, theme.WHITE, w, scale=2)
-
-        # Menu items — scroll to keep selection centered
         row_h = 24 if landscape else 20
-        menu_h = h - title_h - 4  # available height for menu items
-        visible = menu_h // row_h  # how many items fit on screen
+        menu_h = h - title_h - 4
+        visible = menu_h // row_h
 
-        # Calculate scroll offset to center the selected item
         n = len(_ITEMS)
         half = visible // 2
         scroll = self._index - half
         scroll = max(0, min(scroll, n - visible))
 
-        for i in range(scroll, min(scroll + visible, n)):
-            key, label_key, item_type = _ITEMS[i]
-            y = title_h + (i - scroll) * row_h
-            selected = i == self._index
+        scroll_changed = scroll != self._prev_scroll
 
-            # Highlight bar for selected item
-            if selected:
-                tft.fill_rect(4, y - 2, w - 8, row_h - 2, theme.DIM)
-
-            # Label
-            color = theme.WHITE if selected else theme.MUTED
-            if item_type == "lang":
-                label = t(label_key, get_language().upper())
+        if self._full_clear or scroll_changed:
+            self._full_clear = False
+            tft.fill(theme.BLACK)
+            # Title (cached sprite, blitted once)
+            _, tw, _ = self._title_sprite
+            blit_sprite(tft, self._title_sprite, (w - tw) // 2, 8)
+            # Draw all visible rows
+            for i in range(scroll, min(scroll + visible, n)):
+                self._render_row(tft, theme, i, scroll, title_h, row_h, w)
+        else:
+            # Only redraw the old and new selected rows
+            old_idx = self._prev_index
+            new_idx = self._index
+            if old_idx != new_idx:
+                if scroll <= old_idx < scroll + visible:
+                    self._render_row(tft, theme, old_idx, scroll, title_h, row_h, w)
+                if scroll <= new_idx < scroll + visible:
+                    self._render_row(tft, theme, new_idx, scroll, title_h, row_h, w)
             else:
-                label = t(label_key)
-            tft.text(label, 12, y + 2, color)
+                # Value toggled on the same row
+                self._render_row(tft, theme, new_idx, scroll, title_h, row_h, w)
 
-            # Value indicator
-            if item_type == "bool":
-                value = self._get_value(key)
-                if value:
-                    tft.fill_rect(w - 40, y, 28, row_h - 6, theme.GREEN)
-                    tft.text(t("on"), w - 36, y + 2, theme.BLACK)
-                else:
-                    tft.fill_rect(w - 40, y, 28, row_h - 6, theme.RED)
-                    tft.text(t("off"), w - 38, y + 2, theme.BLACK)
-            elif item_type == "cycle":
-                val_str = str(self._get_value(key))
-                tx = w - 8 - len(val_str) * 8
-                tft.text(val_str, tx, y + 2, theme.WHITE if selected else theme.MUTED)
+        self._prev_index = self._index
+        self._prev_scroll = scroll
 
         # Scroll indicators
         if scroll > 0:
             draw_centered(tft, "^", title_h - 10, theme.MUTED, w)
         if scroll + visible < n:
             draw_centered(tft, "v", h - 12, theme.MUTED, w)
+
+    def _render_row(self, tft, theme, i, scroll, title_h, row_h, w):
+        """Draw a single menu row, clearing its background first."""
+        key, label_key, item_type = _ITEMS[i]
+        y = title_h + (i - scroll) * row_h
+        selected = i == self._index
+
+        # Clear row background
+        tft.fill_rect(0, y - 2, w, row_h, theme.BLACK)
+
+        # Highlight bar for selected item
+        if selected:
+            tft.fill_rect(4, y - 2, w - 8, row_h - 2, theme.DIM)
+
+        # Label
+        color = theme.WHITE if selected else theme.MUTED
+        if item_type == "lang":
+            label = t(label_key, get_language().upper())
+        else:
+            label = t(label_key)
+        draw_label(tft, label, 12, y + 2, color)
+
+        # Value indicator
+        if item_type == "bool":
+            value = self._get_value(key)
+            if value:
+                tft.fill_rect(w - 40, y, 28, row_h - 6, theme.GREEN)
+                blit_sprite(tft, self._on_sprite, w - 36, y + 2)
+            else:
+                tft.fill_rect(w - 40, y, 28, row_h - 6, theme.RED)
+                blit_sprite(tft, self._off_sprite, w - 38, y + 2)
+        elif item_type == "cycle":
+            val_str = str(self._get_value(key))
+            tx = w - 8 - len(val_str) * 8
+            tft.text(val_str, tx, y + 2, theme.WHITE if selected else theme.MUTED)

--- a/firmware/boot.py
+++ b/firmware/boot.py
@@ -39,9 +39,21 @@ try:
 except OSError:
     pass
 
+import sys as _sys
+
+
+def _abort_boot():
+    """Ctrl-C during boot — exit immediately so REPL is available for mpremote."""
+    print("boot.py: interrupted — dropping to REPL")
+    _sys.exit()
+
+
 if not _fast_boot:
     print("boot.py: 5s safe-boot window (Ctrl-C to abort)...")
-    time.sleep(5)
+    try:
+        time.sleep(5)
+    except KeyboardInterrupt:
+        _abort_boot()
 
 settings = None
 ip = "0.0.0.0"
@@ -71,7 +83,7 @@ try:
         _mcp2_boot = None
         _i2c_boot = None
     except KeyboardInterrupt:
-        raise
+        _abort_boot()
     except Exception:
         _diag_requested = False
 
@@ -105,7 +117,7 @@ try:
             madctl=config.TFT_MADCTL,
         )
     except KeyboardInterrupt:
-        raise
+        _abort_boot()
     except Exception:
         spi = SPI(
             1,
@@ -130,7 +142,7 @@ try:
         timing=1,
     )
 except KeyboardInterrupt:
-    raise
+    _abort_boot()
 except Exception as e:
     print("Boot display init error:", e)
 
@@ -185,6 +197,8 @@ def _translate(key):
         from bodn.i18n import t
 
         return t(key)
+    except KeyboardInterrupt:
+        _abort_boot()
     except Exception:
         return key
 
@@ -374,8 +388,12 @@ try:
         from bodn.i18n import init as _i18n_init
 
         _i18n_init(settings.get("language", "sv"))
+    except KeyboardInterrupt:
+        _abort_boot()
     except Exception:
         pass
+except KeyboardInterrupt:
+    _abort_boot()
 except Exception as e:
     print("Settings load failed:", e)
     _results[0] = "fail"
@@ -409,6 +427,8 @@ try:
         _results[1] = "ok"
     else:
         _results[1] = "skip"
+except KeyboardInterrupt:
+    _abort_boot()
 except Exception as e:
     print("SD card mount skipped:", e)
     _results[1] = "skip"
@@ -430,6 +450,8 @@ if _results[1] == "ok" and _draw_mod is not None:
         _logo_sprite, _logo_data, _logo_sprite_w, _logo_sprite_h = _load_sprite(
             "/sd/sprites/lo-logo.bdf"
         )
+    except KeyboardInterrupt:
+        _abort_boot()
     except Exception as _e:
         print("BOOT logo:", _e)
 
@@ -438,6 +460,8 @@ if _results[1] == "ok" and _draw_mod is not None:
         _logo_sm_sprite, _logo_sm_data, _logo_sm_w, _logo_sm_h = _load_sprite(
             "/sd/sprites/lo-logo-sm.bdf"
         )
+    except KeyboardInterrupt:
+        _abort_boot()
     except Exception as _e:
         print("BOOT logo-sm:", _e)
 
@@ -446,6 +470,8 @@ if _results[1] == "ok" and _draw_mod is not None:
         _logo_s2_sprite, _logo_s2_data, _logo_s2_w, _logo_s2_h = _load_sprite(
             "/sd/sprites/lo-logo-s2.bdf"
         )
+    except KeyboardInterrupt:
+        _abort_boot()
     except Exception as _e:
         print("BOOT logo-s2:", _e)
 
@@ -462,6 +488,8 @@ else:
 
         ip = connect(settings)
         _results[2] = "ok"
+    except KeyboardInterrupt:
+        _abort_boot()
     except Exception as e:
         print("WiFi failed:", e)
         _results[2] = "fail"
@@ -531,6 +559,8 @@ else:
             )
         )
         _results[3] = "ok"
+    except KeyboardInterrupt:
+        _abort_boot()
     except Exception:
         _results[3] = "warn"
         settings["quiet_start"] = None
@@ -566,6 +596,8 @@ try:
         _results[4] = "ok"
         _bat_detail = "USB"
         _bat_col = COL_GREEN
+except KeyboardInterrupt:
+    _abort_boot()
 except Exception as e:
     print("Battery check failed:", e)
     _results[4] = "skip"
@@ -589,8 +621,19 @@ if _logo_sprite is not None and tft:
     tft.fill(COL_BLACK)
     _lx = (tft.width - _logo_sprite_w) // 2
     _ly = (tft.height - _logo_sprite_h) // 2
+    # White backing rect so the logo's dark parts are visible on black
+    _pad = 6
+    tft.fill_rect(
+        _lx - _pad,
+        _ly - _pad,
+        _logo_sprite_w + _pad * 2,
+        _logo_sprite_h + _pad * 2,
+        COL_WHITE,
+    )
     _draw_mod.sprite(tft._buf, tft.width, _lx, _ly, _logo_sprite, 0, COL_WHITE)
-    tft.mark_dirty(_lx, _ly, _logo_sprite_w, _logo_sprite_h)
+    tft.mark_dirty(
+        _lx - _pad, _ly - _pad, _logo_sprite_w + _pad * 2, _logo_sprite_h + _pad * 2
+    )
     tft.show()
 
 # Free large logo — splash is done
@@ -650,6 +693,8 @@ if _diag_requested and tft:
             time.sleep_ms(50)
         _mcp2_diag = None
         _i2c_diag = None
+    except KeyboardInterrupt:
+        _abort_boot()
     except Exception:
         # MCP2 unavailable — just show for 5 s then continue
         time.sleep(5)
@@ -665,6 +710,8 @@ _logo_s2_data = None  # noqa: F841 — frees backing buffer
 _draw_mod = None
 try:
     _spidma.deinit()
+except KeyboardInterrupt:
+    _abort_boot()
 except Exception:
     pass
 if spi:
@@ -692,5 +739,7 @@ try:
     with open("/data/boot_log.json", "w") as _f:
         _json.dump(_boot_log, _f)
     del _json, _boot_log
+except KeyboardInterrupt:
+    _abort_boot()
 except Exception as _e:
     print("boot log:", _e)


### PR DESCRIPTION
## Summary
- **Sequencer metronome**: toggle via outer left switch (sw[2]), accented quarter-note clicks on dedicated voice, state on secondary display
- **Session overlay blank screen fix**: ScreenManager detects overlay takeover→release transition and forces full redraw — fixes screen going blank after session timeout
- **Settings screen**: fix "PÅ" rendering (extended glyphs via draw_label), pre-rendered sprites for title/toggles, incremental row redraws instead of full-screen clear
- **FTP socket leak**: STOR closed `dr` (reader) instead of `dw` (writer) — only writer.close() releases the socket in MicroPython, causing exhaustion after ~10 uploads
- **Boot Ctrl-C handling**: guard all `except Exception` with `except KeyboardInterrupt` (MicroPython subclasses it from Exception), call `sys.exit()` to abort boot immediately
- **MicroPython pinned** back to v1.27.0 (was on v1.29.0-preview)
- **Boot splash**: white backing rect behind logo

## Test plan
- [ ] Toggle outer left switch in sequencer — metronome clicks on beats, accented on downbeat
- [ ] Let session timer expire — screen should recover after cooldown ends
- [ ] Settings menu: "PÅ"/"AV" renders correctly, scrolling feels responsive
- [ ] FTP sync: `uv run python tools/ftp-sync.py <ip>` completes all files including large WAVs
- [ ] Boot: Ctrl-C during 5s window drops to REPL immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)