### PR TITLE
feat: clock-driven tone tracks for sample-accurate sequencer

### DIFF
--- a/boards/BODN_S3/sdkconfig.board
+++ b/boards/BODN_S3/sdkconfig.board
@@ -1,3 +1,7 @@
+# 8 MiB flash with OTA support (2×2.4 MiB app slots)
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-8MiBplus-ota.csv"
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
+
 # Dual-core (default for S3, but be explicit)
 CONFIG_FREERTOS_UNICORE=n
 

--- a/cmodules/audiomix/audiomix.c
+++ b/cmodules/audiomix/audiomix.c
@@ -3,6 +3,8 @@
 // Registers the _audiomix module and exposes Python-callable functions
 // that control the core 1 mix task.
 
+#include <string.h>
+
 #include "py/runtime.h"
 #include "py/obj.h"
 
@@ -524,6 +526,68 @@ static mp_obj_t audiomix_clock_set_melody_config(mp_obj_t dur_obj, mp_obj_t wave
 static MP_DEFINE_CONST_FUN_OBJ_2(audiomix_clock_set_melody_config_obj,
                                   audiomix_clock_set_melody_config);
 
+// _audiomix.clock_set_tone_track(track, voice_idx, step_mask)
+static mp_obj_t audiomix_clock_set_tone_track(mp_obj_t track_obj,
+                                               mp_obj_t voice_obj,
+                                               mp_obj_t mask_obj) {
+    if (audiomix_state == NULL) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("not initialised"));
+    }
+    int track = mp_obj_get_int(track_obj);
+    if (track < 0 || track >= SEQ_MAX_TONE_TRACKS) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad tone track"));
+    }
+    seq_tone_track_t *trk = &audiomix_state->clock.tone_tracks[track];
+    trk->voice_idx = mp_obj_get_int(voice_obj);
+    trk->step_mask = mp_obj_get_int(mask_obj) & 0xFFFF;
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_3(audiomix_clock_set_tone_track_obj,
+                                  audiomix_clock_set_tone_track);
+
+// _audiomix.clock_set_tone_step(track, step, freq, duration_ms, wave,
+//                                attack_ms, release_ms, velocity)
+static mp_obj_t audiomix_clock_set_tone_step(size_t n_args, const mp_obj_t *args) {
+    if (audiomix_state == NULL) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("not initialised"));
+    }
+    int track = mp_obj_get_int(args[0]);
+    int step  = mp_obj_get_int(args[1]);
+    if (track < 0 || track >= SEQ_MAX_TONE_TRACKS) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad tone track"));
+    }
+    if (step < 0 || step >= SEQ_MAX_STEPS) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad step"));
+    }
+    seq_tone_step_t *ts = &audiomix_state->clock.tone_tracks[track].steps[step];
+    ts->freq        = mp_obj_get_int(args[2]);
+    ts->duration_ms = mp_obj_get_int(args[3]);
+    ts->wave        = mp_obj_get_int(args[4]);
+    ts->attack_ms   = mp_obj_get_int(args[5]);
+    ts->release_ms  = mp_obj_get_int(args[6]);
+    ts->velocity    = mp_obj_get_int(args[7]);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiomix_clock_set_tone_step_obj, 8, 8,
+                                            audiomix_clock_set_tone_step);
+
+// _audiomix.clock_tone_preview(track)
+// Mark a tone track as just previewed (anti-double for button feedback)
+static mp_obj_t audiomix_clock_tone_preview(mp_obj_t track_obj) {
+    if (audiomix_state == NULL) {
+        return mp_const_none;
+    }
+    int track = mp_obj_get_int(track_obj);
+    if (track < 0 || track >= SEQ_MAX_TONE_TRACKS) {
+        return mp_const_none;
+    }
+    audiomix_state->clock.manual_trigger_sample[SEQ_MAX_PERC_TRACKS + track] =
+        audiomix_state->clock.total_samples;
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(audiomix_clock_tone_preview_obj,
+                                  audiomix_clock_tone_preview);
+
 // _audiomix.clock_clear_grid()
 static mp_obj_t audiomix_clock_clear_grid(void) {
     if (audiomix_state == NULL) {
@@ -533,6 +597,13 @@ static mp_obj_t audiomix_clock_clear_grid(void) {
     for (int i = 0; i < SEQ_MAX_STEPS; i++) {
         clk->steps[i].perc_mask = 0;
         clk->steps[i].melody_freq = 0;
+    }
+    // Clear all tone tracks
+    for (int t = 0; t < SEQ_MAX_TONE_TRACKS; t++) {
+        clk->tone_tracks[t].step_mask = 0;
+        for (int s = 0; s < SEQ_MAX_STEPS; s++) {
+            memset(&clk->tone_tracks[t].steps[s], 0, sizeof(seq_tone_step_t));
+        }
     }
     return mp_const_none;
 }
@@ -645,8 +716,13 @@ static const mp_rom_map_elem_t audiomix_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_clock_set_melody_config), MP_ROM_PTR(&audiomix_clock_set_melody_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_clock_clear_grid),   MP_ROM_PTR(&audiomix_clock_clear_grid_obj) },
     { MP_ROM_QSTR(MP_QSTR_clock_preview),     MP_ROM_PTR(&audiomix_clock_preview_obj) },
+    // Tone tracks
+    { MP_ROM_QSTR(MP_QSTR_clock_set_tone_track), MP_ROM_PTR(&audiomix_clock_set_tone_track_obj) },
+    { MP_ROM_QSTR(MP_QSTR_clock_set_tone_step),  MP_ROM_PTR(&audiomix_clock_set_tone_step_obj) },
+    { MP_ROM_QSTR(MP_QSTR_clock_tone_preview),   MP_ROM_PTR(&audiomix_clock_tone_preview_obj) },
     // Constants
     { MP_ROM_QSTR(MP_QSTR_NUM_VOICES),           MP_ROM_INT(AUDIOMIX_NUM_VOICES) },
+    { MP_ROM_QSTR(MP_QSTR_SEQ_MAX_TONE_TRACKS),  MP_ROM_INT(SEQ_MAX_TONE_TRACKS) },
     // Waveform type constants
     { MP_ROM_QSTR(MP_QSTR_WAVE_SQUARE),          MP_ROM_INT(AUDIOMIX_WAVE_SQUARE) },
     { MP_ROM_QSTR(MP_QSTR_WAVE_SINE),            MP_ROM_INT(AUDIOMIX_WAVE_SINE) },

--- a/cmodules/audiomix/audiomix.h
+++ b/cmodules/audiomix/audiomix.h
@@ -67,7 +67,7 @@ typedef struct {
     volatile uint32_t gain;             // fixed-point 16.16 multiplier
     volatile uint8_t  loop;             // 1 = loop, 0 = one-shot
     volatile uint8_t  stop_req;         // Python sets 1; core 0 clears + stops
-    volatile uint8_t  fade_in;          // apply fade-in on first chunk
+    volatile uint8_t  fade_in;          // apply fade-in on first chunk (WAV/legacy)
     volatile uint8_t  fade_out;         // 1 = fade out this chunk then stop
     volatile uint8_t  writing;          // 1 = Python is writing fields, clock must skip
 
@@ -80,6 +80,13 @@ typedef struct {
     uint32_t tone_samples_left;
     uint32_t tone_phase;
     uint8_t  tone_wave;
+
+    // Envelope state (for clock-driven tone tracks — replaces fade_in for tones)
+    uint32_t env_attack_samples;        // attack ramp length (0 = instant)
+    uint32_t env_release_samples;       // release ramp length
+    uint32_t env_total_samples;         // total note duration (0 = legacy fade path)
+    uint32_t env_pos;                   // current position in envelope
+    uint8_t  env_velocity;              // 0-127 volume scaling
 
     // SRC_SEQUENCE fields
     uint8_t  seq_buf[AUDIOMIX_SEQ_MAX_STEPS * AUDIOMIX_SEQ_STEP_SIZE];
@@ -107,10 +114,8 @@ typedef struct {
 
 // Per-step trigger: what to play when the playhead crosses this step
 typedef struct {
-    // Percussion: which tracks are active (bitmask, bits 0-4)
-    uint8_t perc_mask;
-    // Melody: frequency in Hz (0 = off)
-    uint16_t melody_freq;
+    uint8_t perc_mask;                  // percussion: which tracks fire (bitmask, bits 0-4)
+    uint16_t melody_freq;               // DEPRECATED — use tone tracks; kept for compat
 } seq_step_t;
 
 // Percussion track config: pointer to pre-loaded PCM buffer
@@ -118,6 +123,25 @@ typedef struct {
     const uint8_t *buf_ptr;
     uint32_t buf_len;
 } seq_perc_track_t;
+
+// Per-step tone parameters (synth note definition)
+typedef struct {
+    uint16_t freq;                      // Hz (0 = rest / silent)
+    uint16_t duration_ms;               // note length
+    uint8_t  wave;                      // AUDIOMIX_WAVE_*
+    uint8_t  attack_ms;                 // envelope attack (0 = instant click)
+    uint8_t  release_ms;                // envelope release tail-off
+    uint8_t  velocity;                  // volume 0-127
+} seq_tone_step_t;                      // 8 bytes, naturally aligned
+
+// Tone track: a voice slot + per-step tone data, triggered by the clock
+#define SEQ_MAX_TONE_TRACKS 3           // melody + metronome + spare
+
+typedef struct {
+    uint8_t  voice_idx;                 // which mixer voice this track drives
+    uint16_t step_mask;                 // bitmask: which steps are active (bits 0-15)
+    seq_tone_step_t steps[SEQ_MAX_STEPS]; // per-step tone parameters
+} seq_tone_track_t;
 
 typedef struct {
     // Clock state
@@ -133,18 +157,20 @@ typedef struct {
     // Percussion track buffers (set once by Python)
     seq_perc_track_t perc_tracks[SEQ_MAX_PERC_TRACKS];
 
-    // Voice mapping: which voice index to use for each track
-    uint8_t perc_voice[SEQ_MAX_PERC_TRACKS];  // voice index for each perc track
-    uint8_t melody_voice;               // voice index for melody
+    // Voice mapping: which voice index to use for each perc track
+    uint8_t perc_voice[SEQ_MAX_PERC_TRACKS];
 
-    // Melody config
-    uint16_t melody_duration_ms;        // tone duration for melody notes (default 150)
+    // DEPRECATED melody fields — kept for backward compat with clock_set_melody()
+    uint8_t melody_voice;               // voice index for melody
+    uint16_t melody_duration_ms;        // tone duration (default 150)
     uint8_t  melody_wave;               // waveform type (default SINE)
 
-    // Anti-double-trigger: sample count when each track/melody was last
-    // manually triggered (by button preview).  Indexed by perc track (0-4)
-    // + melody (index 5).
-    uint32_t manual_trigger_sample[SEQ_MAX_PERC_TRACKS + 1];
+    // Tone tracks (clock-driven synth notes — replaces melody for new code)
+    seq_tone_track_t tone_tracks[SEQ_MAX_TONE_TRACKS];
+
+    // Anti-double-trigger: sample count when each track was last manually
+    // triggered.  Indices 0..4 = perc tracks, 5..7 = tone tracks.
+    uint32_t manual_trigger_sample[SEQ_MAX_PERC_TRACKS + SEQ_MAX_TONE_TRACKS];
     uint32_t total_samples;             // monotonic sample counter for anti-repeat
 
     // BPM for Python query

--- a/cmodules/audiomix/mixer.c
+++ b/cmodules/audiomix/mixer.c
@@ -147,12 +147,21 @@ static uint32_t voice_read(audiomix_state_t *state, audiomix_voice_t *v,
             break;
         }
 
-        // Fade in/out at start/end of tone
-        int is_last = (v->tone_samples_left <= n);
-        if (v->fade_in || is_last) {
-            tonegen_fade(voice_buf, n, v->fade_in, is_last,
-                        AUDIOMIX_FADE_SAMPLES);
-            v->fade_in = 0;
+        // Apply envelope or legacy fade
+        if (v->env_total_samples > 0) {
+            // Clock-driven envelope (attack/release + velocity)
+            tonegen_envelope(voice_buf, n, v->env_pos, v->env_total_samples,
+                            v->env_attack_samples, v->env_release_samples,
+                            v->env_velocity);
+            v->env_pos += n;
+        } else {
+            // Legacy fade for Python-triggered tones
+            int is_last = (v->tone_samples_left <= n);
+            if (v->fade_in || is_last) {
+                tonegen_fade(voice_buf, n, v->fade_in, is_last,
+                            AUDIOMIX_FADE_SAMPLES);
+                v->fade_in = 0;
+            }
         }
 
         v->tone_samples_left -= n;
@@ -302,11 +311,10 @@ static void mix_task(void *arg) {
                     }
                 }
 
-                // Melody
+                // Melody (DEPRECATED — kept for backward compat)
                 if (st->melody_freq > 0) {
                     int vi = clk->melody_voice;
                     if (vi < AUDIOMIX_NUM_VOICES && !state->voices[vi].writing) {
-                        // Anti-double: check melody preview marker (index 5)
                         uint32_t since = clk->total_samples - clk->manual_trigger_sample[SEQ_MAX_PERC_TRACKS];
                         if (since >= threshold) {
                             audiomix_voice_t *v = &state->voices[vi];
@@ -320,9 +328,50 @@ static void mix_task(void *arg) {
                             v->fade_in = 1;
                             v->fade_out = 0;
                             v->stop_req = 0;
+                            v->env_total_samples = 0;  // legacy path
                             v->source_type = SRC_TONE;
                         }
                     }
+                }
+
+                // Tone tracks (sample-accurate synth notes)
+                for (int tt = 0; tt < SEQ_MAX_TONE_TRACKS; tt++) {
+                    seq_tone_track_t *trk = &clk->tone_tracks[tt];
+                    if (!(trk->step_mask & (1 << next))) continue;
+
+                    int vi = trk->voice_idx;
+                    if (vi >= AUDIOMIX_NUM_VOICES) continue;
+                    if (state->voices[vi].writing) continue;
+
+                    // Anti-double-trigger
+                    uint32_t since = clk->total_samples
+                        - clk->manual_trigger_sample[SEQ_MAX_PERC_TRACKS + tt];
+                    if (since < threshold) continue;
+
+                    seq_tone_step_t *ts = &trk->steps[next];
+                    if (ts->freq == 0) continue;  // rest step
+
+                    audiomix_voice_t *v = &state->voices[vi];
+                    v->source_type = SRC_NONE;
+
+                    uint32_t dur_samples = (state->sample_rate * ts->duration_ms) / 1000;
+                    v->tone_freq = ts->freq;
+                    v->tone_samples_left = dur_samples;
+                    v->tone_phase = 0;
+                    v->tone_wave = ts->wave;
+                    v->loop = 0;
+                    v->fade_in = 0;   // envelope handles attack
+                    v->fade_out = 0;
+                    v->stop_req = 0;
+
+                    // Envelope parameters
+                    v->env_attack_samples = (state->sample_rate * ts->attack_ms) / 1000;
+                    v->env_release_samples = (state->sample_rate * ts->release_ms) / 1000;
+                    v->env_total_samples = dur_samples;
+                    v->env_pos = 0;
+                    v->env_velocity = ts->velocity;
+
+                    v->source_type = SRC_TONE;
                 }
             }
             // Clock is active — always process even if no voices were triggered
@@ -446,6 +495,12 @@ const char *mixer_init(const mixer_config_t *cfg, audiomix_state_t **state_out) 
         state->clock.perc_voice[i] = i;
     }
     state->clock.melody_voice = 5;
+
+    // Tone track defaults: all disabled (voice_idx=255, step_mask=0)
+    for (int i = 0; i < SEQ_MAX_TONE_TRACKS; i++) {
+        state->clock.tone_tracks[i].voice_idx = 255;
+        state->clock.tone_tracks[i].step_mask = 0;
+    }
 
     // Initialise per-voice state
     for (int i = 0; i < AUDIOMIX_NUM_VOICES; i++) {

--- a/cmodules/audiomix/tonegen.c
+++ b/cmodules/audiomix/tonegen.c
@@ -98,6 +98,37 @@ void tonegen_noise(int16_t *out, uint32_t n_samples,
     }
 }
 
+void tonegen_envelope(int16_t *buf, uint32_t n_samples,
+                      uint32_t pos, uint32_t total,
+                      uint32_t attack, uint32_t release,
+                      uint8_t velocity) {
+    // Velocity gain: 0-127 mapped to 0-256 (fixed-point 8.8 style, >>7)
+    // 127 → 256 (unity), 64 → ~128 (half), 0 → 0 (silent)
+    uint32_t vel_gain = (velocity < 127) ? (velocity * 2) : 256;
+    uint32_t release_start = (total > release) ? (total - release) : 0;
+
+    for (uint32_t i = 0; i < n_samples; i++) {
+        uint32_t abs_pos = pos + i;
+        uint32_t gain = 256;  // full amplitude (8-bit fixed point)
+
+        if (attack > 0 && abs_pos < attack) {
+            // Attack ramp: linear 0 → 256
+            gain = (abs_pos * 256) / attack;
+        } else if (release > 0 && abs_pos >= release_start) {
+            // Release ramp: linear 256 → 0
+            uint32_t rel_pos = abs_pos - release_start;
+            gain = ((release - rel_pos) * 256) / release;
+        }
+
+        // Combine envelope gain with velocity
+        gain = (gain * vel_gain) >> 8;
+
+        int32_t val = buf[i];
+        val = (val * (int32_t)gain) >> 8;
+        buf[i] = (int16_t)val;
+    }
+}
+
 void tonegen_fade(int16_t *buf, uint32_t n_samples,
                   int fade_in, int fade_out, uint32_t fade_len) {
     if (fade_in) {

--- a/cmodules/audiomix/tonegen.h
+++ b/cmodules/audiomix/tonegen.h
@@ -24,7 +24,20 @@ void tonegen_noise(int16_t *out, uint32_t n_samples,
                    uint32_t decay_rate, uint32_t sample_rate);
 
 // Apply linear fade-in and/or fade-out to a sample buffer.
+// Used for WAV buffer click suppression (SRC_RINGBUF, SRC_BUFFER).
 void tonegen_fade(int16_t *buf, uint32_t n_samples,
                   int fade_in, int fade_out, uint32_t fade_len);
+
+// Apply attack/release envelope with velocity scaling to a tone buffer.
+// Used for clock-driven tone tracks (SRC_TONE with env_total_samples > 0).
+//   pos:      current sample position within the overall note
+//   total:    total note duration in samples
+//   attack:   attack ramp length in samples (0 = instant onset)
+//   release:  release ramp length in samples (0 = hard stop)
+//   velocity: volume 0-127 (127 = full amplitude)
+void tonegen_envelope(int16_t *buf, uint32_t n_samples,
+                      uint32_t pos, uint32_t total,
+                      uint32_t attack, uint32_t release,
+                      uint8_t velocity);
 
 #endif // AUDIOMIX_TONEGEN_H

--- a/firmware/bodn/ui/sequencer.py
+++ b/firmware/bodn/ui/sequencer.py
@@ -145,12 +145,29 @@ class SequencerScreen(Screen):
         # Register drum buffers with C clock for sample-accurate triggering
         if _has_clock:
             _audiomix.clock_clear_grid()
-            _audiomix.clock_set_melody_config(150, _audiomix.WAVE_SINE)
             if self._drum_bufs:
-                for t in range(min(NUM_PERC_TRACKS, len(self._drum_bufs))):
-                    buf = self._drum_bufs[t]
+                for ti in range(min(NUM_PERC_TRACKS, len(self._drum_bufs))):
+                    buf = self._drum_bufs[ti]
                     if buf:
-                        _audiomix.clock_set_perc_buffer(t, buf, len(buf))
+                        _audiomix.clock_set_perc_buffer(ti, buf, len(buf))
+
+            # Melody tone track (track 0, voice 5)
+            _audiomix.clock_set_tone_track(0, 5, 0)  # mask filled by _sync_all
+
+            # Metronome tone track (track 1, voice 7)
+            # Pre-fill step data for all 16 possible steps
+            for s in range(16):
+                is_down = (
+                    s % (self._engine.n_steps // 2) == 0
+                    if self._engine.n_steps > 2
+                    else s == 0
+                )
+                freq = _METRO_HI if (s % 4 == 0) else _METRO_LO
+                _audiomix.clock_set_tone_step(
+                    1, s, freq, 30, _audiomix.WAVE_SQUARE, 0, 5, 100
+                )
+            metro_mask = self._metro_mask() if self._engine.metronome else 0
+            _audiomix.clock_set_tone_track(1, _METRO_VOICE, metro_mask)
 
         # Compute grid geometry
         w = manager.tft.width if hasattr(manager.tft, "width") else 320
@@ -234,6 +251,9 @@ class SequencerScreen(Screen):
             if _has_clock:
                 _audiomix.clock_set_steps(new_steps)
                 self._sync_all_to_clock()
+                # Update metronome mask for new step count
+                if eng.metronome:
+                    _audiomix.clock_set_tone_track(1, _METRO_VOICE, self._metro_mask())
             self._recompute_grid()
             self._dirty = True
             self._full_clear = True
@@ -243,6 +263,9 @@ class SequencerScreen(Screen):
         sw2 = sw[2] if len(sw) > 2 else False
         if self._prev_sw2 is not None and sw2 != self._prev_sw2:
             eng.toggle_metronome()
+            if _has_clock:
+                mask = self._metro_mask() if eng.metronome else 0
+                _audiomix.clock_set_tone_track(1, _METRO_VOICE, mask)
             self._dirty = True
         self._prev_sw2 = sw2
 
@@ -260,6 +283,16 @@ class SequencerScreen(Screen):
             eng.clear_all()
             if _has_clock:
                 _audiomix.clock_clear_grid()
+                # Re-setup tone tracks (clear_grid zeros them)
+                _audiomix.clock_set_tone_track(0, 5, 0)  # melody
+                # Re-fill metronome step data and restore mask if active
+                for s in range(16):
+                    freq = _METRO_HI if (s % 4 == 0) else _METRO_LO
+                    _audiomix.clock_set_tone_step(
+                        1, s, freq, 30, _audiomix.WAVE_SQUARE, 0, 5, 100
+                    )
+                metro_mask = self._metro_mask() if eng.metronome else 0
+                _audiomix.clock_set_tone_track(1, _METRO_VOICE, metro_mask)
             self._dirty = True
             self._full_clear = True
             self._flash_msg = t("seq_cleared")
@@ -309,8 +342,13 @@ class SequencerScreen(Screen):
             if eng.step_advanced:
                 self._trigger_step_sounds(eng.step)
 
-        # --- Metronome click on beat ---
-        if eng.metronome and eng.state == PLAYING and eng.step_advanced:
+        # --- Metronome click on beat (fallback: no C clock) ---
+        if (
+            not _has_clock
+            and eng.metronome
+            and eng.state == PLAYING
+            and eng.step_advanced
+        ):
             if eng.is_beat(eng.step):
                 self._play_metronome(eng.is_downbeat(eng.step))
 
@@ -357,16 +395,34 @@ class SequencerScreen(Screen):
             if eng.perc[ti][step]:
                 mask |= 1 << ti
         _audiomix.clock_set_perc(step, mask)
+        # Melody via tone track 0
         mel = eng.melody[step]
-        freq = MELODY_FREQS[mel - 1] if mel > 0 else 0
-        _audiomix.clock_set_melody(step, freq)
+        if mel > 0:
+            freq = MELODY_FREQS[mel - 1]
+            _audiomix.clock_set_tone_step(
+                0, step, freq, 150, _audiomix.WAVE_SINE, 2, 10, 100
+            )
+        else:
+            _audiomix.clock_set_tone_step(0, step, 0, 0, 0, 0, 0, 0)
 
     def _sync_all_to_clock(self):
         """Push entire grid to C clock."""
         if not _has_clock:
             return
+        mel_mask = 0
         for s in range(self._engine.n_steps):
             self._sync_step_to_clock(s)
+            if self._engine.melody[s] > 0:
+                mel_mask |= 1 << s
+        _audiomix.clock_set_tone_track(0, 5, mel_mask)
+
+    def _metro_mask(self):
+        """Build step bitmask for metronome beats (every 2nd step = quarter note)."""
+        mask = 0
+        for s in range(self._engine.n_steps):
+            if self._engine.is_beat(s):
+                mask |= 1 << s
+        return mask
 
     # ------------------------------------------------------------------
     # Audio helpers
@@ -389,8 +445,18 @@ class SequencerScreen(Screen):
             return
         freq = MELODY_FREQS[btn_idx]
         if _has_clock:
-            _audiomix.clock_preview(5)  # suppress clock trigger for melody
+            _audiomix.clock_tone_preview(0)  # suppress clock trigger for melody
+            self._update_melody_mask()
         self._audio.tone(freq, 150, "sine", voice=_PREVIEW_VOICE)
+
+    def _update_melody_mask(self):
+        """Recompute and push the melody tone track step mask."""
+        mel_mask = 0
+        eng = self._engine
+        for s in range(eng.n_steps):
+            if eng.melody[s] > 0:
+                mel_mask |= 1 << s
+        _audiomix.clock_set_tone_track(0, 5, mel_mask)
 
     def _play_metronome(self, downbeat):
         """Play a short metronome click. Accented on downbeats."""

--- a/firmware/bodn/ui/sequencer.py
+++ b/firmware/bodn/ui/sequencer.py
@@ -157,11 +157,6 @@ class SequencerScreen(Screen):
             # Metronome tone track (track 1, voice 7)
             # Pre-fill step data for all 16 possible steps
             for s in range(16):
-                is_down = (
-                    s % (self._engine.n_steps // 2) == 0
-                    if self._engine.n_steps > 2
-                    else s == 0
-                )
                 freq = _METRO_HI if (s % 4 == 0) else _METRO_LO
                 _audiomix.clock_set_tone_step(
                     1, s, freq, 30, _audiomix.WAVE_SQUARE, 0, 5, 100


### PR DESCRIPTION
## Summary
- Add per-step tone tracks to the C audio mixer clock, giving generated tones (melody, metronome) the same sample-accurate timing as WAV percussion samples
- New `seq_tone_step_t` struct with freq, duration, waveform, attack/release envelope, and velocity per step — a rudimentary clock-driven synth
- Sequencer melody (track 0, voice 5) and metronome (track 1, voice 7) now fire from the C mix loop instead of Python, eliminating 10-30ms drift
- Switch board to 8 MiB OTA partition table (~500 KB headroom)

### New C API
- `clock_set_tone_track(track, voice_idx, step_mask)` — assign voice + enable steps
- `clock_set_tone_step(track, step, freq, dur, wave, attack_ms, release_ms, velocity)` — configure one step
- `clock_tone_preview(track)` — anti-double-trigger for button preview
- `tonegen_envelope()` — linear attack/release with velocity scaling (separate from WAV fade)

### Files changed
- `audiomix.h` — new `seq_tone_step_t`, `seq_tone_track_t`, envelope fields on voice
- `mixer.c` — tone track triggering loop + envelope path in `voice_read()`
- `tonegen.c/h` — `tonegen_envelope()` function
- `audiomix.c` — Python bindings + updated `clock_clear_grid()`
- `sequencer.py` — migrated melody + metronome to tone tracks
- `sdkconfig.board` — 8 MiB flash + OTA partition table

## Test plan
- [x] Firmware builds cleanly (512 KB remaining in app partition)
- [x] All 615 host tests pass
- [ ] Flash and verify metronome clicks are tight with drum samples
- [ ] Verify melody notes align with percussion on the beat
- [ ] Test 8/16 step switching with metronome active
- [ ] Test clear-all restores metronome after grid wipe
- [ ] Verify fallback path (no C clock) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)