### PR TITLE
feat: NFC data layer — tag format, card sets, generator, and UI scaffold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ bodn-esp32/
 │     ├─ life_rules.py      # Game of Life cellular automata (pure logic)
 │     ├─ mcp23017.py        # MCP23017 I2C GPIO expander driver
 │     ├─ mystery_rules.py   # Mystery Box rule engine (pure logic)
+│     ├─ nfc.py             # NFC tag parsing, card sets, UID cache, reader stub
 │     ├─ patterns.py        # LED animation patterns (shared buffer)
 │     ├─ pca9685.py         # PCA9685 I2C PWM driver
 │     ├─ power.py           # power management (sleep, wake, master switch)
@@ -131,6 +132,7 @@ bodn-esp32/
 │        ├─ input.py        # unified input state with debouncing
 │        ├─ logo.py         # pixel art boot logo (Norse mead vessel)
 │        ├─ mystery.py      # Mystery Box discovery game
+│        ├─ nfc_provision.py # NFC card set viewer + provisioning (stub)
 │        ├─ overlay.py      # session state overlay
 │        ├─ pause.py        # in-game pause menu (hold-to-open)
 │        ├─ rulefollow.py   # Rule Follow game screen
@@ -146,6 +148,7 @@ bodn-esp32/
 │  ├─ wiring.md             # auto-generated pin diagram and tables
 │  ├─ UX_GUIDELINES.md      # child-facing interaction design
 │  ├─ PERFORMANCE_GUIDELINES.md  # ESP32 performance rules
+│  ├─ nfc.md                # NFC tag format, card sets, provisioning
 │  └─ roadmap.md            # milestones and progress
 ├─ tools/
 │  ├─ pinout.py             # generate wiring docs from config.py
@@ -156,7 +159,8 @@ bodn-esp32/
 │  ├─ build-firmware.sh      # build custom MicroPython firmware with C modules
 │  ├─ generate_story_tts.py  # generate story narration TTS from story scripts
 │  ├─ story_preview.py      # preview story scripts in terminal
-│  └─ sd-sync.py            # build + sync SD card assets (TTS, sounds, etc.)
+│  ├─ sd-sync.py            # build + sync SD card assets (TTS, sounds, etc.)
+│  └─ generate_cards.py     # NFC card face PDF generator (OpenMoji → A4 PDF)
 ├─ cmodules/                  # native C extensions (compiled into firmware)
 │  ├─ micropython.cmake       # top-level cmake: includes sub-modules
 │  ├─ audiomix/               # native audio mixer (_audiomix module, core 0)
@@ -259,6 +263,12 @@ uv run python tools/sd-sync.py /Volumes/BODN_SD   # explicit mount point
 uv run python tools/sd-sync.py --build-only        # build without copying
 uv run python tools/sd-sync.py --no-build /Volumes/BODN_SD  # copy without rebuilding
 uv run python tools/sd-sync.py --dry-run           # preview what would happen
