### PR TITLE
feat: filter Sortera cards by programmed NFC tags

### DIFF
--- a/firmware/bodn/ui/sortera.py
+++ b/firmware/bodn/ui/sortera.py
@@ -89,6 +89,40 @@ _CATEGORY_KEYS = {
 }
 
 
+def _filter_by_cache(card_set, cache):
+    """Filter a card set to only cards with programmed NFC tags.
+
+    If the cache has no sortera entries, returns the full card set
+    unchanged (assume demo/first-time use).  Otherwise, keeps only
+    cards whose IDs appear in the cache, and prunes dimensions that
+    no longer have at least 2 distinct values.
+    """
+    known_ids = set()
+    for entry in cache.entries().values():
+        if entry.get("mode") == "sortera":
+            known_ids.add(entry["id"])
+
+    if not known_ids:
+        return card_set
+
+    cards = [c for c in card_set.get("cards", []) if c["id"] in known_ids]
+    if not cards:
+        return card_set
+
+    # Prune dimensions: keep only those with 2+ distinct values
+    dims = []
+    for dim in card_set.get("dimensions", []):
+        values = set()
+        for card in cards:
+            val = card.get(dim)
+            if val is not None:
+                values.add(val)
+        if len(values) >= 2:
+            dims.append(dim)
+
+    return {"mode": card_set.get("mode", "sortera"), "dimensions": dims, "cards": cards}
+
+
 def _card_bilingual_label(card):
     """Build a dual-language label from a card dict, e.g. 'Katt / Cat'."""
     if card is None:
@@ -152,7 +186,7 @@ class SorteraScreen(Screen):
         self._full_clear = True
 
         # Load card set and create engine
-        from bodn.nfc import load_card_set
+        from bodn.nfc import load_card_set, UIDCache
 
         card_set = load_card_set("sortera")
         if card_set is None:
@@ -170,6 +204,9 @@ class SorteraScreen(Screen):
                     for c in DEMO_CARDS
                 ],
             }
+        else:
+            # Filter card set to only include physically programmed tags
+            card_set = _filter_by_cache(card_set, UIDCache())
         self._engine = SorteraEngine(card_set)
         self._pending_card_id = None
 

--- a/tests/test_sortera_rules.py
+++ b/tests/test_sortera_rules.py
@@ -16,6 +16,7 @@ from bodn.sortera_rules import (
     SWITCH_MS,
     DEMO_CARDS,
 )
+from bodn.ui.sortera import _filter_by_cache
 
 SAMPLE_CARD_SET = {
     "mode": "sortera",
@@ -306,3 +307,68 @@ class TestLEDs:
         buf = engine.make_static_leds(100)
         # Should have some non-zero LEDs (rule colour)
         assert any(t != (0, 0, 0) for t in buf)
+
+
+class _FakeCache:
+    """Minimal stand-in for nfc.UIDCache with pre-loaded entries."""
+
+    def __init__(self, entries):
+        self._entries = entries
+
+    def entries(self):
+        return dict(self._entries)
+
+
+class TestFilterByCache:
+    def test_empty_cache_returns_full_set(self):
+        result = _filter_by_cache(SAMPLE_CARD_SET, _FakeCache({}))
+        assert result is SAMPLE_CARD_SET
+
+    def test_filters_to_known_cards(self):
+        cache = _FakeCache(
+            {
+                "AA:BB": {"mode": "sortera", "id": "cat_red"},
+                "CC:DD": {"mode": "sortera", "id": "dog_green"},
+            }
+        )
+        result = _filter_by_cache(SAMPLE_CARD_SET, cache)
+        ids = {c["id"] for c in result["cards"]}
+        assert ids == {"cat_red", "dog_green"}
+
+    def test_prunes_dimensions_with_single_value(self):
+        # Both cards are animals — "vehicle" dimension should be pruned
+        cache = _FakeCache(
+            {
+                "AA:BB": {"mode": "sortera", "id": "cat_red"},
+                "CC:DD": {"mode": "sortera", "id": "dog_green"},
+            }
+        )
+        result = _filter_by_cache(SAMPLE_CARD_SET, cache)
+        assert "vehicle" not in result["dimensions"]
+        assert "animal" in result["dimensions"]
+        assert "colour" in result["dimensions"]
+
+    def test_keeps_dimensions_with_two_values(self):
+        cache = _FakeCache(
+            {
+                "AA:BB": {"mode": "sortera", "id": "cat_red"},
+                "CC:DD": {"mode": "sortera", "id": "car_blue"},
+            }
+        )
+        result = _filter_by_cache(SAMPLE_CARD_SET, cache)
+        # category has "animal" + "vehicle" → kept
+        assert "category" in result["dimensions"]
+        assert "colour" in result["dimensions"]
+
+    def test_ignores_non_sortera_cache_entries(self):
+        cache = _FakeCache(
+            {
+                "AA:BB": {"mode": "simon", "id": "start"},
+                "CC:DD": {"mode": "sortera", "id": "cat_red"},
+                "EE:FF": {"mode": "sortera", "id": "dog_green"},
+            }
+        )
+        result = _filter_by_cache(SAMPLE_CARD_SET, cache)
+        ids = {c["id"] for c in result["cards"]}
+        assert "start" not in ids
+        assert ids == {"cat_red", "dog_green"}


### PR DESCRIPTION
## Summary
- On each game start, reads the UID cache to find which sortera NFC tags have been physically programmed
- Filters the card set to only include those cards, and prunes dimensions with fewer than 2 distinct values (e.g. no "find the cars" rule when only animal tags exist)
- Falls back to the full card set if the cache is empty (fresh flash / first use)
- Re-checked on every `enter()` so newly programmed tags are picked up without a reboot

## Test plan
- [x] Unit tests for `_filter_by_cache`: empty cache, partial cards, dimension pruning, non-sortera entries ignored
- [ ] On-device: start Sortera with only animal tags programmed → verify no vehicle/category rules appear
- [ ] Program a vehicle tag, re-enter Sortera → verify vehicle dimensions now included

🤖 Generated with [Claude Code](https://claude.com/claude-code)