+
+# NFC card face PDF generator (requires OpenMoji SVGs)
+# One-time: git clone --depth 1 https://github.com/hfg-gmuend/openmoji.git ~/openmoji
+uv run python tools/generate_cards.py --openmoji ~/openmoji  # generate all card PDFs
+uv run python tools/generate_cards.py --set sortera          # specific set
+uv run python tools/generate_cards.py --dry-run              # preview without generating
 ```
 
 ## Git hooks

--- a/assets/nfc/sortera.json
+++ b/assets/nfc/sortera.json
@@ -1,0 +1,23 @@
+{
+  "mode": "sortera",
+  "version": 1,
+  "dimensions": ["category", "colour"],
+  "cards": [
+    {"id": "cat_red",      "category": "animal", "colour": "red",    "label_sv": "katt",  "label_en": "cat",    "icon": "1F431"},
+    {"id": "cat_blue",     "category": "animal", "colour": "blue",   "label_sv": "katt",  "label_en": "cat",    "icon": "1F431"},
+    {"id": "dog_green",    "category": "animal", "colour": "green",  "label_sv": "hund",  "label_en": "dog",    "icon": "1F436"},
+    {"id": "dog_yellow",   "category": "animal", "colour": "yellow", "label_sv": "hund",  "label_en": "dog",    "icon": "1F436"},
+    {"id": "rabbit_red",   "category": "animal", "colour": "red",    "label_sv": "kanin", "label_en": "rabbit", "icon": "1F430"},
+    {"id": "rabbit_green", "category": "animal", "colour": "green",  "label_sv": "kanin", "label_en": "rabbit", "icon": "1F430"},
+    {"id": "bird_blue",    "category": "animal", "colour": "blue",   "label_sv": "fågel", "label_en": "bird",   "icon": "1F426"},
+    {"id": "bird_yellow",  "category": "animal", "colour": "yellow", "label_sv": "fågel", "label_en": "bird",   "icon": "1F426"},
+    {"id": "fish_red",     "category": "animal", "colour": "red",    "label_sv": "fisk",  "label_en": "fish",   "icon": "1F41F"},
+    {"id": "fish_blue",    "category": "animal", "colour": "blue",   "label_sv": "fisk",  "label_en": "fish",   "icon": "1F41F"},
+    {"id": "horse_green",  "category": "animal", "colour": "green",  "label_sv": "häst",  "label_en": "horse",  "icon": "1F434"},
+    {"id": "horse_yellow", "category": "animal", "colour": "yellow", "label_sv": "häst",  "label_en": "horse",  "icon": "1F434"},
+    {"id": "cow_red",      "category": "animal", "colour": "red",    "label_sv": "ko",    "label_en": "cow",    "icon": "1F404"},
+    {"id": "cow_green",    "category": "animal", "colour": "green",  "label_sv": "ko",    "label_en": "cow",    "icon": "1F404"},
+    {"id": "frog_blue",    "category": "animal", "colour": "blue",   "label_sv": "groda", "label_en": "frog",   "icon": "1F438"},
+    {"id": "frog_yellow",  "category": "animal", "colour": "yellow", "label_sv": "groda", "label_en": "frog",   "icon": "1F438"}
+  ]
+}

--- a/docs/nfc.md
+++ b/docs/nfc.md
@@ -1,0 +1,157 @@
+# NFC Integration
+
+Bodn supports NFC-tagged cards and stickers via a PN532 reader connected
+over I2C. Cards carry self-describing data and are used as input for
+classification games, storytelling, vocabulary, and free exploration.
+
+See `docs/science/nfc_tangible_learning.md` for the developmental science
+behind this feature.
+
+## Tag Data Format
+
+Tags use **NDEF Text Records** so they're also readable by NFC phone apps.
+
+The payload follows a simple colon-separated format:
+
+```
+BODN:1:sortera:cat_red
+│    │ │       └─ card ID (unique within the set)
+│    │ └─ mode (matches card set template filename)
+│    └─ schema version
+└─ magic prefix
+```
+
+### Special tags
+
+| Tag data | Purpose |
+|----------|---------|
+| `BODN:1:admin:unlock` | Admin fob — opens settings without web UI |
+
+### NDEF encoding
+
+The tag stores an NDEF Text Record with language code `en`:
+
+```
+Byte 0:     status (0x02 = UTF-8, lang_len=2)
+Bytes 1-2:  "en"
+Bytes 3+:   "BODN:1:sortera:cat_red"
+```
+
+Total: ~30 bytes. NTAG213 (144 bytes usable) has plenty of room.
+
+## Card Set Templates
+
+Card sets are JSON files stored on the SD card at `/sd/nfc/{mode}.json`.
+They define the cards in a deck, their properties, and sorting dimensions.
+
+```json
+{
+  "mode": "sortera",
+  "version": 1,
+  "dimensions": ["category", "colour"],
+  "cards": [
+    {
+      "id": "cat_red",
+      "category": "animal",
+      "colour": "red",
+      "label_sv": "katt",
+      "label_en": "cat",
+      "icon": "1F431"
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| `mode` | Mode identifier, matches the filename |
+| `version` | Schema version (currently 1) |
+| `dimensions` | List of sortable property names |
+| `cards[].id` | Unique card identifier (written to NFC tag) |
+| `cards[].label_sv` | Swedish display name |
+| `cards[].label_en` | English display name |
+| `cards[].icon` | OpenMoji Unicode codepoint (hex string) |
+| `cards[].<dim>` | Value for each dimension (e.g., `category`, `colour`) |
+
+### Adding a new card set
+
+1. Create `assets/nfc/{mode}.json` following the schema above
+2. Run `uv run python tools/sd-sync.py` to copy it to the SD card
+3. The card set will appear in the settings NFC screen and web UI
+
+## UID Cache
+
+After the first read of a tag, the device caches the UID→card mapping at
+`/data/nfc_cache.json` on flash. This speeds up subsequent reads from
+~200 ms (full data read) to ~50 ms (UID only).
+
+The cache is **not the source of truth** — it's rebuilt automatically from
+tag data on cache miss. Deleting the cache file has no impact beyond a
+brief speed penalty on first scans.
+
+## Card Face Generation
+
+A host-side tool generates printable PDF sheets from card set templates:
+
+```bash
+# One-time: clone OpenMoji SVGs
+git clone --depth 1 https://github.com/hfg-gmuend/openmoji.git ~/openmoji
+
+# Generate all card sets
+uv run python tools/generate_cards.py --openmoji ~/openmoji
+
+# Specific set only
+uv run python tools/generate_cards.py --set sortera --openmoji ~/openmoji
+
+# Preview without generating
+uv run python tools/generate_cards.py --dry-run
+```
+
+Output: `build/cards/{mode}_cards.pdf` — A4 pages with credit-card-sized
+(85×54 mm) card faces in a 2×4 grid.
+
+### Card production workflow
+
+1. Generate the PDF: `uv run python tools/generate_cards.py --openmoji ~/openmoji`
+2. Print on cardstock or thick paper
+3. Attach an NFC sticker (NTAG213) to the back of each card
+4. Laminate for durability
+5. Provision tags via the on-device screen or web UI (requires PN532, issue #121)
+
+## Hardware (Issue #121)
+
+The PN532 NFC reader connects via I2C:
+
+| PN532 Pin | ESP32-S3 | Notes |
+|-----------|----------|-------|
+| VCC | 3.3V | Check board regulator |
+| GND | GND | |
+| SDA | Shared I2C bus | With MCP23017s |
+| SCL | Shared I2C bus | |
+| IRQ | Free GPIO (optional) | Power-efficient detection |
+
+I2C address: **0x24** (no conflict with MCP23017 at 0x21/0x23 or PCA9685 at 0x40).
+
+## Module API
+
+```python
+from bodn.nfc import (
+    parse_tag_data,    # bytes or str → {prefix, version, mode, id} or None
+    encode_tag_data,   # (mode, card_id) → NDEF bytes
+    load_card_set,     # mode → dict or None
+    lookup_card,       # (mode, card_id) → card dict or None
+    list_card_sets,    # () → [mode_name, ...]
+    UIDCache,          # .lookup(uid), .store(uid, mode, id), .clear()
+    NFCReader,         # .scan() → (uid, data), .write(data), .available()
+)
+```
+
+## Web API
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/nfc/sets` | GET | List available card sets |
+| `/api/nfc/set/{mode}` | GET | Full card set data |
+| `/api/nfc/cache` | GET | UID cache contents |

--- a/firmware/bodn/lang/en.py
+++ b/firmware/bodn/lang/en.py
@@ -31,6 +31,7 @@ STRINGS = {
     "settings_debug": "Debug log",
     "settings_perf": "Perf stats",
     "settings_diag": "Diagnostics",
+    "settings_nfc": "NFC Cards",
     "settings_sleep": "Sleep timer",
     "settings_encoder": "Sensitivity",
     "settings_tz": "Timezone",

--- a/firmware/bodn/lang/sv.py
+++ b/firmware/bodn/lang/sv.py
@@ -31,6 +31,7 @@ STRINGS = {
     "settings_debug": "Debug logg",
     "settings_perf": "Perf stats",
     "settings_diag": "Diagnostik",
+    "settings_nfc": "NFC-kort",
     "settings_sleep": "Vilotimer",
     "settings_encoder": "Känslighet",
     "settings_tz": "Tidszon",

--- a/firmware/bodn/nfc.py
+++ b/firmware/bodn/nfc.py
@@ -1,0 +1,253 @@
+# bodn/nfc.py — NFC tag data handling, card set loading, and UID cache
+#
+# Tag data format (NDEF Text Record payload):
+#   BODN:1:sortera:cat_red
+#   ^^^^  ^ ^^^^^^^ ^^^^^^^
+#   prefix version mode   card_id
+#
+# Card set templates live on SD at /sd/nfc/{mode}.json
+# UID cache lives on flash at /data/nfc_cache.json
+
+import os
+
+try:
+    import json
+except ImportError:
+    import ujson as json
+
+TAG_PREFIX = "BODN"
+TAG_VERSION = 1
+NFC_CACHE_PATH = "/data/nfc_cache.json"
+NFC_DIR = "/nfc"
+
+
+# ---------------------------------------------------------------------------
+# Tag data parsing and encoding
+# ---------------------------------------------------------------------------
+
+
+def parse_tag_data(data):
+    """Parse a BODN tag identifier from raw NDEF bytes or a plain string.
+
+    Accepts either:
+      - bytes/bytearray (NDEF Text Record: status byte + lang code + text)
+      - str (plain text: "BODN:1:sortera:cat_red")
+
+    Returns dict with keys (prefix, version, mode, id) or None on failure.
+    """
+    if isinstance(data, (bytes, bytearray)):
+        text = _decode_ndef_text(data)
+        if text is None:
+            return None
+    else:
+        text = str(data)
+
+    parts = text.split(":")
+    if len(parts) < 4:
+        return None
+    if parts[0] != TAG_PREFIX:
+        return None
+
+    try:
+        version = int(parts[1])
+    except (ValueError, IndexError):
+        return None
+
+    return {
+        "prefix": parts[0],
+        "version": version,
+        "mode": parts[2],
+        "id": parts[3],
+    }
+
+
+def encode_tag_data(mode, card_id, version=None):
+    """Create NDEF Text Record payload bytes for writing to a tag.
+
+    Returns bytes: status_byte + b'en' + payload text.
+    The status byte encodes UTF-8 flag (bit 7 = 0) and language code
+    length (bits 5-0 = 2 for 'en').
+    """
+    if version is None:
+        version = TAG_VERSION
+    text = "{}:{}:{}:{}".format(TAG_PREFIX, version, mode, card_id)
+    lang = b"en"
+    status = len(lang)  # UTF-8 (bit 7 = 0), lang length = 2
+    return bytes([status]) + lang + text.encode("utf-8")
+
+
+def _decode_ndef_text(data):
+    """Decode an NDEF Text Record payload to a string.
+
+    Format: 1 byte status (bit 7 = encoding, bits 5-0 = lang code length)
+            N bytes language code
+            remaining bytes = text
+    """
+    if len(data) < 2:
+        return None
+    status = data[0]
+    lang_len = status & 0x3F
+    if len(data) < 1 + lang_len + 1:
+        return None
+    text_bytes = data[1 + lang_len :]
+    try:
+        return text_bytes.decode("utf-8")
+    except (UnicodeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Card set loading
+# ---------------------------------------------------------------------------
+
+
+def load_card_set(mode):
+    """Load a card set template from /nfc/{mode}.json.
+
+    Checks SD card first via assets.resolve(), falls back to flash.
+    Returns the parsed dict or None on error.
+    """
+    path = "{}/{}.json".format(NFC_DIR, mode)
+    try:
+        from bodn.assets import resolve
+
+        resolved = resolve(path)
+    except ImportError:
+        resolved = path
+
+    try:
+        with open(resolved, "r") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
+
+
+def lookup_card(mode, card_id):
+    """Find a specific card within a card set by ID.
+
+    Returns the card dict or None.
+    """
+    cs = load_card_set(mode)
+    if cs is None:
+        return None
+    for card in cs.get("cards", []):
+        if card.get("id") == card_id:
+            return card
+    return None
+
+
+def list_card_sets():
+    """List available card set modes by scanning the NFC directory.
+
+    Returns a list of mode name strings (filenames without .json).
+    """
+    # Try SD first, then flash
+    for base in ("/sd" + NFC_DIR, NFC_DIR):
+        try:
+            entries = os.listdir(base)
+            return [name[:-5] for name in sorted(entries) if name.endswith(".json")]
+        except OSError:
+            continue
+    return []
+
+
+# ---------------------------------------------------------------------------
+# UID cache
+# ---------------------------------------------------------------------------
+
+
+class UIDCache:
+    """On-device UID-to-card mapping cache.
+
+    Persisted at /data/nfc_cache.json. This is a performance optimisation
+    only — the tag data on the NFC tag is the source of truth. If the
+    cache is lost or corrupted, it rebuilds automatically from tag reads.
+    """
+
+    def __init__(self, path=None):
+        self._path = path or NFC_CACHE_PATH
+        self._cache = {}
+        self._load()
+
+    def _load(self):
+        try:
+            with open(self._path, "r") as f:
+                self._cache = json.load(f)
+        except (OSError, ValueError):
+            self._cache = {}
+
+    def _save(self):
+        _ensure_dir(self._path)
+        tmp = self._path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(self._cache, f)
+        try:
+            os.remove(self._path)
+        except OSError:
+            pass
+        os.rename(tmp, self._path)
+
+    def lookup(self, uid):
+        """Look up a UID string. Returns dict {mode, id} or None."""
+        return self._cache.get(uid)
+
+    def store(self, uid, mode, card_id):
+        """Store a UID mapping and persist to flash."""
+        self._cache[uid] = {"mode": mode, "id": card_id}
+        self._save()
+
+    def clear(self):
+        """Clear all cached mappings."""
+        self._cache = {}
+        self._save()
+
+    def entries(self):
+        """Return the full cache dict (for diagnostics/web UI)."""
+        return dict(self._cache)
+
+
+def _ensure_dir(path):
+    """Create parent directory if it doesn't exist."""
+    parts = path.rsplit("/", 1)
+    if len(parts) == 2 and parts[0]:
+        try:
+            os.mkdir(parts[0])
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# NFC reader stub (hardware implementation in #121)
+# ---------------------------------------------------------------------------
+
+
+class NFCReader:
+    """Stub NFC reader — real PN532 driver replaces this in issue #121.
+
+    Provides the interface that game modes and provisioning code will use.
+    """
+
+    def __init__(self):
+        self._available = False
+
+    def available(self):
+        """Return True if NFC hardware is detected on the I2C bus."""
+        return self._available
+
+    def scan(self):
+        """Scan for a tag in the field.
+
+        Returns (uid_str, raw_data_bytes) if a tag is present,
+        or (None, None) if no tag is detected.
+
+        uid_str format: colon-separated hex, e.g. "04:A3:B2:C1:D4:E5:F6"
+        raw_data_bytes: NDEF Text Record payload (status + lang + text)
+        """
+        return None, None
+
+    def write(self, data):
+        """Write data bytes to the tag currently in the field.
+
+        Returns True on success, False on failure or no tag present.
+        """
+        return False

--- a/firmware/bodn/ui/nfc_provision.py
+++ b/firmware/bodn/ui/nfc_provision.py
@@ -1,0 +1,155 @@
+# bodn/ui/nfc_provision.py — NFC card set viewer and provisioning screen
+#
+# Shows available NFC card sets loaded from /sd/nfc/.
+# Actual tag scanning is stubbed until PN532 hardware is available (#121).
+
+from micropython import const
+from bodn.ui.screen import Screen
+from bodn.ui.widgets import draw_centered, make_label_sprite, blit_sprite
+from bodn.i18n import t
+
+NAV = const(0)
+
+
+class NFCProvisionScreen(Screen):
+    """NFC card provisioning screen.
+
+    Scrollable list of available card sets.  Selecting one shows card
+    count and dimensions.  Tag writing is stubbed until the PN532
+    hardware reader is wired up (issue #121).
+    """
+
+    def __init__(self, settings):
+        self._settings = settings
+        self._index = 0
+        self._manager = None
+        self._dirty = True
+        self._full_clear = True
+        self._sets = []  # list of (mode, card_count, dims) tuples
+        self._state = "menu"  # "menu" | "detail"
+        self._title_sprite = None
+
+    def enter(self, manager):
+        self._manager = manager
+        self._dirty = True
+        self._full_clear = True
+        self._index = 0
+        self._state = "menu"
+        self._title_sprite = make_label_sprite(t("settings_nfc"), 0xFFFF, scale=2)
+        self._load_sets()
+
+    def _load_sets(self):
+        try:
+            from bodn.nfc import list_card_sets, load_card_set
+
+            self._sets = []
+            for mode in list_card_sets():
+                cs = load_card_set(mode)
+                if cs:
+                    cards = cs.get("cards", [])
+                    dims = cs.get("dimensions", [])
+                    self._sets.append((mode, len(cards), ", ".join(dims)))
+        except Exception:
+            self._sets = []
+
+    def needs_redraw(self):
+        return self._dirty
+
+    def update(self, inp, frame):
+        if self._state == "menu":
+            delta = inp.enc_delta[NAV]
+            if delta != 0:
+                n = len(self._sets) + 1  # +1 for "Back"
+                step = 1 if delta > 0 else -1
+                self._index = (self._index + step) % n
+                self._dirty = True
+
+            if inp.enc_btn_pressed[NAV] or inp.any_btn_pressed():
+                if self._index == len(self._sets):
+                    self._manager.pop()
+                elif self._sets:
+                    self._state = "detail"
+                    self._dirty = True
+                    self._full_clear = True
+
+        elif self._state == "detail":
+            if inp.enc_btn_pressed[NAV] or inp.any_btn_pressed():
+                self._state = "menu"
+                self._dirty = True
+                self._full_clear = True
+
+    def render(self, tft, theme, frame):
+        self._dirty = False
+        w = theme.width
+        h = theme.height
+
+        if self._full_clear:
+            tft.fill(theme.BLACK)
+            self._full_clear = False
+
+        if self._state == "menu":
+            self._render_menu(tft, theme, w, h)
+        elif self._state == "detail":
+            self._render_detail(tft, theme, w, h)
+
+    def _render_menu(self, tft, theme, w, h):
+        # Title
+        if self._title_sprite:
+            _, tw, _ = self._title_sprite
+            blit_sprite(tft, self._title_sprite, (w - tw) // 2, 8)
+
+        title_h = 28
+        row_h = 20
+        y0 = title_h + 4
+        available_h = h - y0 - 4
+        visible = available_h // row_h
+
+        n = len(self._sets) + 1  # +1 for back
+        half = visible // 2
+        scroll = max(0, min(self._index - half, n - visible))
+
+        for vi in range(visible):
+            idx = scroll + vi
+            if idx >= n:
+                break
+            y = y0 + vi * row_h
+            selected = idx == self._index
+
+            # Clear row
+            bg = theme.DIM if selected else theme.BLACK
+            tft.fill_rect(0, y, w, row_h, bg)
+
+            if idx < len(self._sets):
+                mode, count, dims = self._sets[idx]
+                label = "{} ({})".format(mode, count)
+            else:
+                label = t("settings_back")
+
+            tft.text(label, 8, y + 6, theme.WHITE if selected else theme.MUTED)
+
+    def _render_detail(self, tft, theme, w, h):
+        if self._index >= len(self._sets):
+            return
+        mode, count, dims = self._sets[self._index]
+
+        tft.fill(theme.BLACK)
+        draw_centered(tft, mode.upper(), 30, theme.WHITE, w)
+        draw_centered(tft, "{} cards".format(count), 50, theme.MUTED, w)
+        if dims:
+            draw_centered(tft, dims, 66, theme.MUTED, w)
+
+        # NFC hardware status
+        y_msg = h // 2
+        try:
+            from bodn.nfc import NFCReader
+
+            reader = NFCReader()
+            if reader.available():
+                draw_centered(tft, "NFC ready", y_msg, theme.GREEN, w)
+            else:
+                draw_centered(tft, "No NFC reader", y_msg, theme.MUTED, w)
+                draw_centered(tft, "See issue #121", y_msg + 14, theme.MUTED, w)
+        except Exception:
+            draw_centered(tft, "NFC not available", y_msg, theme.MUTED, w)
+
+        draw_centered(tft, "Press to go back", h - 20, theme.MUTED, w)

--- a/firmware/bodn/ui/settings.py
+++ b/firmware/bodn/ui/settings.py
@@ -26,6 +26,7 @@ _ITEMS = [
     ("admin_url", "settings_admin", "action"),
     ("standby", "settings_standby", "action"),
     ("diag", "settings_diag", "action"),
+    ("nfc_provision", "settings_nfc", "action"),
     ("back", "settings_back", "action"),
 ]
 
@@ -112,6 +113,12 @@ class SettingsScreen(Screen):
                 from bodn.ui.diag import DiagScreen
 
                 self._manager.push(DiagScreen())
+            return
+        if key == "nfc_provision":
+            if self._manager:
+                from bodn.ui.nfc_provision import NFCProvisionScreen
+
+                self._manager.push(NFCProvisionScreen(self._settings))
             return
         if key == "standby":
             self._settings["_sleep_now"] = True

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -486,6 +486,53 @@ async def _handle_request(reader, writer, session_mgr, settings):
                 pass
             await _send_json(writer, file_list)
 
+        # --- NFC card set endpoints ---
+
+        elif method == "GET" and path == "/api/nfc/sets":
+            try:
+                from bodn.nfc import list_card_sets, load_card_set
+
+                sets = []
+                for mode in list_card_sets():
+                    cs = load_card_set(mode)
+                    if cs:
+                        sets.append(
+                            {
+                                "mode": mode,
+                                "version": cs.get("version", 1),
+                                "card_count": len(cs.get("cards", [])),
+                                "dimensions": cs.get("dimensions", []),
+                            }
+                        )
+                await _send_json(writer, sets)
+            except Exception as e:
+                await _send_json(writer, {"error": str(e)}, 500)
+
+        elif method == "GET" and path.startswith("/api/nfc/set/"):
+            mode_name = path.rsplit("/", 1)[-1]
+            try:
+                from bodn.nfc import load_card_set
+
+                cs = load_card_set(mode_name)
+                if cs:
+                    await _send_json(writer, cs)
+                else:
+                    await _send_json(writer, {"error": "not found"}, 404)
+            except Exception as e:
+                await _send_json(writer, {"error": str(e)}, 500)
+
+        elif method == "GET" and path == "/api/nfc/cache":
+            try:
+                from bodn.nfc import UIDCache
+
+                cache = UIDCache()
+                await _send_json(writer, cache.entries())
+            except Exception as e:
+                await _send_json(writer, {"error": str(e)}, 500)
+
+        # NFC provisioning endpoints (POST /api/nfc/provision/*) will be
+        # added when the PN532 hardware reader is available (issue #121).
+
         else:
             await _send(writer, 404, "text/plain", "Not found")
 

--- a/firmware/bodn/web_ui.py
+++ b/firmware/bodn/web_ui.py
@@ -109,6 +109,7 @@ th{color:#aaa}
 <button class="tab" onclick="show('wifi',this)">WiFi</button>
 <button class="tab" onclick="show('security',this)">Security</button>
 <button class="tab" onclick="show('debug',this)">Debug</button>
+<button class="tab" onclick="show('nfc',this)">NFC</button>
 </div>
 
 <div id="dash" class="panel active">
@@ -189,6 +190,15 @@ th{color:#aaa}
 <div id="boot-log"><p style="font-size:0.8em;color:#666">Open this tab to load.</p></div>
 </div>
 
+<div id="nfc" class="panel">
+<h3 style="color:#e94560;font-size:0.95em;margin-bottom:8px">Card Sets</h3>
+<div id="nfc-sets"><p style="font-size:0.8em;color:#666">Loading...</p></div>
+<h3 style="margin-top:16px;color:#e94560;font-size:0.95em;margin-bottom:8px">Provisioning</h3>
+<p style="font-size:0.8em;color:#666">Tag provisioning requires NFC reader hardware. See <a href="https://github.com/mandakan/bodn-esp32/issues/121" style="color:#e94560">#121</a>.</p>
+<h3 style="margin-top:16px;color:#e94560;font-size:0.95em;margin-bottom:8px">UID Cache</h3>
+<div id="nfc-cache"><p style="font-size:0.8em;color:#666">Loading...</p></div>
+</div>
+
 <div id="wifi" class="panel">
 <div class="field"><label>Mode</label><select class="input-field" id="wifi_mode"><option value="ap">Access Point</option><option value="sta">Connect to network</option></select></div>
 <div class="field"><label>SSID</label><input class="input-field" type="text" id="wifi_ssid"></div>
@@ -207,6 +217,7 @@ el.classList.add('active');
 if(id==='history')loadHistory();
 if(id==='stats')loadStats();
 if(id==='debug')loadBootLog();
+if(id==='nfc')loadNFC();
 }
 function updRv(el,id,suf){document.getElementById(id).textContent=el.value+suf}
 function badgeClass(s){
@@ -457,6 +468,32 @@ if(d.hw){var hws=[];for(var k in d.hw){hws.push('<span style="color:'+(d.hw[k]?'
 html+='</tbody></table>';
 el.innerHTML=html;
 }catch(e){el.innerHTML='<p style="font-size:0.8em;color:#e94560">Failed to load boot log.</p>';}
+}
+async function loadNFC(){
+try{
+var r=await fetch('/api/nfc/sets');var sets=await r.json();
+var el=document.getElementById('nfc-sets');
+if(sets.error){el.innerHTML='<p style="color:#e94560">'+sets.error+'</p>';return;}
+if(!sets.length){el.innerHTML='<p style="color:#aaa;font-size:0.8em">No card sets found on SD card.</p>';return;}
+var html='';
+sets.forEach(function(s){
+html+='<div style="background:#16213e;border-radius:8px;padding:10px;margin:6px 0">';
+html+='<strong style="color:#e94560">'+s.mode+'</strong>';
+html+=' <span style="color:#aaa;font-size:0.8em">v'+s.version+' &middot; '+s.card_count+' cards &middot; '+s.dimensions.join(', ')+'</span>';
+html+='</div>';
+});
+el.innerHTML=html;
+}catch(e){document.getElementById('nfc-sets').innerHTML='<p style="color:#e94560;font-size:0.8em">Error loading card sets.</p>';}
+try{
+var cr=await fetch('/api/nfc/cache');var cache=await cr.json();
+var ce=document.getElementById('nfc-cache');
+var keys=Object.keys(cache);
+if(!keys.length){ce.innerHTML='<p style="color:#aaa;font-size:0.8em">Empty (no tags scanned yet).</p>';return;}
+var html='<table style="width:100%;border-collapse:collapse;font-size:0.8em"><thead><tr><th style="text-align:left;padding:4px;color:#aaa">UID</th><th style="text-align:left;padding:4px;color:#aaa">Mode</th><th style="text-align:left;padding:4px;color:#aaa">Card</th></tr></thead><tbody>';
+keys.forEach(function(uid){html+='<tr><td style="font-family:monospace;padding:4px">'+uid+'</td><td style="padding:4px">'+cache[uid].mode+'</td><td style="padding:4px">'+cache[uid].id+'</td></tr>';});
+html+='</tbody></table>';
+ce.innerHTML=html;
+}catch(e){}
 }
 var hnEl=document.getElementById('hostname');
 if(hnEl)hnEl.addEventListener('input',function(){document.getElementById('hostname-preview').textContent=this.value.trim()||'bodn'});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "black>=26.3.1",
+    "cairosvg>=2.7.0",
+    "fpdf2>=2.8.0",
     "mpremote>=1.27.0",
     "pathvalidate>=3.3.1",
     "piper-tts>=1.4.1",

--- a/tests/test_nfc.py
+++ b/tests/test_nfc.py
@@ -1,0 +1,324 @@
+"""Tests for bodn.nfc — tag parsing, encoding, card sets, and UID cache."""
+
+import json
+import os
+import pytest
+from bodn.nfc import (
+    parse_tag_data,
+    encode_tag_data,
+    load_card_set,
+    lookup_card,
+    list_card_sets,
+    UIDCache,
+    NFC_DIR,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tag data parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseTagData:
+    def test_plain_string(self):
+        result = parse_tag_data("BODN:1:sortera:cat_red")
+        assert result == {
+            "prefix": "BODN",
+            "version": 1,
+            "mode": "sortera",
+            "id": "cat_red",
+        }
+
+    def test_ndef_bytes(self):
+        # NDEF Text Record: status=0x02 (UTF-8, lang_len=2), "en", payload
+        payload = b"\x02en" + b"BODN:1:sortera:cat_red"
+        result = parse_tag_data(payload)
+        assert result is not None
+        assert result["mode"] == "sortera"
+        assert result["id"] == "cat_red"
+        assert result["version"] == 1
+
+    def test_wrong_prefix(self):
+        assert parse_tag_data("NOPE:1:sortera:cat_red") is None
+
+    def test_too_few_fields(self):
+        assert parse_tag_data("BODN:1:sortera") is None
+
+    def test_empty_string(self):
+        assert parse_tag_data("") is None
+
+    def test_empty_bytes(self):
+        assert parse_tag_data(b"") is None
+
+    def test_short_ndef_bytes(self):
+        assert parse_tag_data(b"\x02") is None
+
+    def test_admin_tag(self):
+        result = parse_tag_data("BODN:1:admin:unlock")
+        assert result == {
+            "prefix": "BODN",
+            "version": 1,
+            "mode": "admin",
+            "id": "unlock",
+        }
+
+    def test_future_version(self):
+        result = parse_tag_data("BODN:2:future:thing")
+        assert result is not None
+        assert result["version"] == 2
+
+    def test_non_numeric_version(self):
+        assert parse_tag_data("BODN:abc:sortera:cat") is None
+
+
+# ---------------------------------------------------------------------------
+# Tag data encoding
+# ---------------------------------------------------------------------------
+
+
+class TestEncodeTagData:
+    def test_basic_encode(self):
+        data = encode_tag_data("sortera", "cat_red")
+        # Status byte: 0x02 (UTF-8, lang_len=2)
+        assert data[0] == 2
+        # Language code: "en"
+        assert data[1:3] == b"en"
+        # Text payload
+        assert data[3:] == b"BODN:1:sortera:cat_red"
+
+    def test_round_trip(self):
+        original_mode = "sortera"
+        original_id = "dog_green"
+        encoded = encode_tag_data(original_mode, original_id)
+        parsed = parse_tag_data(encoded)
+        assert parsed is not None
+        assert parsed["mode"] == original_mode
+        assert parsed["id"] == original_id
+        assert parsed["version"] == 1
+
+    def test_custom_version(self):
+        data = encode_tag_data("test", "card", version=3)
+        parsed = parse_tag_data(data)
+        assert parsed["version"] == 3
+
+    def test_admin_encode(self):
+        data = encode_tag_data("admin", "unlock")
+        parsed = parse_tag_data(data)
+        assert parsed["mode"] == "admin"
+        assert parsed["id"] == "unlock"
+
+
+# ---------------------------------------------------------------------------
+# Card set loading
+# ---------------------------------------------------------------------------
+
+SAMPLE_CARD_SET = {
+    "mode": "test",
+    "version": 1,
+    "dimensions": ["category"],
+    "cards": [
+        {"id": "cat", "category": "animal", "label_sv": "katt", "label_en": "cat"},
+        {"id": "car", "category": "vehicle", "label_sv": "bil", "label_en": "car"},
+    ],
+}
+
+
+class TestLoadCardSet:
+    def test_loads_valid_json(self, tmp_path, monkeypatch):
+        nfc_dir = tmp_path / "nfc"
+        nfc_dir.mkdir()
+        (nfc_dir / "test.json").write_text(json.dumps(SAMPLE_CARD_SET))
+
+        # Monkeypatch resolve to return our tmp file
+        def fake_resolve(path):
+            return str(nfc_dir / path.split("/")[-1])
+
+        monkeypatch.setattr("bodn.nfc.resolve", fake_resolve, raising=False)
+        # Patch the import inside load_card_set
+        import bodn.nfc as nfc_mod
+
+        # Replace the dynamic import with a direct function patch
+        original = nfc_mod.load_card_set
+
+        def patched_load(mode):
+            path = "{}/{}.json".format(NFC_DIR, mode)
+            resolved = fake_resolve(path)
+            with open(resolved, "r") as f:
+                return json.load(f)
+
+        monkeypatch.setattr(nfc_mod, "load_card_set", patched_load)
+        result = nfc_mod.load_card_set("test")
+        assert result is not None
+        assert result["mode"] == "test"
+        assert len(result["cards"]) == 2
+        # Restore
+        monkeypatch.setattr(nfc_mod, "load_card_set", original)
+
+    def test_missing_file_returns_none(self):
+        result = load_card_set("nonexistent_mode_xyz")
+        assert result is None
+
+
+class TestLookupCard:
+    def test_finds_existing_card(self, tmp_path, monkeypatch):
+        nfc_dir = tmp_path / "nfc"
+        nfc_dir.mkdir()
+        (nfc_dir / "test.json").write_text(json.dumps(SAMPLE_CARD_SET))
+
+        import bodn.nfc as nfc_mod
+
+        def fake_load(mode):
+            path = nfc_dir / "{}.json".format(mode)
+            try:
+                with open(str(path), "r") as f:
+                    return json.load(f)
+            except (OSError, ValueError):
+                return None
+
+        monkeypatch.setattr(nfc_mod, "load_card_set", fake_load)
+        result = nfc_mod.lookup_card("test", "cat")
+        assert result is not None
+        assert result["label_en"] == "cat"
+
+    def test_missing_card_returns_none(self, tmp_path, monkeypatch):
+        nfc_dir = tmp_path / "nfc"
+        nfc_dir.mkdir()
+        (nfc_dir / "test.json").write_text(json.dumps(SAMPLE_CARD_SET))
+
+        import bodn.nfc as nfc_mod
+
+        def fake_load(mode):
+            path = nfc_dir / "{}.json".format(mode)
+            try:
+                with open(str(path), "r") as f:
+                    return json.load(f)
+            except (OSError, ValueError):
+                return None
+
+        monkeypatch.setattr(nfc_mod, "load_card_set", fake_load)
+        result = nfc_mod.lookup_card("test", "nonexistent")
+        assert result is None
+
+    def test_missing_mode_returns_none(self):
+        result = lookup_card("nonexistent_xyz", "cat")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# list_card_sets
+# ---------------------------------------------------------------------------
+
+
+class TestListCardSets:
+    def test_lists_json_files(self, tmp_path, monkeypatch):
+        nfc_dir = tmp_path / "nfc"
+        nfc_dir.mkdir()
+        (nfc_dir / "sortera.json").write_text("{}")
+        (nfc_dir / "saga.json").write_text("{}")
+        (nfc_dir / "readme.txt").write_text("ignore me")
+
+        import bodn.nfc as nfc_mod
+
+        # Patch os.listdir to check our tmp dir first
+        original_listdir = os.listdir
+
+        def fake_listdir(path):
+            if path.endswith("/nfc"):
+                return original_listdir(str(nfc_dir))
+            return original_listdir(path)
+
+        monkeypatch.setattr(os, "listdir", fake_listdir)
+        result = nfc_mod.list_card_sets()
+        assert "saga" in result
+        assert "sortera" in result
+        assert "readme" not in result
+
+    def test_empty_directory(self, tmp_path, monkeypatch):
+        nfc_dir = tmp_path / "nfc"
+        nfc_dir.mkdir()
+
+        import bodn.nfc as nfc_mod
+
+        original_listdir = os.listdir
+
+        def fake_listdir(path):
+            if path.endswith("/nfc"):
+                return original_listdir(str(nfc_dir))
+            return original_listdir(path)
+
+        monkeypatch.setattr(os, "listdir", fake_listdir)
+        result = nfc_mod.list_card_sets()
+        assert result == []
+
+    def test_missing_directory(self, monkeypatch):
+        import bodn.nfc as nfc_mod
+
+        def fake_listdir(path):
+            raise OSError("No such directory")
+
+        monkeypatch.setattr(os, "listdir", fake_listdir)
+        result = nfc_mod.list_card_sets()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# UID cache
+# ---------------------------------------------------------------------------
+
+
+class TestUIDCache:
+    def test_empty_cache(self, tmp_path):
+        cache = UIDCache(path=str(tmp_path / "cache.json"))
+        assert cache.lookup("04:A3:B2:C1") is None
+        assert cache.entries() == {}
+
+    def test_store_and_lookup(self, tmp_path):
+        cache = UIDCache(path=str(tmp_path / "cache.json"))
+        cache.store("04:A3:B2:C1", "sortera", "cat_red")
+        result = cache.lookup("04:A3:B2:C1")
+        assert result == {"mode": "sortera", "id": "cat_red"}
+
+    def test_persistence(self, tmp_path):
+        path = str(tmp_path / "cache.json")
+        cache1 = UIDCache(path=path)
+        cache1.store("04:A3:B2:C1", "sortera", "cat_red")
+
+        # Create a new instance — should load from the file
+        cache2 = UIDCache(path=path)
+        result = cache2.lookup("04:A3:B2:C1")
+        assert result == {"mode": "sortera", "id": "cat_red"}
+
+    def test_multiple_entries(self, tmp_path):
+        cache = UIDCache(path=str(tmp_path / "cache.json"))
+        cache.store("AA:BB:CC:DD", "sortera", "cat_red")
+        cache.store("11:22:33:44", "sortera", "dog_green")
+        assert cache.lookup("AA:BB:CC:DD")["id"] == "cat_red"
+        assert cache.lookup("11:22:33:44")["id"] == "dog_green"
+        assert len(cache.entries()) == 2
+
+    def test_overwrite(self, tmp_path):
+        cache = UIDCache(path=str(tmp_path / "cache.json"))
+        cache.store("AA:BB:CC:DD", "sortera", "cat_red")
+        cache.store("AA:BB:CC:DD", "sortera", "dog_green")
+        assert cache.lookup("AA:BB:CC:DD")["id"] == "dog_green"
+
+    def test_clear(self, tmp_path):
+        path = str(tmp_path / "cache.json")
+        cache = UIDCache(path=path)
+        cache.store("AA:BB:CC:DD", "sortera", "cat_red")
+        cache.clear()
+        assert cache.lookup("AA:BB:CC:DD") is None
+        assert cache.entries() == {}
+        # Verify cleared on disk
+        cache2 = UIDCache(path=path)
+        assert cache2.entries() == {}
+
+    def test_corrupt_file(self, tmp_path):
+        path = tmp_path / "cache.json"
+        path.write_text("this is not valid json {{{")
+        cache = UIDCache(path=str(path))
+        # Should start with empty cache, not crash
+        assert cache.entries() == {}
+        # Should still be usable
+        cache.store("AA:BB:CC:DD", "sortera", "cat_red")
+        assert cache.lookup("AA:BB:CC:DD") is not None

--- a/tools/generate_cards.py
+++ b/tools/generate_cards.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+Generate printable card face PDFs from NFC card set templates.
+
+Reads card set definitions from assets/nfc/{mode}.json, pulls matching
+OpenMoji SVGs by Unicode codepoint, and renders A4 PDF sheets with
+credit-card-sized card faces ready for printing, cutting, and laminating.
+
+Usage:
+  # Generate all card sets (requires OpenMoji SVGs)
+  uv run python tools/generate_cards.py --openmoji ~/openmoji
+
+  # Specific card set only
+  uv run python tools/generate_cards.py --set sortera --openmoji ~/openmoji
+
+  # Custom output directory
+  uv run python tools/generate_cards.py --openmoji ~/openmoji --output build/cards
+
+  # Preview mode (list cards without generating)
+  uv run python tools/generate_cards.py --dry-run
+
+Setup:
+  # Clone OpenMoji SVGs (one-time, ~200 MB)
+  git clone --depth 1 https://github.com/hfg-gmuend/openmoji.git ~/openmoji
+"""
+
+import argparse
+import json
+import sys
+from io import BytesIO
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+ASSETS_DIR = REPO_ROOT / "assets" / "nfc"
+BUILD_DIR = REPO_ROOT / "build" / "cards"
+
+# Card dimensions in mm (credit card size)
+CARD_W = 85
+CARD_H = 54
+
+# A4 page dimensions in mm
+PAGE_W = 210
+PAGE_H = 297
+
+# Layout: 2 columns × 4 rows = 8 cards per page
+COLS = 2
+ROWS = 4
+MARGIN_X = (PAGE_W - COLS * CARD_W) / (COLS + 1)
+MARGIN_Y = (PAGE_H - ROWS * CARD_H) / (ROWS + 1)
+
+# Emoji render size in pixels (rasterised from SVG, then placed in PDF)
+EMOJI_PX = 256
+
+# Colour palette for card backgrounds (soft, child-friendly tones)
+COLOUR_MAP = {
+    "red": (233, 69, 96),
+    "blue": (52, 152, 219),
+    "green": (46, 204, 113),
+    "yellow": (241, 196, 15),
+    "orange": (230, 126, 34),
+    "purple": (155, 89, 182),
+    "pink": (232, 67, 147),
+    "white": (236, 240, 241),
+}
+
+# Default background for cards without a colour dimension
+DEFAULT_BG = (236, 240, 241)
+
+# Border and text colours
+BORDER_COLOUR = (44, 62, 80)
+LABEL_COLOUR = (255, 255, 255)
+ID_COLOUR = (200, 200, 200)
+
+
+def load_card_set(path: Path) -> dict:
+    """Load and validate a card set JSON file."""
+    with open(path) as f:
+        data = json.load(f)
+    if "cards" not in data or "mode" not in data:
+        raise ValueError(f"Invalid card set: missing 'cards' or 'mode' in {path}")
+    return data
+
+
+def find_openmoji_svg(codepoint: str, openmoji_dir: Path) -> Path | None:
+    """Find an OpenMoji SVG file by Unicode codepoint."""
+    svg_path = openmoji_dir / "svg" / "color" / f"{codepoint.upper()}.svg"
+    if svg_path.exists():
+        return svg_path
+    # Try lowercase
+    svg_path = openmoji_dir / "svg" / "color" / f"{codepoint.lower()}.svg"
+    if svg_path.exists():
+        return svg_path
+    return None
+
+
+def render_emoji_png(svg_path: Path, size_px: int) -> bytes:
+    """Rasterise an OpenMoji SVG to PNG bytes at the given size."""
+    import cairosvg
+
+    return cairosvg.svg2png(
+        url=str(svg_path),
+        output_width=size_px,
+        output_height=size_px,
+    )
+
+
+def generate_pdf(card_set: dict, openmoji_dir: Path | None, output_path: Path):
+    """Generate an A4 PDF with card faces laid out in a grid."""
+    from fpdf import FPDF
+
+    cards = card_set["cards"]
+    mode = card_set["mode"]
+
+    pdf = FPDF(orientation="P", unit="mm", format="A4")
+    pdf.set_auto_page_break(auto=False)
+
+    # Embed a clean sans-serif font if available, else use Helvetica
+    pdf.set_font("Helvetica")
+
+    cards_per_page = COLS * ROWS
+    total_pages = (len(cards) + cards_per_page - 1) // cards_per_page
+
+    for page_idx in range(total_pages):
+        pdf.add_page()
+        start = page_idx * cards_per_page
+        page_cards = cards[start : start + cards_per_page]
+
+        for i, card in enumerate(page_cards):
+            col = i % COLS
+            row = i // COLS
+
+            x = MARGIN_X + col * (CARD_W + MARGIN_X)
+            y = MARGIN_Y + row * (CARD_H + MARGIN_Y)
+
+            _draw_card(pdf, card, x, y, mode, openmoji_dir)
+
+    # Footer with attribution
+    pdf.set_y(-15)
+    pdf.set_font("Helvetica", size=6)
+    pdf.set_text_color(150, 150, 150)
+    pdf.cell(
+        0,
+        5,
+        f"Bodn {mode} cards | Icons: OpenMoji (CC-BY-SA 4.0, openmoji.org)",
+        align="C",
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    pdf.output(str(output_path))
+
+
+def _draw_card(pdf, card: dict, x: float, y: float, mode: str, openmoji_dir):
+    """Draw a single card face at the given position."""
+    # Background colour
+    colour = card.get("colour", "")
+    bg = COLOUR_MAP.get(colour, DEFAULT_BG)
+    pdf.set_fill_color(*bg)
+    pdf.rect(x, y, CARD_W, CARD_H, style="F")
+
+    # Border (cutting guide)
+    pdf.set_draw_color(*BORDER_COLOUR)
+    pdf.set_line_width(0.3)
+    pdf.rect(x, y, CARD_W, CARD_H, style="D")
+
+    # Emoji icon
+    icon_codepoint = card.get("icon", "")
+    emoji_placed = False
+    if openmoji_dir and icon_codepoint:
+        svg_path = find_openmoji_svg(icon_codepoint, openmoji_dir)
+        if svg_path:
+            try:
+                png_data = render_emoji_png(svg_path, EMOJI_PX)
+                # Place emoji centred in the upper portion of the card
+                emoji_mm = 28  # display size in mm
+                emoji_x = x + (CARD_W - emoji_mm) / 2
+                emoji_y = y + 3
+                pdf.image(
+                    BytesIO(png_data),
+                    x=emoji_x,
+                    y=emoji_y,
+                    w=emoji_mm,
+                    h=emoji_mm,
+                )
+                emoji_placed = True
+            except Exception as e:
+                print(f"  Warning: failed to render {icon_codepoint}: {e}")
+
+    if not emoji_placed:
+        # Fallback: show codepoint text
+        pdf.set_font("Helvetica", "B", size=24)
+        pdf.set_text_color(*BORDER_COLOUR)
+        pdf.set_xy(x, y + 8)
+        pdf.cell(CARD_W, 20, f"U+{icon_codepoint}", align="C")
+
+    # Swedish label (primary, larger)
+    label_sv = card.get("label_sv", "")
+    label_y = y + 34
+    pdf.set_font("Helvetica", "B", size=14)
+    # Use dark text on light backgrounds, white on dark
+    brightness = bg[0] * 0.299 + bg[1] * 0.587 + bg[2] * 0.114
+    if brightness > 160:
+        pdf.set_text_color(*BORDER_COLOUR)
+    else:
+        pdf.set_text_color(*LABEL_COLOUR)
+    pdf.set_xy(x, label_y)
+    pdf.cell(CARD_W, 7, label_sv, align="C")
+
+    # English label (secondary, smaller)
+    label_en = card.get("label_en", "")
+    pdf.set_font("Helvetica", size=9)
+    pdf.set_xy(x, label_y + 7)
+    pdf.cell(CARD_W, 5, label_en, align="C")
+
+    # Card ID in small text (bottom-right corner, for parent reference)
+    pdf.set_font("Helvetica", size=5)
+    pdf.set_text_color(*(ID_COLOUR if brightness < 160 else (120, 120, 120)))
+    pdf.set_xy(x, y + CARD_H - 6)
+    pdf.cell(CARD_W - 2, 4, card.get("id", ""), align="R")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate printable NFC card face PDFs from card set templates.",
+        epilog=(
+            "OpenMoji SVGs can be obtained by cloning:\n"
+            "  git clone --depth 1 https://github.com/hfg-gmuend/openmoji.git ~/openmoji"
+        ),
+    )
+    parser.add_argument(
+        "--set",
+        help="Generate for a specific card set only (e.g., 'sortera')",
+    )
+    parser.add_argument(
+        "--openmoji",
+        type=Path,
+        default=Path.home() / "openmoji",
+        help="Path to OpenMoji repository (default: ~/openmoji)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=BUILD_DIR,
+        help="Output directory (default: build/cards)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List cards without generating PDFs",
+    )
+    args = parser.parse_args()
+
+    # Find card set files
+    if not ASSETS_DIR.exists():
+        print(f"Error: assets directory not found: {ASSETS_DIR}")
+        sys.exit(1)
+
+    if args.set:
+        json_files = [ASSETS_DIR / f"{args.set}.json"]
+        if not json_files[0].exists():
+            print(f"Error: card set not found: {json_files[0]}")
+            sys.exit(1)
+    else:
+        json_files = sorted(ASSETS_DIR.glob("*.json"))
+
+    if not json_files:
+        print("No card set files found in assets/nfc/")
+        sys.exit(0)
+
+    # Check OpenMoji availability
+    openmoji_dir = args.openmoji if args.openmoji.exists() else None
+    if not openmoji_dir and not args.dry_run:
+        print(f"Warning: OpenMoji directory not found at {args.openmoji}")
+        print("         Cards will show Unicode codepoints instead of emoji.")
+        print(
+            "         To fix: git clone --depth 1 https://github.com/hfg-gmuend/openmoji.git ~/openmoji"
+        )
+        print()
+
+    for json_file in json_files:
+        card_set = load_card_set(json_file)
+        mode = card_set["mode"]
+        cards = card_set["cards"]
+        dims = card_set.get("dimensions", [])
+
+        print(f"\n{mode}: {len(cards)} cards, dimensions: {', '.join(dims)}")
+
+        if args.dry_run:
+            for card in cards:
+                labels = f"{card.get('label_sv', '')} / {card.get('label_en', '')}"
+                colour = card.get("colour", "-")
+                print(
+                    f"  {card['id']:20s}  {labels:20s}  colour={colour:8s}  icon=U+{card.get('icon', '?')}"
+                )
+            continue
+
+        output_path = args.output / f"{mode}_cards.pdf"
+        print(f"  Generating {output_path} ...")
+        generate_pdf(card_set, openmoji_dir, output_path)
+        print(f"  Done: {output_path}")
+
+    if not args.dry_run:
+        print(f"\nAll PDFs saved to {args.output}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/sd-sync.py
+++ b/tools/sd-sync.py
@@ -46,6 +46,7 @@ SD_ASSETS = [
     (BUILD_DIR / "tts_converted", "sounds/tts"),
     (BUILD_DIR / "stories", "stories"),
     (BUILD_DIR / "sprites", "sprites"),
+    (REPO_ROOT / "assets" / "nfc", "nfc"),
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -113,6 +113,8 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "black" },
+    { name = "cairosvg" },
+    { name = "fpdf2" },
     { name = "mpremote" },
     { name = "pathvalidate" },
     { name = "piper-tts" },
@@ -128,6 +130,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", specifier = ">=26.3.1" },
+    { name = "cairosvg", specifier = ">=2.7.0" },
+    { name = "fpdf2", specifier = ">=2.8.0" },
     { name = "mpremote", specifier = ">=1.27.0" },
     { name = "pathvalidate", specifier = ">=3.3.1" },
     { name = "piper-tts", specifier = ">=1.4.1" },
@@ -137,6 +141,34 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "esptool", specifier = ">=5.2.0" }]
+
+[[package]]
+name = "cairocffi"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/c5/1a4dc131459e68a173cbdab5fad6b524f53f9c1ef7861b7698e998b837cc/cairocffi-1.7.1.tar.gz", hash = "sha256:2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b", size = 88096, upload-time = "2024-06-18T10:56:06.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d8/ba13451aa6b745c49536e87b6bf8f629b950e84bd0e8308f7dc6883b67e2/cairocffi-1.7.1-py3-none-any.whl", hash = "sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f", size = 75611, upload-time = "2024-06-18T10:55:59.489Z" },
+]
+
+[[package]]
+name = "cairosvg"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cairocffi" },
+    { name = "cssselect2" },
+    { name = "defusedxml" },
+    { name = "pillow" },
+    { name = "tinycss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/07/e8412a13019b3f737972dea23a2c61ca42becafc16c9338f4ca7a0caa993/cairosvg-2.9.0.tar.gz", hash = "sha256:1debb00cd2da11350d8b6f5ceb739f1b539196d71d5cf5eb7363dbd1bfbc8dc5", size = 40877, upload-time = "2026-03-13T15:42:00.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5011747466414c12cac8a8df77aa235068669a6a5a5df301a96209db6054/cairosvg-2.9.0-py3-none-any.whl", hash = "sha256:4b82d07d145377dffdfc19d9791bd5fb65539bb4da0adecf0bdbd9cd4ffd7c68", size = 45962, upload-time = "2026-03-14T13:56:33.512Z" },
+]
 
 [[package]]
 name = "cffi"
@@ -270,6 +302,28 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "esptool"
 version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -291,6 +345,61 @@ version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.62.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d4/dbacced3953544b9a93088cc10ef2b596d348c983d5c67a404fa41ec51ba/fonttools-4.62.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:90365821debbd7db678809c7491ca4acd1e0779b9624cdc6ddaf1f31992bf974", size = 2870219, upload-time = "2026-03-13T13:52:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9e/a769c8e99b81e5a87ab7e5e7236684de4e96246aae17274e5347d11ebd78/fonttools-4.62.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12859ff0b47dd20f110804c3e0d0970f7b832f561630cd879969011541a464a9", size = 2414891, upload-time = "2026-03-13T13:52:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936", size = 5033197, upload-time = "2026-03-13T13:52:59.179Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392", size = 4988768, upload-time = "2026-03-13T13:53:02.761Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04", size = 4971512, upload-time = "2026-03-13T13:53:05.678Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d", size = 5122723, upload-time = "2026-03-13T13:53:08.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/47/b3a5342d381595ef439adec67848bed561ab7fdb1019fa522e82101b7d9c/fonttools-4.62.1-cp312-cp312-win32.whl", hash = "sha256:a24decd24d60744ee8b4679d38e88b8303d86772053afc29b19d23bb8207803c", size = 2281278, upload-time = "2026-03-13T13:53:10.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b1/0c2ab56a16f409c6c8a68816e6af707827ad5d629634691ff60a52879792/fonttools-4.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e7863e10b3de72376280b515d35b14f5eeed639d1aa7824f4cf06779ec65e42", size = 2331414, upload-time = "2026-03-13T13:53:13.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/56/6f389de21c49555553d6a5aeed5ac9767631497ac836c4f076273d15bd72/fonttools-4.62.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c22b1014017111c401469e3acc5433e6acf6ebcc6aa9efb538a533c800971c79", size = 2865155, upload-time = "2026-03-13T13:53:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c5/0e3966edd5ec668d41dfe418787726752bc07e2f5fd8c8f208615e61fa89/fonttools-4.62.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68959f5fc58ed4599b44aad161c2837477d7f35f5f79402d97439974faebfebe", size = 2412802, upload-time = "2026-03-13T13:53:18.878Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/e6ac4b44026de7786fe46e3bfa0c87e51d5d70a841054065d49cd62bb909/fonttools-4.62.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef46db46c9447103b8f3ff91e8ba009d5fe181b1920a83757a5762551e32bb68", size = 5013926, upload-time = "2026-03-13T13:53:21.379Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1", size = 4964575, upload-time = "2026-03-13T13:53:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/46/76/7d051671e938b1881670528fec69cc4044315edd71a229c7fd712eaa5119/fonttools-4.62.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e7abd2b1e11736f58c1de27819e1955a53267c21732e78243fa2fa2e5c1e069", size = 4953693, upload-time = "2026-03-13T13:53:26.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/b41f8628ec0be3c1b934fc12b84f4576a5c646119db4d3bdd76a217c90b5/fonttools-4.62.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:403d28ce06ebfc547fbcb0cb8b7f7cc2f7a2d3e1a67ba9a34b14632df9e080f9", size = 5094920, upload-time = "2026-03-13T13:53:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/53a1e9469331a23dcc400970a27a4caa3d9f6edbf5baab0260285238b884/fonttools-4.62.1-cp313-cp313-win32.whl", hash = "sha256:93c316e0f5301b2adbe6a5f658634307c096fd5aae60a5b3412e4f3e1728ab24", size = 2279928, upload-time = "2026-03-13T13:53:32.352Z" },
+    { url = "https://files.pythonhosted.org/packages/38/60/35186529de1db3c01f5ad625bde07c1f576305eab6d86bbda4c58445f721/fonttools-4.62.1-cp313-cp313-win_amd64.whl", hash = "sha256:7aa21ff53e28a9c2157acbc44e5b401149d3c9178107130e82d74ceb500e5056", size = 2330514, upload-time = "2026-03-13T13:53:34.991Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f0/2888cdac391807d68d90dcb16ef858ddc1b5309bfc6966195a459dd326e2/fonttools-4.62.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fa1d16210b6b10a826d71bed68dd9ec24a9e218d5a5e2797f37c573e7ec215ca", size = 2864442, upload-time = "2026-03-13T13:53:37.509Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b2/e521803081f8dc35990816b82da6360fa668a21b44da4b53fc9e77efcd62/fonttools-4.62.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aa69d10ed420d8121118e628ad47d86e4caa79ba37f968597b958f6cceab7eca", size = 2410901, upload-time = "2026-03-13T13:53:40.55Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/8c3511ff06e53110039358dbbdc1a65d72157a054638387aa2ada300a8b8/fonttools-4.62.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd13b7999d59c5eb1c2b442eb2d0c427cb517a0b7a1f5798fc5c9e003f5ff782", size = 4999608, upload-time = "2026-03-13T13:53:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/28/63/cd0c3b26afe60995a5295f37c246a93d454023726c3261cfbb3559969bb9/fonttools-4.62.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8d337fdd49a79b0d51c4da87bc38169d21c3abbf0c1aa9367eff5c6656fb6dae", size = 4912726, upload-time = "2026-03-13T13:53:45.405Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b9/ac677cb07c24c685cf34f64e140617d58789d67a3dd524164b63648c6114/fonttools-4.62.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d241cdc4a67b5431c6d7f115fdf63335222414995e3a1df1a41e1182acd4bcc7", size = 4951422, upload-time = "2026-03-13T13:53:48.326Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/10/11c08419a14b85b7ca9a9faca321accccc8842dd9e0b1c8a72908de05945/fonttools-4.62.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c05557a78f8fa514da0f869556eeda40887a8abc77c76ee3f74cf241778afd5a", size = 5060979, upload-time = "2026-03-13T13:53:51.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3c/12eea4a4cf054e7ab058ed5ceada43b46809fce2bf319017c4d63ae55bb4/fonttools-4.62.1-cp314-cp314-win32.whl", hash = "sha256:49a445d2f544ce4a69338694cad575ba97b9a75fff02720da0882d1a73f12800", size = 2283733, upload-time = "2026-03-13T13:53:53.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/67/74b070029043186b5dd13462c958cb7c7f811be0d2e634309d9a1ffb1505/fonttools-4.62.1-cp314-cp314-win_amd64.whl", hash = "sha256:1eecc128c86c552fb963fe846ca4e011b1be053728f798185a1687502f6d398e", size = 2335663, upload-time = "2026-03-13T13:53:56.23Z" },
+    { url = "https://files.pythonhosted.org/packages/42/c5/4d2ed3ca6e33617fc5624467da353337f06e7f637707478903c785bd8e20/fonttools-4.62.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1596aeaddf7f78e21e68293c011316a25267b3effdaccaf4d59bc9159d681b82", size = 2947288, upload-time = "2026-03-13T13:53:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e9/7ab11ddfda48ed0f89b13380e5595ba572619c27077be0b2c447a63ff351/fonttools-4.62.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8f8fca95d3bb3208f59626a4b0ea6e526ee51f5a8ad5d91821c165903e8d9260", size = 2449023, upload-time = "2026-03-13T13:54:01.642Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/10/a800fa090b5e8819942e54e19b55fc7c21fe14a08757c3aa3ca8db358939/fonttools-4.62.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee91628c08e76f77b533d65feb3fbe6d9dad699f95be51cf0d022db94089cdc4", size = 5137599, upload-time = "2026-03-13T13:54:04.495Z" },
+    { url = "https://files.pythonhosted.org/packages/37/dc/8ccd45033fffd74deb6912fa1ca524643f584b94c87a16036855b498a1ed/fonttools-4.62.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f37df1cac61d906e7b836abe356bc2f34c99d4477467755c216b72aa3dc748b", size = 4920933, upload-time = "2026-03-13T13:54:07.557Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/e618adefb839598d25ac8136cd577925d6c513dc0d931d93b8af956210f0/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92bb00a947e666169c99b43753c4305fc95a890a60ef3aeb2a6963e07902cc87", size = 5016232, upload-time = "2026-03-13T13:54:10.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5f/9b5c9bfaa8ec82def8d8168c4f13615990d6ce5996fe52bd49bfb5e05134/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bdfe592802ef939a0e33106ea4a318eeb17822c7ee168c290273cbd5fabd746c", size = 5042987, upload-time = "2026-03-13T13:54:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/90/aa/dfbbe24c6a6afc5c203d90cc0343e24bcbb09e76d67c4d6eef8c2558d7ba/fonttools-4.62.1-cp314-cp314t-win32.whl", hash = "sha256:b820fcb92d4655513d8402d5b219f94481c4443d825b4372c75a2072aa4b357a", size = 2348021, upload-time = "2026-03-13T13:54:16.98Z" },
+    { url = "https://files.pythonhosted.org/packages/13/6f/ae9c4e4dd417948407b680855c2c7790efb52add6009aaecff1e3bc50e8e/fonttools-4.62.1-cp314-cp314t-win_amd64.whl", hash = "sha256:59b372b4f0e113d3746b88985f1c796e7bf830dd54b28374cd85c2b8acd7583e", size = 2414147, upload-time = "2026-03-13T13:54:19.416Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[[package]]
+name = "fpdf2"
+version = "2.8.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "fonttools" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/f2/72feae0b2827ed38013e4307b14f95bf0b3d124adfef4d38a7d57533f7be/fpdf2-2.8.7.tar.gz", hash = "sha256:7060ccee5a9c7ab0a271fb765a36a23639f83ef8996c34e3d46af0a17ede57f9", size = 362351, upload-time = "2026-02-28T05:39:16.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/0a/cf50ecffa1e3747ed9380a3adfc829259f1f86b3fdbd9e505af789003141/fpdf2-2.8.7-py3-none-any.whl", hash = "sha256:d391fc508a3ce02fc43a577c830cda4fe6f37646f2d143d489839940932fbc19", size = 327056, upload-time = "2026-02-28T05:39:14.619Z" },
 ]
 
 [[package]]
@@ -482,6 +591,75 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
 ]
 
 [[package]]
@@ -760,4 +938,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/63/60220fb502beb857306afd4a5bac4a8617ae496f3b1f4968d127380fdefe/tibs-0.5.7-cp38-abi3-win32.whl", hash = "sha256:d4f3ff613d486650816bc5516760c0382a2cc0ca8aeddd8914d011bc3b81d9a2", size = 288454, upload-time = "2026-03-12T13:06:30.978Z" },
     { url = "https://files.pythonhosted.org/packages/46/ab/aab78827ba7e0d65fe346b86d1d61e0792c38d5f9b7547e0f71b7027c835/tibs-0.5.7-cp38-abi3-win_amd64.whl", hash = "sha256:a61d36155f8ab8642e1b6744e13822f72050fc7ec4f86ec6965295afa04949e2", size = 304135, upload-time = "2026-03-12T13:06:35.884Z" },
     { url = "https://files.pythonhosted.org/packages/48/59/e9e6a610928a4bcbf04f0ac1436ee320aa8cbe95181f1aa32687c50e858b/tibs-0.5.7-cp38-abi3-win_arm64.whl", hash = "sha256:130bc68ff500fc8185677df7a97350b5d5339e6ba7e325bc3031337f6424ede7", size = 289272, upload-time = "2026-03-12T13:06:19.247Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]


### PR DESCRIPTION
## Summary

- Implement the full NFC data layer (tag format, card sets, UID cache, reader stub) independent of PN532 hardware
- Create a printable card face PDF generator using OpenMoji icons
- Add web UI tab and on-device screen for NFC card set management
- 29 unit tests covering parse/encode/cache/card set operations

## Key design decisions

- **Self-describing tags**: NDEF Text Records (`BODN:1:sortera:cat_red`) so cards are portable between devices and readable by phones
- **Card sets as data**: JSON templates on SD card — adding a new card set requires no code changes
- **UID cache**: performance-only optimization on flash, auto-rebuilt from tag data on miss
- **OpenMoji icons**: CC-BY-SA 4.0, consistent picture-book aesthetic for both printed cards and future on-screen use (#124)

## New files

| File | Purpose |
|------|---------|
| `firmware/bodn/nfc.py` | Tag parser/encoder, card set loader, UID cache, NFCReader stub |
| `firmware/bodn/ui/nfc_provision.py` | On-device card set viewer + provisioning shell |
| `assets/nfc/sortera.json` | 16-card starter deck (8 animals × 2 colours) |
| `tools/generate_cards.py` | OpenMoji SVG → A4 PDF card face generator |
| `tests/test_nfc.py` | 29 unit tests |
| `docs/nfc.md` | Tag format spec, card set schema, provisioning workflow |

## Modified files

- `firmware/bodn/web.py` — 3 new API endpoints (`/api/nfc/sets`, `/api/nfc/set/{mode}`, `/api/nfc/cache`)
- `firmware/bodn/web_ui.py` — NFC tab with card set listing and UID cache display
- `firmware/bodn/ui/settings.py` — NFC provisioning entry in settings menu
- `firmware/bodn/lang/sv.py`, `en.py` — `settings_nfc` i18n key
- `tools/sd-sync.py` — `assets/nfc/` → `/sd/nfc/` sync
- `pyproject.toml` — `cairosvg` + `fpdf2` dependencies
- `CLAUDE.md` — updated repo layout and common commands

## Test plan

- [x] `uv run pytest` — 664 tests pass (29 new NFC tests)
- [x] `uv run ruff check firmware/` — no lint errors
- [x] `uv run python tools/generate_cards.py --dry-run` — lists all 16 cards
- [x] `uv run python tools/generate_cards.py` — generates PDF (fallback mode without OpenMoji)
- [ ] Verify web UI NFC tab on device
- [ ] Verify settings menu NFC entry on device

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)