### PR TITLE
docs: refresh README to cover recent modes, NFC, C modules, and TTS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 - **Language**: MicroPython on ESP32-S3. No C/C++ unless absolutely required.
 - **Style**: keep modules small and self-contained. Prefer clarity over cleverness.
 - **Hardware**: check `firmware/bodn/config.py` before assigning pins. Non-time-critical I/O (buttons, toggles, status LEDs) should use the MCP23017 I2C expanders; latency-sensitive peripherals (encoder CLK/DT, SPI, I2S) stay on native GPIOs. See `docs/hardware.md` for reserved pins and the GPIO budget.
-- **SD card**: media assets (sound banks, arcade sounds, music, game-mode TTS, space SFX) live on `/sd/`. Only critical audio (UI SFX, battery/goodnight TTS) stays on flash. Use `from bodn.assets import resolve` to look up any asset path — it checks SD first, falls back to flash transparently. `tools/convert_audio.py` routes SD-bound output to `build/sounds/`; `tools/sd-sync.py` copies it to the card. See `docs/assets.md` for the directory structure. The SD card is mounted at boot; the device runs normally without one (soundboard falls back gracefully).
+- **SD card**: media assets (sound banks, arcade sounds, music, game-mode TTS, space SFX, story packages, hand-recorded voices) live on `/sd/`. Only critical audio (UI SFX, battery/goodnight TTS) stays on flash. Use `from bodn.assets import resolve` to look up any asset path — it checks SD first, falls back to flash transparently. `tools/convert_audio.py` routes SD-bound output to `build/sounds/`; `tools/sd-sync.py` copies it to the card. See `docs/assets.md` for the directory structure. The SD card is mounted at boot; the device runs normally without one (soundboard falls back gracefully).
 - **Testing**: pure logic modules (debounce, UI state, audio format) are tested with `pytest` on the host. Hardware wrappers are tested on-device via `mpremote` or in Wokwi. MicroPython compatibility tests (`tests/test_micropython_compat.py`) import firmware modules under the real MicroPython Unix port to catch CPython-only APIs (e.g. `str.capitalize()`) before they reach the device. These tests are skipped if the Unix port binary hasn't been built — see "MicroPython Unix port" below for setup.
 - **MicroPython portability**: MicroPython `str` lacks `.capitalize()`, `.title()`, `.swapcase()`, and `.casefold()`. Use `from bodn.i18n import capitalize` instead. The compat tests catch this automatically.
 - **Dependencies**: host tools are managed with `uv`. MicroPython libs go directly into `firmware/`.
@@ -80,12 +80,15 @@ Constraints: ≤ 1500 SEK budget, modular & hackable, open source from day one.
 bodn-esp32/
 ├─ firmware/
 │  ├─ boot.py              # WiFi setup, NTP sync, battery check, boot screen
-│  ├─ main.py              # async entry point (uasyncio)
+│  ├─ main.py              # async entry point (uasyncio) + housekeeping/thermal task
+│  ├─ sdcard.py            # SPI SD card driver (native-optimised for audio streaming)
 │  ├─ st7735.py            # framebuf-based ST7735/ILI9341 driver (DMA or blocking SPI)
 │  └─ bodn/
 │     ├─ __init__.py
 │     ├─ arcade.py          # arcade button input + LED output via MCP/PCA
+│     ├─ assets.py          # SD-first / flash-fallback asset path resolver
 │     ├─ audio.py           # AudioEngine (native core-0 C mixer or fallback viper)
+│     ├─ battery.py         # battery level reading and USB-only detection
 │     ├─ chord.py           # multi-button chord/combo detection
 │     ├─ cli.py             # serial REPL helpers (wifi, settings, reboot)
 │     ├─ config.py          # pin assignments, constants, encoder sensitivity
@@ -94,27 +97,42 @@ bodn-esp32/
 │     ├─ encoder.py         # PCNT hardware rotary encoder (zero-CPU quadrature)
 │     ├─ encoder_scope.py   # visual encoder oscilloscope (CLK/DT on TFT)
 │     ├─ flode_rules.py     # Flöde puzzle engine (pure logic)
+│     ├─ ftp.py             # FTP server for OTA bulk sync
 │     ├─ gesture.py         # tap/hold/long-press gesture detection
+│     ├─ highfive_rules.py  # High-Five Friends reflex game engine (pure logic)
 │     ├─ i2c_diag.py        # live I2C bus diagnostic tool (REPL)
 │     ├─ i18n.py            # internationalisation: t(), set_language(), init()
 │     ├─ lang/
 │     │  ├─ sv.py           # Swedish string table (default)
 │     │  └─ en.py           # English string table
+│     ├─ life_presets.py    # curated Game of Life seed patterns
 │     ├─ life_rules.py      # Game of Life cellular automata (pure logic)
 │     ├─ mcp23017.py        # MCP23017 I2C GPIO expander driver
 │     ├─ mystery_rules.py   # Mystery Box rule engine (pure logic)
-│     ├─ nfc.py             # NFC tag parsing, card sets, UID cache, reader stub
+│     ├─ native_i2c.py      # native C I2C wrapper for deterministic scans
+│     ├─ neo.py             # NeoPixel facade over the native _neopixel C engine
+│     ├─ nfc.py             # NFC tag parsing, NDEF records, card sets, UID cache
 │     ├─ patterns.py        # LED animation patterns (shared buffer)
-│     ├─ pca9685.py         # PCA9685 I2C PWM driver
+│     ├─ pca9685.py         # PCA9685 I2C PWM driver (arcade button LEDs)
+│     ├─ pn532.py           # PN532 NFC reader driver (I2C, polling task)
 │     ├─ power.py           # power management (sleep, wake, master switch)
 │     ├─ qr.py              # minimal QR code encoder (V1-V2)
+│     ├─ rakna_rules.py     # Räkna math game engine (levels 1–6, pure logic)
 │     ├─ rulefollow_rules.py # Rule Follow game engine (pure logic)
+│     ├─ sdcard.py          # SD card initialisation and mount
+│     ├─ sequencer_rules.py # loop Sequencer timing and step model (pure logic)
 │     ├─ session.py         # play session state machine (pure logic)
 │     ├─ simon_rules.py     # Simon game engine (pure logic)
 │     ├─ sortera_rules.py   # Sortera classification game engine (pure logic)
+│     ├─ soundboard_rules.py # Soundboard bank/slot model (pure logic)
+│     ├─ sounds.py          # sound asset catalogue
+│     ├─ space_rules.py     # Spaceship cockpit state machine (pure logic)
 │     ├─ storage.py         # JSON settings & session history on flash
+│     ├─ stories/           # story package — scripts discovered at runtime on SD
+│     ├─ story_rules.py     # story graph validation + traversal (pure logic)
 │     ├─ temperature.py     # DS18B20 + SoC temperature monitoring
 │     ├─ tones.py           # procedural tone generation (pure logic)
+│     ├─ tts.py             # TTS playback helper (SD-first voice resolution)
 │     ├─ wav.py             # WAV header parser + streaming reader (pure logic)
 │     ├─ wifi.py            # WiFi connect (STA / AP) + mDNS + runtime control
 │     ├─ web.py             # async HTTP server for parental controls
@@ -122,51 +140,74 @@ bodn-esp32/
 │     └─ ui/
 │        ├─ admin_qr.py     # admin URL screen with QR code
 │        ├─ ambient.py      # AmbientClock (content) + StatusStrip (status)
+│        ├─ android.py      # boot-time Android-style status bar helper
 │        ├─ catface.py      # cat face with emotions (secondary content)
 │        ├─ clock.py        # clock display mode
 │        ├─ demo.py         # LED playground mode
 │        ├─ diag.py         # on-device diagnostics screen
+│        ├─ draw.py         # wrapper around the native _draw C module
 │        ├─ flode.py        # Flöde flow alignment puzzle
 │        ├─ font_ext.py     # 8×8 bitmap glyphs for å ä ö Å Ä Ö
 │        ├─ garden.py       # Garden of Life (cellular automata)
 │        ├─ garden_secondary.py # Garden secondary display content
+│        ├─ highfive.py     # High-Five Friends reflex game screen
 │        ├─ home.py         # home screen with carousel mode selection
-│        ├─ icons.py        # 16×16 bitmap icons
+│        ├─ icon_browser.py # OpenMoji emoji sprite browser (settings)
+│        ├─ icons.py        # 16×16 bitmap icons (flash fallback)
 │        ├─ input.py        # unified input state with debouncing
 │        ├─ logo.py         # pixel art boot logo (Norse mead vessel)
 │        ├─ mystery.py      # Mystery Box discovery game
-│        ├─ nfc_provision.py # NFC card set viewer + provisioning (stub)
-│        ├─ icon_browser.py # OpenMoji emoji sprite browser (settings)
+│        ├─ nfc_provision.py # NFC card set viewer + tag programming
 │        ├─ overlay.py      # session state overlay
 │        ├─ pause.py        # in-game pause menu (hold-to-open)
+│        ├─ rakna.py        # Räkna NFC math game screen
 │        ├─ rulefollow.py   # Rule Follow game screen
 │        ├─ screen.py       # Screen base class + ScreenManager
 │        ├─ secondary.py    # two-zone secondary display manager
+│        ├─ sequencer.py    # loop Sequencer mode
+│        ├─ sequencer_secondary.py # Sequencer secondary display content
 │        ├─ settings.py     # on-device settings menu (scrollable)
 │        ├─ simon.py        # Simon memory game screen
 │        ├─ sortera.py      # Sortera NFC classification game
+│        ├─ soundboard.py   # Soundboard discovery mode
+│        ├─ soundboard_secondary.py # Soundboard secondary display content
+│        ├─ space.py        # Spaceship cockpit mode
+│        ├─ story.py        # branching story mode (scripts + TTS on SD)
 │        ├─ theme.py        # colour palette and layout constants
-│        └─ widgets.py      # stateless draw helpers
+│        └─ widgets.py      # stateless draw helpers + sprite cache
 ├─ docs/
+│  ├─ assets.md             # SD/flash asset layout and resolver rules
 │  ├─ audio.md              # audio file preparation guide
+│  ├─ audio_assets.md       # sound asset pipeline, drum kits, recordings
+│  ├─ getting-started.md    # first-boot walkthrough (flashing, serial, debugging)
 │  ├─ hardware.md           # BOM, board notes, pin assignments
-│  ├─ wiring.md             # auto-generated pin diagram and tables
-│  ├─ UX_GUIDELINES.md      # child-facing interaction design
-│  ├─ PERFORMANCE_GUIDELINES.md  # ESP32 performance rules
 │  ├─ nfc.md                # NFC tag format, card sets, provisioning
-│  └─ roadmap.md            # milestones and progress
+│  ├─ PERFORMANCE_GUIDELINES.md  # ESP32 performance rules
+│  ├─ protoboard_layout.md  # hand-wired protoboard reference
+│  ├─ roadmap.md            # milestones and progress
+│  ├─ schematics/           # reference images for DevKit, GPIO, power supply
+│  ├─ science/              # development matrix, guide, report.tex/pdf/bib
+│  ├─ soundboard.md         # soundboard bank layout and manifest
+│  ├─ story_authoring.md    # branching story authoring guide
+│  ├─ UX_GUIDELINES.md      # child-facing interaction design
+│  └─ wiring.md             # auto-generated pin diagram and tables
 ├─ tools/
 │  ├─ pinout.py             # generate wiring docs from config.py
 │  ├─ sync.sh               # deploy firmware to device via mpremote
 │  ├─ wokwi-sync.py         # deploy firmware to Wokwi simulator (raw TCP)
+│  ├─ wokwi-push.py         # push a single file into a running Wokwi sim
 │  ├─ ota-push.py           # push firmware over WiFi via HTTP (no USB needed)
 │  ├─ ftp-sync.py           # push firmware over WiFi via FTP (faster, STA mode only)
-│  ├─ build-firmware.sh      # build custom MicroPython firmware with C modules
-│  ├─ generate_story_tts.py  # generate story narration TTS from story scripts
-│  ├─ story_preview.py      # preview story scripts in terminal
+│  ├─ build-firmware.sh     # build custom MicroPython firmware with C modules
+│  ├─ generate_tts.py       # generate i18n TTS WAVs from STRINGS dicts
+│  ├─ generate_story_tts.py # generate story narration TTS from story scripts
+│  ├─ convert_audio.py      # convert all audio sources to device format
+│  ├─ story_preview.py      # preview story scripts in terminal / browser
 │  ├─ sd-sync.py            # build + sync SD card assets (TTS, sounds, etc.)
 │  ├─ generate_cards.py     # NFC card face PDF generator (OpenMoji → A4 PDF)
-│  └─ convert_icons.py      # OpenMoji SVG → BDF sprite conversion for on-screen icons
+│  ├─ convert_icons.py      # OpenMoji SVG → BDF sprite conversion for on-screen icons
+│  ├─ import_freesound.py   # import and licence-track Freesound.org samples
+│  └─ make_asset.py         # rasterise SVG sources into 4bpp BDF sprites
 ├─ cmodules/                  # native C extensions (compiled into firmware)
 │  ├─ micropython.cmake       # top-level cmake: includes sub-modules
 │  ├─ audiomix/               # native audio mixer (_audiomix module, core 0)
@@ -175,9 +216,26 @@ bodn-esp32/
 │  │  ├─ mixer.c/h            # FreeRTOS task: mix loop + I2S + step clock on core 0
 │  │  ├─ ringbuf.c/h          # lock-free SPSC ring buffer
 │  │  └─ tonegen.c/h          # sine/square/sawtooth/noise generators
-│  └─ spidma/                 # DMA SPI display driver (_spidma module, ISR-driven)
+│  ├─ spidma/                 # DMA SPI display driver (_spidma module, ISR-driven)
+│  │  ├─ micropython.cmake    # per-module cmake (INTERFACE lib)
+│  │  └─ spidma.c/h           # Python bindings + ESP-IDF spi_master DMA
+│  ├─ draw/                   # bitmap fonts, sprite blit, primitives (_draw module)
+│  │  ├─ micropython.cmake    # per-module cmake (INTERFACE lib)
+│  │  ├─ draw.c/h             # Python bindings
+│  │  ├─ primitives.c/h       # fill_rect, hline/vline, blit helpers
+│  │  ├─ blit.c/h             # sprite blit with optional alpha
+│  │  ├─ decode.c/h           # BDF sprite decoder (1/2/4/8 bpp)
+│  │  ├─ font_render.c/h      # bitmap font rasteriser
+│  │  └─ fonts/               # compiled BDF font headers
+│  ├─ mcpinput/               # deterministic MCP23017 input scanner (_mcpinput)
+│  │  ├─ micropython.cmake    # per-module cmake (INTERFACE lib)
+│  │  ├─ mcpinput.c/h         # Python bindings + core 1 scan task
+│  │  └─ scanner.c/h          # I2C read loop + edge detection
+│  └─ neopixel/               # NeoPixel pattern engine (_neopixel module)
 │     ├─ micropython.cmake    # per-module cmake (INTERFACE lib)
-│     └─ spidma.c/h           # Python bindings + ESP-IDF spi_master DMA
+│     ├─ neopixel_mod.c/h     # Python bindings
+│     ├─ engine.c/h           # animation engine (tick, blend, frame buffer)
+│     └─ patterns.c/h         # built-in animations (breathe, chase, rainbow, …)
 ├─ boards/
 │  └─ BODN_S3/                # custom board definition (external to MicroPython tree)
 │     ├─ mpconfigboard.cmake  # sdkconfig layering (spiram_oct, I2S IRAM-safe)
@@ -235,8 +293,8 @@ uv run pytest
 make -C micropython/mpy-cross                     # build the cross-compiler
 make -C micropython/ports/unix submodules          # init Unix port dependencies
 make -C micropython/ports/unix                     # build the Unix port binary
-# After building, `uv run pytest` automatically includes 26 MicroPython
-# import-compatibility tests. If the binary isn't built, they skip gracefully.
+# After building, `uv run pytest` automatically includes the MicroPython
+# import-compatibility suite. If the binary isn't built, they skip gracefully.
 
 # Parental controls web UI
 # On real hardware: connect to Bodn AP, open http://192.168.4.1
@@ -264,7 +322,7 @@ uv run python tools/generate_story_tts.py --dry-run  # preview
 uv run python tools/generate_story_tts.py --story peter_rabbit  # single story
 uv run python tools/convert_audio.py              # convert all audio to device format
 
-# Custom firmware build (optional — enables native C audio mixer on core 1)
+# Custom firmware build (optional — enables native C audio mixer on core 0)
 # One-time setup:
 #   git submodule add https://github.com/micropython/micropython.git micropython
 #   cd micropython && git checkout v1.27.0 && cd ..
@@ -274,9 +332,13 @@ source ~/esp-idf/export.sh                        # once per terminal session
 ./tools/build-firmware.sh                          # build firmware
 ./tools/build-firmware.sh flash                    # build + flash
 ./tools/build-firmware.sh clean                    # clean build directory
-# The custom firmware is stock MicroPython + _audiomix + _spidma C modules.
-# If _audiomix is not available, AudioEngine falls back to the viper/IRQ path.
-# If _spidma is not available, display writes fall back to blocking machine.SPI.
+# The custom firmware is stock MicroPython + _audiomix, _spidma, _draw,
+# _mcpinput, and _neopixel C modules. Each has a Python fallback:
+#   _audiomix  → AudioEngine falls back to the viper/IRQ path
+#   _spidma    → display writes fall back to blocking machine.SPI
+#   _draw      → bodn.ui.draw falls back to pure-Python framebuf helpers
+#   _mcpinput  → MCP23017 input scanned on the main loop
+#   _neopixel  → bodn.neo falls back to the built-in neopixel module
 
 # SD card asset sync (build + copy in one step — runs all 3 steps above)
 uv run python tools/sd-sync.py                    # auto-detect BODN* SD card on macOS
@@ -327,7 +389,17 @@ Hooks live in `.githooks/` and are activated with `git config core.hooksPath .gi
 
 ## Roadmap
 
-1. **Hardware bring-up** — ST7735 displaying text/graphics; buttons & encoders with debouncing.
-2. **Audio basics** — play tones/samples via MAX98357A; record/playback short clips from INMP441.
-3. **Kid-facing UI** — home screen with icons; modes for sounds, recording, and sequencing.
-4. **Quality-of-life** — battery level indicator; serial/WiFi config; simple web UI for adults.
+See [`docs/roadmap.md`](docs/roadmap.md) for the authoritative milestone
+breakdown. Status at a glance:
+
+1. **Hardware bring-up** — complete (dual displays, inputs, LEDs, thermal).
+2. **Audio basics** — complete (16-voice native C mixer, TTS, hand-recordings).
+   Record/replay from INMP441 still outstanding.
+3. **Kid-facing UI** — 12 game modes shipped (Mystery, Simon, Flöde, Rule
+   Follow, Garden, Soundboard, Sequencer, High-Five, Space, Story, Sortera,
+   Räkna). Record & replay still planned.
+4. **Parental controls** — complete (web UI, session limits, PIN, OTA, FTP).
+5. **Quality-of-life** — complete (battery, thermal, diagnostics, SD card,
+   asset resolver, custom firmware build, boot-log persistence).
+6. **NFC card games** — PN532 driver + provisioning UI shipped; Sortera,
+   Räkna, and launcher card sets live. More card sets planned.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ mythology — the drink that granted wisdom and poetic inspiration.
 A colourful, tactile device that grows with a child (starting around age 4):
 
 - **Press buttons and turn knobs** → hear sounds, see colours and animations
-- **Play games** → Simon memory game, Mystery Box discovery, Flöde flow puzzles, Rule Follow, Garden of Life, Soundboard, Spaceship cockpit, Story Mode, High-Five Friends, Sequencer
-- **NFC card games** *(planned)* → scan physical cards to sort, count, build stories, and learn (PN532 reader + NTAG213 stickers)
+- **Play games** → Simon memory, Mystery Box discovery, Flöde flow puzzles, Rule Follow, Garden of Life, Soundboard, Spaceship cockpit, Story Mode, High-Five Friends, Sequencer
+- **NFC card games** → scan physical cards for Sortera (classification) and Räkna (math); launcher cards start any game mode (PN532 reader + NTAG213 stickers)
+- **Offline spoken audio** → Piper TTS generates Swedish and English narration for game instructions and stories; hand-recorded WAVs can transparently override any line
 - **Parental controls** → session time limits, break enforcement, quiet hours, lockdown — all configured from a phone via a local web UI
 
 ## Hardware
@@ -41,57 +42,79 @@ Written in MicroPython, runs directly on the ESP32-S3.
 ```
 firmware/
   boot.py              # WiFi setup, NTP sync, battery check, boot screen
-  main.py              # async entry point (uasyncio)
+  main.py              # async entry point (uasyncio) + housekeeping/thermal task
+  sdcard.py            # SPI SD card driver (optimised for ESP32-S3 audio streaming)
   st7735.py            # framebuf-based ST7735/ILI9341 driver + dirty rect tracking
   bodn/
-    config.py           # pin assignments, constants, encoder sensitivity
     arcade.py           # arcade button input + LED output via MCP/PCA
-    audio.py            # async AudioEngine (multi-channel priority playback)
+    assets.py           # SD-first / flash-fallback asset path resolver
+    audio.py            # AudioEngine (native core-0 C mixer, falls back to viper)
     battery.py          # battery level reading and USB-only detection
     chord.py            # multi-button chord/combo detection
     cli.py              # serial REPL helpers (wifi, settings, reboot)
+    config.py           # pin assignments, constants, encoder sensitivity
     debounce.py         # generic debounce logic
     diag.py             # system diagnostics data gathering
     encoder.py          # PCNT hardware rotary encoder (zero-CPU quadrature)
+    encoder_scope.py    # visual encoder oscilloscope (CLK/DT on TFT)
     ftp.py              # FTP server for OTA bulk sync
     gesture.py          # tap/hold/long-press gesture detection
     i18n.py             # internationalisation: t(), set_language(), init()
+    i2c_diag.py         # live I2C bus diagnostic tool (REPL)
     lang/
       sv.py             # Swedish string table (default)
       en.py             # English string table
     mcp23017.py         # MCP23017 I2C GPIO expander driver
-    nfc.py              # NFC tag parsing, card sets, UID cache, reader stub
+    native_i2c.py       # native C I2C wrapper for deterministic scans
+    neo.py              # NeoPixel facade over the native C pattern engine
+    nfc.py              # NFC tag parsing, card sets, UID cache
     patterns.py         # LED animation patterns (shared buffer)
     pca9685.py          # PCA9685 I2C PWM driver (arcade button LEDs)
+    pn532.py            # PN532 NFC reader driver (I2C, polling task)
     power.py            # power management (sleep, wake, master switch)
     qr.py               # minimal QR code encoder (V1–V2)
+    sdcard.py           # SD card initialisation and mount
     session.py          # play session state machine (pure logic)
     sounds.py           # sound asset catalogue
     storage.py          # JSON settings & session history on flash
+    stories/            # story package (scripts discovered at runtime on SD)
     temperature.py      # DS18B20 + SoC temperature monitoring
     tones.py            # procedural tone generation (pure logic)
+    tts.py              # TTS playback helper (SD-first voice resolution)
     wav.py              # WAV header parser + streaming reader (pure logic)
-    wifi.py             # WiFi connect (STA / AP) + mDNS + runtime control
     web.py              # async HTTP server for parental controls
     web_ui.py           # HTML/CSS/JS served to the browser
-    *_rules.py          # pure-logic game engines (mystery, simon, flode,
-                        #   rulefollow, life, soundboard)
+    wifi.py             # WiFi connect (STA / AP) + mDNS + runtime control
+    *_rules.py          # pure-logic game engines: mystery, simon, flode,
+                        #   rulefollow, life, soundboard, space, story,
+                        #   sequencer, highfive, sortera, rakna
     ui/
       screen.py         # Screen base class + ScreenManager
       theme.py          # colour palette and layout constants
       input.py          # unified input state with debouncing
-      widgets.py        # stateless draw helpers
-      icons.py          # 16×16 bitmap icons
+      draw.py           # wrapper around the native _draw C module
+      widgets.py        # stateless draw helpers + sprite cache
+      icons.py          # 16×16 bitmap icons (flash fallback)
       font_ext.py       # extended glyphs: å ä ö Å Ä Ö
       logo.py           # pixel-art boot logo
+      android.py        # boot-time Android-style status bar helper
       home.py           # home screen with animated carousel
       demo.py           # LED playground mode
-      mystery.py        # Mystery Box discovery game
-      simon.py          # Simon memory game
-      flode.py          # Flöde flow-alignment puzzle
-      rulefollow.py     # Rule Follow (inhibition & flexibility)
-      garden.py         # Garden of Life (cellular automata)
-      soundboard.py     # Soundboard discovery mode
+      mystery.py              # Mystery Box discovery game
+      simon.py                # Simon memory game
+      flode.py                # Flöde flow-alignment puzzle
+      rulefollow.py           # Rule Follow (inhibition & flexibility)
+      garden.py               # Garden of Life (cellular automata)
+      garden_secondary.py     # Garden secondary display content
+      soundboard.py           # Soundboard discovery mode
+      soundboard_secondary.py # Soundboard secondary display content
+      sequencer.py            # loop sequencer mode
+      sequencer_secondary.py  # Sequencer secondary display content
+      highfive.py             # High-Five Friends reflex game
+      space.py                # Spaceship cockpit mode
+      story.py                # branching story mode (scripts + TTS on SD)
+      sortera.py              # Sortera NFC classification game
+      rakna.py                # Räkna NFC math game
       clock.py          # clock display mode
       catface.py        # animated cat face (secondary content)
       ambient.py        # AmbientClock + StatusStrip (secondary display)
@@ -104,6 +127,20 @@ firmware/
       nfc_provision.py  # NFC card set viewer + provisioning
       icon_browser.py   # OpenMoji emoji sprite browser
 ```
+
+### Native C modules
+
+Five C modules in `cmodules/` compile into a custom MicroPython firmware build
+(see `tools/build-firmware.sh`). Each has a Python fallback so stock
+MicroPython still runs — the board definition lives in `boards/BODN_S3/`.
+
+| Module | What it does |
+|---|---|
+| `_audiomix` | 16-voice audio mixer + I2S + step clock on core 0 |
+| `_spidma` | DMA-driven SPI display writes in 32 KB chunks |
+| `_draw` | Bitmap fonts, sprite blit, primitives with alpha blending |
+| `_mcpinput` | Deterministic MCP23017 input scanner (core 1 task) |
+| `_neopixel` | NeoPixel pattern engine (animations run in C, not Python) |
 
 ## Getting started
 
@@ -280,11 +317,11 @@ wind-down cycle.
 See [`docs/roadmap.md`](docs/roadmap.md) for detailed milestones.
 
 1. ~~**Hardware bring-up**~~ — display, buttons, encoders ✓
-2. ~~**Audio basics**~~ — tones, WAV playback, volume control ✓
-3. **Kid-facing UI** — 10 game modes shipped; NFC card games planned
-4. ~~**Parental controls**~~ — web UI, session limits, OTA, FTP sync ✓
-5. **Quality-of-life** — battery indicator, temperature monitoring, i18n (Swedish/English) ✓
-6. **NFC integration** — data layer and card generation ready; PN532 hardware bring-up next
+2. ~~**Audio basics**~~ — tones, WAV playback, native C mixer on core 0 ✓
+3. **Kid-facing UI** — 12 game modes shipped (incl. Sortera + Räkna NFC games); record & replay still planned
+4. ~~**Parental controls**~~ — web UI, session limits, PIN, OTA, FTP sync ✓
+5. **Quality-of-life** — battery indicator, temperature monitoring, i18n (Swedish/English), offline TTS ✓
+6. **NFC integration** — PN532 driver, Sortera + Räkna shipped; more card-based modes on deck
 
 ## Developmental foundations
 
@@ -313,10 +350,22 @@ See [`docs/nfc.md`](docs/nfc.md) for the tag format specification and
 [`docs/science/nfc_tangible_learning.md`](docs/science/nfc_tangible_learning.md) for the
 research foundations.
 
-### Hardware (not yet wired)
+### Hardware
 
-A PN532 NFC reader connects via I2C (address 0x24, shared bus with existing devices).
-See [issue #121](https://github.com/mandakan/bodn-esp32/issues/121) for wiring details.
+A PN532 NFC reader connects via I2C (address 0x24) on a power-gated rail so it
+can be turned off during sleep and low-battery states. The driver (`bodn/pn532.py`)
+runs a polling task; tags are written with retries and automatic PN532 recovery.
+
+### Shipped card sets
+
+| Set | Game | Contents |
+|---|---|---|
+| `sortera` | Classification (DCCS-style) | 16 animal cards in 4 colours |
+| `rakna` | Math (levels 1–6) | Numbers, operators, and equation builders |
+| `launcher` | Shortcut cards | Tap a card to jump straight into any game mode |
+
+Programmed cards are tracked via the NFC provisioning UI; the Sortera set filters
+down to whatever is actually written to tags on startup.
 
 ### Card production
 
@@ -326,17 +375,17 @@ Cards are printed on paper/cardstock with an NFC sticker on the back, then lamin
 # One-time: clone OpenMoji icons (CC-BY-SA 4.0, ~200 MB)
 git clone --depth 1 https://github.com/hfg-gmuend/openmoji.git ~/openmoji
 
-# Generate printable A4 PDF with card faces (85×54 mm, 2×4 per page)
+# Generate printable A4 PDFs for all card sets (85×54 mm, 2×4 per page)
 uv run python tools/generate_cards.py
+
+# Specific set only
+uv run python tools/generate_cards.py --set sortera
 
 # Preview without generating
 uv run python tools/generate_cards.py --dry-run
 ```
 
-Output: `build/cards/sortera_cards.pdf` — print, cut, laminate, attach NFC stickers.
-
-The first card set is **Sortera** (16 animal cards in 4 colours) for a classification
-game based on the Dimensional Change Card Sort (DCCS) task.
+Output: `build/cards/*_cards.pdf` — print, cut, laminate, attach NFC stickers.
 
 ## OpenMoji icons
 
@@ -351,7 +400,7 @@ if not available.
 # Clone OpenMoji (one-time, or set OPENMOJI_DIR to an existing checkout)
 git clone --depth 1 https://github.com/hfg-gmuend/openmoji.git ~/openmoji
 
-# Convert all icons (25 emoji × 3 sizes = 75 BDF files)
+# Convert all icons (33 emoji × 4 sizes → BDF sprites, ~4 bpp)
 uv run python tools/convert_icons.py
 
 # Or let sd-sync handle everything automatically:
@@ -373,6 +422,29 @@ uv run python tools/sd-sync.py --dry-run             # preview
 
 The pipeline runs 5 steps: TTS generation → story TTS → audio conversion → sprite
 building → emoji icon conversion. Each step skips up-to-date files automatically.
+
+## Stories and TTS
+
+Two offline TTS pipelines generate spoken audio with [Piper TTS](https://github.com/rhasspy/piper):
+
+- **i18n TTS** (`tools/generate_tts.py`) — game instructions, safety alerts, and
+  overlay phrases from the `STRINGS` dicts in `firmware/bodn/lang/`. Safety-critical
+  keys (e.g. `bat_critical`, `overlay_goodnight`) stay on flash; the rest live on
+  the SD card.
+- **Story TTS** (`tools/generate_story_tts.py`) — narration and choice labels for
+  branching stories authored in `assets/stories/{story_id}/script.py`. Stories are
+  self-contained SD packages: script + per-language WAVs, discovered at runtime.
+  Ships with `peter_rabbit` and `forest_walk`.
+
+Any TTS line can be replaced with a human recording — drop a WAV at
+`assets/audio/source/recordings/{lang}/{key}.wav` (i18n) or
+`assets/stories/{id}/recordings/{lang}/{node}.wav` (story). Filenames must match
+the TTS key/node exactly. `convert_audio.py` normalises the recording to 16 kHz
+mono PCM with loudnorm; `bodn.assets.resolve_voice()` prefers recordings over
+TTS. Coverage is incremental — record one key, the rest stay on TTS.
+
+See [`docs/story_authoring.md`](docs/story_authoring.md) for the story authoring
+guide and [`docs/audio_assets.md`](docs/audio_assets.md) for the audio pipeline.
 
 ## Design goals
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,17 +18,21 @@
 ## Milestone 2: Audio basics
 
 - [x] Play simple tones through MAX98357A (procedural tone generation)
-- [x] Play WAV samples from flash (streaming WAV reader + audio engine)
-- [x] Multi-channel audio mixing (6 simultaneous voices, priority channels)
+- [x] Play WAV samples from flash and SD card (streaming WAV reader + audio engine)
+- [x] Multi-channel audio mixing (16 uniform voices, priority channels)
+- [x] Native C audio mixer on core 0 (`_audiomix`), with viper/IRQ fallback
+- [x] Sample-accurate step clock for sequencer and clock-driven tone tracks
 - [x] Click feedback on UI interactions
 - [x] Volume control via rotary encoder
 - [x] Audio asset pipeline with EBU R128 loudness normalisation
+- [x] Offline Piper TTS pipeline (Swedish + English) with flash/SD split
+- [x] Hand-recorded WAV overrides (recording > TTS at each storage layer)
 - [ ] Record short clips from INMP441 into RAM
 - [ ] Playback recorded clips
 
 ## Milestone 3: Kid-facing UI
 
-- [x] Home screen with colourful icons and animated carousel (velocity-aware slide)
+- [x] Home screen with colourful OpenMoji carousel (velocity-aware slide, sprite cache)
 - [x] Gesture layer: tap, double-tap, long-press on all buttons
 - [x] Multi-button chord / combo detection
 - [x] **Mystery Box** — colour discovery game with hue-shift feedback
@@ -37,11 +41,17 @@
 - [x] **Rule Follow** — inhibition & cognitive flexibility game
 - [x] **Garden of Life** — Conway's Game of Life with interactive seeding
 - [x] **Soundboard** — discovery mode mapping buttons to sounds
+- [x] **Sequencer** — chain tones and LED steps into a loop (C-driven timing)
+- [x] **High-Five Friends** — reflex game with C-driven arcade LEDs
+- [x] **Spaceship** — cockpit mode with arcade buttons, ambience, and SFX
+- [x] **Story Mode** — branching stories read aloud via SD-loaded TTS packages
+- [x] **Sortera** — NFC classification game (DCCS-style, 16 animal cards)
+- [x] **Räkna** — NFC math game (levels 1–6, from counting to symbolic equations)
 - [x] Pause menu (hold-to-open), session overlay, in-game wind-down animation
 - [x] Secondary display content per game mode (cat face, ambient clock, status strip)
 - [x] i18n with Swedish default and English fallback (å/ä/ö extended font glyphs)
+- [x] NFC launcher cards — tap a card to jump straight into any mode
 - [ ] "Record & replay" mode — record voice and play back on button press
-- [ ] "Sequencer" mode — chain lights + sounds into a sequence
 
 ## Milestone 4: Parental controls
 
@@ -70,3 +80,20 @@
 - [x] On-device diagnostics screen (hold-button at boot)
 - [x] Power-save mode with light sleep and master switch
 - [x] Thermal protection (software-only safeguard for LiPo — shed load at 50 °C, sleep at 60 °C)
+- [x] SD card support for bulk media (mounted at boot, graceful fallback if absent)
+- [x] Asset resolver (`bodn.assets.resolve` / `resolve_voice`) with SD-first / flash-fallback precedence
+- [x] Custom MicroPython firmware build with native C modules (`_audiomix`, `_spidma`, `_draw`, `_mcpinput`, `_neopixel`)
+- [x] Boot log persistence to flash, viewable via the web UI
+
+## Milestone 6: NFC card games
+
+- [x] NFC tag format (self-describing NDEF Text Records) and card-set schema
+- [x] PN532 NFC reader driver (I2C, polling task, power-gated rail)
+- [x] Robust tag writing with retries and PN532 recovery
+- [x] NFC provisioning UI (card set viewer, programming, UID cache)
+- [x] Card-face PDF generator (OpenMoji emoji → A4, 85×54 mm, 2×4 per page)
+- [x] Sortera card set (16 animal cards × 4 colours) with runtime filter by programmed tags
+- [x] Räkna card set (numbers, operators, equation builders — levels 1–6)
+- [x] Launcher cards — tap any card to open the matching game mode
+- [x] `bodn.thias.se` web landing page for per-card info (card viewer parses NFC URLs)
+- [ ] Additional card sets — vocabulary, storytelling props, day-of-week, colours, etc.

--- a/docs/science/development_guide.md
+++ b/docs/science/development_guide.md
@@ -115,6 +115,11 @@ to press it because the current rule says to press the *opposite* color.
   for the target to appear. Premature taps are ignored — rewarding patience
   and focused attention.
 
+- **Sortera**: When the rule switches from "colour" to "animal," the child must
+  actively suppress the previously rewarded sorting strategy. This is the same
+  executive demand that makes classroom transitions challenging for
+  preschoolers, practised here in a low-stakes, playful setting.
+
 #### Cognitive Flexibility
 
 **What it looks like:** the rules change mid-game — what worked 30 seconds ago
@@ -129,6 +134,16 @@ no longer applies, and the child must switch strategies.
 - **Spaceship** (core mechanic): Five different scenario types, each requiring a
   different input (steer, press button, flip switch, push throttle). The child
   cannot predict which scenario comes next — they must stay flexible.
+
+- **Sortera** (core mechanic): A direct tangible implementation of the
+  Dimensional Change Card Sort (DCCS) — the standard preschool assessment of
+  cognitive flexibility (Zelazo, 2006). The device announces a sorting rule
+  ("Find the animals!"), the child scans NFC cards matching that rule, and
+  after several successes the rule switches to a different dimension ("Find
+  the red ones!"). The physical cards carry **all** dimensions at once
+  (animal × colour), so switching rules requires the child to inhibit the
+  previously relevant dimension and attend to a new one — exactly the
+  classroom transition skill EF training is meant to strengthen.
 
 ---
 
@@ -264,9 +279,10 @@ thinking process (Weisberg et al., 2013).
   requires trial-and-error to solve. The snap-to-grid design ensures the child
   can make progress without pixel-perfect precision.
 
-- *Future opportunity:* The planned Sequencer mode introduces debugging — the
-  child creates a pattern, runs it, hears something unexpected, and must figure
-  out which step to change.
+- **Sequencer**: Introduces debugging as a natural part of creative play — the
+  child builds a pattern, runs it, hears something unexpected, and toggles
+  individual steps until it sounds right. This is computational thinking
+  disguised as music-making.
 
 ### Early Mathematics and Number Sense
 
@@ -282,20 +298,24 @@ number sense predicts math achievement through at least third grade, with the
 prediction strength not weakening over time (Jordan et al., 2009). This makes
 number sense one of the highest-impact domains to support in early childhood.
 
-**How Böðn will support it:**
+**How Böðn supports it:**
 
-- **Räkna** (planned NFC mode): Dot-pattern NFC cards serve as tangible number
+- **Räkna** (core NFC math mode): Dot-pattern NFC cards serve as tangible number
   tokens, following Bruner's Concrete-Pictorial-Abstract (CPA) progression — the
   child places a physical card (concrete), the screen shows matching dots
-  (pictorial), and optionally the numeral appears (abstract). This three-layer
-  progression is consistently validated in early math education research.
+  (pictorial), and at higher levels the numeral appears (abstract). This
+  three-layer progression is consistently validated in early math education
+  research (Bruner, 1966; Willingham, 2017).
 
-  The mode uses structured dot patterns (like dice faces) rather than numerals,
-  because subitising — instant recognition of small quantities — is the
-  developmental foundation of number sense, not numeral recognition (Clements &
-  Sarama, 2014). Six progressive levels span ages 3–7: from free exploration
-  of quantities, through matching and comparison, to simple addition and
-  subtraction with concrete tokens, and finally symbolic equation building.
+  The mode uses structured dot patterns (like dice faces) at lower levels rather
+  than numerals, because **subitising** — instant recognition of small
+  quantities — is the developmental foundation of number sense, not numeral
+  recognition (Clements & Sarama, 2014). Six progressive levels span ages 3–7:
+  (1) free exploration of quantities, (2) quantity matching, (3) more/less
+  comparison, (4) addition with dot cards, (5) subtraction, (6) symbolic
+  equations with numerals and operator cards. The child physically composes an
+  equation by scanning cards in sequence, turning an abstract arithmetic
+  statement into a concrete tangible act.
 
   **Critical design constraint:** The mode is always self-paced, never timed.
   Research shows that timed math exercises cause anxiety even in preschoolers
@@ -307,6 +327,11 @@ number sense one of the highest-impact domains to support in early childhood.
   improved preschoolers' number competence, with gains persisting 9 weeks.
   The path runs left-to-right (small to large) — circular layouts do not
   produce the same benefit.
+
+- **Bilingual number naming** reinforces both languages during the mathematically
+  engaging task: each successful scan announces the number in Swedish and
+  English, leveraging translation-equivalent bootstrapping (Tan et al., 2024)
+  while the child is actively manipulating quantity.
 
 See `docs/science/nfc_tangible_learning.md` § 6.6 for the full research summary.
 
@@ -539,14 +564,15 @@ the thing to the thing, something happens.
 
 ### Developmental Impact
 
-NFC modes can address several gaps identified in the development matrix:
+NFC modes already address several gaps identified in the development matrix:
 
-| Gap | NFC Application |
-|-----|----------------|
-| **Problem Solving** | Scavenger hunts, puzzle cards (scan clues to unlock next step) |
-| **Fine Motor** | Card manipulation, sorting into physical piles, precision placement |
-| **Bilingual Exposure** | Same picture, two language cards — scan to hear each word |
-| **Categorisation (CF/IC)** | Physical DCCS: sort cards by one dimension, then switch rules |
+| Gap | NFC Application | Status |
+|-----|----------------|--------|
+| **Categorisation (CF/IC)** | Sortera: physical DCCS — sort cards by one dimension, then switch rules | Shipped |
+| **Early Mathematics (PR/ST/PS)** | Räkna: dot-pattern cards with CPA progression (concrete → pictorial → abstract) | Shipped |
+| **Bilingual Exposure** | Dual-language labels on cards; bilingual TTS on scans | Shipped via Sortera + Räkna |
+| **Fine Motor** | Card manipulation, sorting into physical piles, precision placement | Shipped via Sortera + Räkna |
+| **Problem Solving** | Scavenger hunts, puzzle cards (scan clues to unlock next step) | Wishlist |
 
 See `docs/science/nfc_tangible_learning.md` for the full research summary with
 references.
@@ -602,12 +628,13 @@ Böðn addresses these guidelines through:
 
 | Developmental Area | Key Finding | Böðn Response |
 |--------------------|-------------|---------------|
-| Executive functions | Strongest predictor of school readiness (Diamond, 2013) | Simon (WM), Rule Follow (IC, CF), Spaceship (CF), High-Five (IC) |
+| Executive functions | Strongest predictor of school readiness (Diamond, 2013) | Simon (WM), Rule Follow (IC, CF), Sortera (CF, tangible DCCS), Spaceship (CF), High-Five (IC), Sequencer (WM) |
 | Self-control | Predicts lifelong outcomes in a gradient (Moffitt et al., 2011) | Gentle failure feedback, session limits, pause mechanics |
 | Tangible interaction | Stronger learning than touchscreen-only (Marshall, 2007) | 18 physical controls; screens for feedback only |
 | Cause-and-effect | Foundation of scientific thinking (Gopnik, 2012) | Mystery Box, Soundboard, Garden |
 | Guided play | Deep learning through structured exploration (Weisberg et al., 2013) | Mystery Box, Garden, Soundboard — open-ended within designed environments |
 | Spatial reasoning | Predicts math achievement (Verdine et al., 2014) | Flöde |
+| Early mathematics | Strongest predictor of later academic achievement (Duncan et al., 2007) | Räkna (CPA progression, subitising, linear number path) |
 | Bilingualism | Enhanced EF through dual-language management (Bialystok, 2011) | Swedish/English UI and TTS |
 | Pretend play | Develops theory of mind and narrative skills (Lillard et al., 2013) | Spaceship cockpit mode, Story Mode |
 | Reaction time & coordination | Hand-eye coordination critical for motor development | High-Five Friends (adaptive difficulty) |

--- a/docs/science/development_matrix.md
+++ b/docs/science/development_matrix.md
@@ -95,6 +95,7 @@ readiness, outperforming IQ (Diamond, 2013; Moffitt et al., 2011).
 | Sequencer | ◉ | | ● | Build and hold patterns in mind (WM), switch between edit/play modes (CF) |
 | *Record & Replay* | ● | | | Remember what to record and play back |
 | Sortera | ○ | ● | ◉ | Remember current rule (WM); resist sorting by previous dimension (IC); rule switches demand flexibility (CF) — tangible DCCS |
+| Räkna | ● | ○ | ○ | Hold equation state across multiple card scans (WM); level progression from counting to symbolic equations nudges CF |
 
 ### Cognitive Development
 
@@ -112,6 +113,7 @@ readiness, outperforming IQ (Diamond, 2013; Moffitt et al., 2011).
 | Sequencer | ● | ◉ | | ◉ | ● | Build patterns step by step; debug sequences |
 | *Record & Replay* | ● | | | ○ | | Voice causes recording; sequential playback |
 | Sortera | ● | ◉ | | | | Card scan → feedback (CE); categorise by matching dimension (PR) |
+| Räkna | ● | ◉ | ○ | ◉ | ● | Dot-pattern subitising (PR); counting and equation order (ST); build solutions step by step (PS); left-to-right number path (SR) |
 
 ### Sensorimotor Development
 
@@ -129,6 +131,7 @@ readiness, outperforming IQ (Diamond, 2013; Moffitt et al., 2011).
 | Sequencer | ● | ● | ● | ● | Precise input, visual-audio feedback loop |
 | *Record & Replay* | ○ | | ◉ | | Listen to own voice, discriminate recordings |
 | Sortera | ● | | ● | ● | Card manipulation (FM); bilingual TTS reinforces audio (AP); emoji + label display (VP) |
+| Räkna | ● | ○ | ● | ◉ | Handling multiple dot/numeral/operator cards (FM); bilingual number names (AP); dot patterns and numerals are the core stimulus (VP) |
 
 ### Language & Communication
 
@@ -146,6 +149,7 @@ readiness, outperforming IQ (Diamond, 2013; Moffitt et al., 2011).
 | Sequencer | | ○ | UI labels only |
 | *Record & Replay* | ● | ● | Hear and produce speech in both languages |
 | Sortera | ○ | ● | Bilingual TTS says both languages on correct scan; dual-language labels on screen match physical cards |
+| Räkna | ● | ● | Number names and instructions spoken in both languages; child hears quantities as well as sees them |
 
 ### Social-Emotional Development
 
@@ -162,6 +166,8 @@ readiness, outperforming IQ (Diamond, 2013; Moffitt et al., 2011).
 | High-Five Friends | ● | ● | | Handle misses gracefully (SReg); keep trying to beat high score (PE) |
 | Sequencer | | ● | ● | Debug patience; pretend to be a musician/programmer |
 | *Record & Replay* | | | ○ | Mild pretend-play with voice |
+| Sortera | ● | ○ | | Wait through the rule announcement (SReg); try again after a mis-sort |
+| Räkna | ○ | ● | | Self-paced and never timed keeps frustration low (SReg); multi-card equations reward sustained effort (PE) |
 
 ### Creative & Exploratory
 
@@ -178,6 +184,8 @@ readiness, outperforming IQ (Diamond, 2013; Moffitt et al., 2011).
 | High-Five Friends | | | | Fixed goal (tap the lit button); no creative latitude |
 | Sequencer | | ◉ | ◉ | Compose original patterns; divergent solutions |
 | *Record & Replay* | ● | | ◉ | Record anything; creative voice play |
+| Sortera | ○ | | | Free-scan mode invites incidental exploration of the card set |
+| Räkna | ○ | ○ | | Low-level free exploration of quantities; multiple card paths to the same total |
 
 ---
 
@@ -187,30 +195,32 @@ readiness, outperforming IQ (Diamond, 2013; Moffitt et al., 2011).
 
 | Aspect | Primary (◉) | Significant (●) | Total strong |
 |--------|:-----------:|:----------------:|:------------:|
-| Visual Processing (VP) | 2 | 6 | 8 |
-| Working Memory (WM) | 2 | 3 | 5 |
-| Cause & Effect (CE) | 1 | 5 | 6 |
-| Pattern Recognition (PR) | 1 | 3 | 4 |
+| Visual Processing (VP) | 3 | 6 | 9 |
+| Working Memory (WM) | 2 | 4 | 6 |
+| Cause & Effect (CE) | 1 | 6 | 7 |
+| Pattern Recognition (PR) | 2 | 3 | 5 |
 | Hand-Eye Coordination (HC) | 1 | 4 | 5 |
 | Open Exploration (OE) | 3 | 0 | 3 |
-| Self-Regulation (SReg) | 1 | 3 | 4 |
+| Self-Regulation (SReg) | 1 | 4 | 5 |
 | Cognitive Flexibility (CF) | 2 | 1 | 3 |
 | Inhibitory Control (IC) | 1 | 2 | 3 |
-| Listening Comprehension (LC) | 2 | 0 | 2 |
-| Bilingual Exposure (BL) | 1 | 1 | 2 |
+| Listening Comprehension (LC) | 2 | 1 | 3 |
+| Bilingual Exposure (BL) | 1 | 2 | 3 |
 | Imaginative Play (IP) | 2 | 1 | 3 |
-| Auditory Processing (AP) | 1 | 3 | 4 |
-| Sequential Thinking (ST) | 2 | 2 | 4 |
-| Persistence (PE) | 1 | 3 | 4 |
+| Auditory Processing (AP) | 1 | 4 | 5 |
+| Sequential Thinking (ST) | 3 | 2 | 5 |
+| Persistence (PE) | 1 | 4 | 5 |
+| Problem Solving (PS) | 1 | 2 | 3 |
+| Fine Motor (FM) | 0 | 3 | 3 |
 
 ### Gaps (1 or fewer features at ◉ or ●)
 
 | Aspect | Current state | Suggested feature |
 |--------|---------------|-------------------|
-| **Spatial Reasoning (SR)** | Only Flöde | Building/construction mode; tangram puzzles |
-| **Problem Solving (PS)** | Only Flöde + Sequencer (debugging) | More puzzle types; NFC scavenger hunts |
-| **Bilingual Exposure (BL)** | Story Mode (◉) + Sortera (●, bilingual TTS + dual labels) + passive UI labels | Language-switch game; more card sets with dual labels |
-| **Fine Motor (FM)** | Mostly incidental (Flöde, Sequencer significant) | NFC card manipulation/sorting; tracing mode |
+| **Spatial Reasoning (SR)** | Flöde (◉) + incidental Räkna number path | Building/construction mode; tangram puzzles |
+| **Problem Solving (PS)** | Flöde (◉) + Sequencer (●) + Räkna (●, equation building) | More puzzle types; NFC scavenger hunts |
+| **Bilingual Exposure (BL)** | Story Mode (◉) + Sortera (●) + Räkna (●, bilingual number naming) + passive UI labels | More card sets with dual labels; dedicated language-switch game |
+| **Fine Motor (FM)** | Sortera + Sequencer + Räkna (all ●) via card/button manipulation | Tracing mode; tangram; more tangible sorting puzzles |
 
 ---
 
@@ -231,6 +241,8 @@ The foundation — everything should produce immediate, rewarding feedback.
 | Simon | Introduce gently — 2-step sequences | Easiest |
 | Spaceship | Exposure — long timeouts, few scenarios | Easiest |
 | Story Mode | **Introduce** — simple stories, 2 choices, short paths | Easy |
+| Sortera | **Introduce** — single-dimension sorting, no rule switches | Easiest |
+| Räkna | **Introduce** — Level 1 free exploration of dot cards 1–5 | Easiest |
 
 ### Age 4–5: Executive Functions Emerge
 
@@ -244,6 +256,8 @@ The child can follow rules, hold short sequences, and switch between ideas.
 | Story Mode | **Growing** — longer stories, 3 choices, remember plot points | Medium |
 | Flöde | **Introduce** — levels 1–2 (1–2 segments) | Easy |
 | Mystery Box | Still engaging — modifier discovery deepens | Same |
+| Sortera | **Growing** — rule switches between colour, shape, and animal dimensions | Medium |
+| Räkna | **Growing** — Levels 2–3 (quantity matching, more/less) | Easy–Medium |
 
 ### Age 5–6: Increasing Challenge
 
@@ -257,6 +271,8 @@ Longer sequences, faster rule switches, real problem-solving.
 | Flöde | Levels 3–4 (3–4 segments, more snap positions) | Medium |
 | High-Five Friends | Faster reaction windows; longer rounds | Medium-Hard |
 | Sequencer | **Introduce** — simple 4-step patterns | Easy |
+| Sortera | Faster rule switches; full 16-card deck with four colour variants | Medium–Hard |
+| Räkna | **Core** — Level 4 addition with dot tokens | Medium |
 
 ### Age 6–7+: Mastery & Creativity
 
@@ -266,6 +282,7 @@ Features shift from guided challenge toward creative expression and composition.
 |---------|------|------------|
 | Sequencer | **Core** — complex patterns, programming concepts | Growing |
 | Flöde | Levels 5–6 (full difficulty) | Hard |
+| Räkna | Levels 5–6 — subtraction and symbolic equations with numerals | Growing |
 | *Record & Replay* | Creative voice compositions | Open-ended |
 | Rule Follow | Near-instant switches; scoring/competition | Expert |
 | Garden of Life | Deliberate pattern engineering | Advanced |
@@ -286,15 +303,11 @@ bring to reader → hold) that exercises fine motor skills and reinforces
 intentionality. See `docs/science/nfc_tangible_learning.md` for the full research
 summary.
 
-#### NFC-1. Sortera — Classification Game
+The first two NFC modes — **Sortera** (tangible DCCS classification) and
+**Räkna** (progressive math with dot-pattern cards) — are shipped and appear in
+the aspect matrices above. The ideas below remain on the wishlist.
 
-**Primary targets:** CF, IC, PR, BL
-**Fills gaps in:** Cognitive flexibility (tangible DCCS), bilingual exposure, fine motor
-**Concept:** Scan NFC cards to sort by announced categories; rules switch mid-game
-(colour → shape → animal). Direct tangible implementation of the DCCS task.
-**References:** Zelazo (2006) DCCS; Diamond (2013) EF training; Antle (2013) TUI for children
-
-#### NFC-2. Saga Builder — Tangible Storytelling
+#### NFC-1. Saga Builder — Tangible Storytelling
 
 **Primary targets:** ST, IP, LC, BL, CX
 **Fills gaps in:** Bilingual exposure, sequential thinking, creative expression
@@ -302,7 +315,7 @@ summary.
 each combination triggers different narration in Swedish or English.
 **References:** Sylla et al. (2012) TinkRBook; Kumpulainen & Lipponen (2012) physical story props
 
-#### NFC-3. NFC Soundboard Extension
+#### NFC-2. NFC Soundboard Extension
 
 **Primary targets:** AP, CE, CX, OE
 **Fills gaps in:** Auditory processing (tangible layer), creative expression
@@ -310,7 +323,7 @@ each combination triggers different narration in Swedish or English.
 layer multiple cards for composition.
 **References:** Paivio (1986) dual coding theory; multisensory association
 
-#### NFC-4. Memory Match
+#### NFC-3. Memory Match
 
 **Primary targets:** WM, HC, FM, VP
 **Fills gaps in:** Fine motor (physical card retrieval), working memory (extended action sequence)
@@ -318,7 +331,7 @@ layer multiple cards for composition.
 a physical spread. Physical search adds motor planning to the memory task.
 **References:** Manches & O'Malley (2012) tangible manipulation and learning
 
-#### NFC-5. Vocabulary Explorer — Bilingual Word Cards
+#### NFC-4. Vocabulary Explorer — Bilingual Word Cards
 
 **Primary targets:** BL, LC, AP
 **Fills gaps in:** Bilingual exposure (primary-level), listening comprehension
@@ -326,26 +339,12 @@ a physical spread. Physical search adds motor planning to the memory task.
 again for English. Quiz mode: device says a word, child scans the right card.
 **References:** Wohlwend (2015) physical-digital literacy; Bialystok (2011) bilingual EF advantage
 
-#### NFC-6. Free Discovery / Tag Registry
+#### NFC-5. Free Discovery / Tag Registry
 
 **Primary targets:** OE, CE, DT
 **Concept:** First-time tags get a random colour + sound + animation. Child builds
 a personal collection by tagging household objects, toys, and drawings.
 **References:** Bonawitz et al. (2011) exploration-driven discovery
-
-#### NFC-7. Räkna — Progressive Math with Tangible Numbers
-
-**Primary targets:** WM, ST, PR, PS, LC, BL, FM
-**Fills gaps in:** Problem solving (tangible math), fine motor, bilingual exposure
-**Concept:** Dot-pattern NFC cards (1--10) for progressive number sense: subitising
-→ quantity matching → more/less → addition → subtraction → symbolic equations.
-Follows Bruner's CPA progression (concrete tokens → pictorial dots → abstract
-numerals). Six levels spanning ages 3--7. Self-paced, never timed.
-**References:** Duncan et al. (2007) early math as #1 achievement predictor;
-Clements & Sarama (2014) learning trajectories; Siegler & Ramani (2009) linear
-number board games; Jordan et al. (2009) kindergarten number sense; Gelman &
-Gallistel (1978) counting principles; Bruner (1966) CPA; Willingham (2017)
-manipulatives and concreteness fading
 
 ---
 

--- a/docs/science/report.bib
+++ b/docs/science/report.bib
@@ -198,6 +198,30 @@
                at least third grade with correlation .63.},
 }
 
+@book{clementssarama2014learning,
+  author    = {Clements, Douglas H. and Sarama, Julie},
+  title     = {Learning and Teaching Early Math: The Learning Trajectories
+               Approach},
+  edition   = {2},
+  publisher = {Routledge},
+  year      = {2014},
+  address   = {New York},
+  note      = {Subitising and trajectory-based teaching from age 3 through
+               primary grades; dot patterns before numerals.},
+}
+
+@article{willingham2017manipulatives,
+  author    = {Willingham, Daniel T.},
+  title     = {Do manipulatives help students learn?},
+  journal   = {American Educator},
+  volume    = {41},
+  number    = {3},
+  pages     = {25--30, 40},
+  year      = {2017},
+  note      = {Review of concreteness-fading and CPA progression: manipulatives
+               help when paired with explicit bridging to abstract symbols.},
+}
+
 @article{siegler2009playing,
   author    = {Siegler, Robert S. and Ramani, Geetha B.},
   title     = {Playing linear number board games --- but not circular ones ---

--- a/docs/science/report.tex
+++ b/docs/science/report.tex
@@ -415,6 +415,32 @@ language first, then secondary \citep{tan2024translation}. This dual-label
 approach leverages the translation-equivalent bootstrapping effect while keeping
 game instructions in the configured language for clarity.
 
+\subsubsection{Räkna --- Progressive Math with Tangible Numbers}
+A six-level NFC math mode targeting \textbf{pattern recognition} (subitising),
+\textbf{sequential thinking} (counting and equation order),
+\textbf{problem solving} (composing equations step by step), and
+\textbf{fine motor} coordination (handling multiple cards per equation). Räkna
+implements Bruner's Concrete--Pictorial--Abstract progression
+\citep{bruner1966instruction,willingham2017manipulatives}: a physical dot-pattern
+card is placed on the reader (concrete), the screen renders matching dots
+(pictorial), and from Level~4 onwards the numeral and operator cards are
+introduced (abstract). Dice-face dot patterns at low levels rather than
+numerals reflect the developmental evidence that subitising is the foundation
+of number sense, not numeral recognition
+\citep{clementssarama2014learning}. Levels span free exploration (ages
+3--4), quantity matching and more/less comparison (4--5), addition and
+subtraction with tokens (5--6), and symbolic equations (6--7+). A left-to-right
+linear number path on the display implements Siegler and Ramani's
+\citeyearpar{siegler2009playing} finding that board-game-style number lines
+measurably improve preschool number competence. Bilingual TTS announces each
+quantity in Swedish and English, carrying the translation-equivalent
+bootstrapping effect \citep{tan2024translation} into a cognitively engaging
+math task. The mode is always self-paced and never timed --- a deliberate
+design choice given the evidence that timed math exercises produce anxiety
+even in preschoolers. Together with Sortera, Räkna addresses the early-math
+domain that \citet{duncan2007school} identified as the single strongest
+predictor of later academic achievement.
+
 \subsubsection{Sequencer (Sequenser)}
 A loop-based step sequencer targeting \textbf{working memory},
 \textbf{sequential thinking}, \textbf{pattern recognition}, and
@@ -441,39 +467,40 @@ feedback.
   blank = not applicable.}
 \label{tab:matrix}
 \small
-\begin{tabular}{lcccccccccc}
+\begin{tabular}{lcccccccccccc}
 \toprule
 \textbf{Domain} & \rotatebox{70}{Simon} & \rotatebox{70}{Rule Follow}
   & \rotatebox{70}{Mystery Box} & \rotatebox{70}{Fl\"ode}
   & \rotatebox{70}{Garden} & \rotatebox{70}{Soundboard}
   & \rotatebox{70}{Spaceship} & \rotatebox{70}{Story Mode}
-  & \rotatebox{70}{High-Five} & \rotatebox{70}{Sequencer} \\
+  & \rotatebox{70}{High-Five} & \rotatebox{70}{Sequencer}
+  & \rotatebox{70}{Sortera} & \rotatebox{70}{R\"akna} \\
 \midrule
-Working memory       & $\bullet\bullet\bullet$ & $\bullet\bullet$ & & $\bullet$ & & & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet$ & $\bullet\bullet\bullet$ \\
-Inhibitory control   & $\bullet$ & $\bullet\bullet\bullet$ & & & & & $\bullet\bullet$ & & $\bullet\bullet$ & \\
-Cognitive flexibility & & $\bullet\bullet\bullet$ & & & & & $\bullet\bullet\bullet$ & & & $\bullet\bullet$ \\
+Working memory       & $\bullet\bullet\bullet$ & $\bullet\bullet$ & & $\bullet$ & & & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet$ & $\bullet\bullet\bullet$ & $\bullet$ & $\bullet\bullet$ \\
+Inhibitory control   & $\bullet$ & $\bullet\bullet\bullet$ & & & & & $\bullet\bullet$ & & $\bullet\bullet$ & & $\bullet\bullet$ & $\bullet$ \\
+Cognitive flexibility & & $\bullet\bullet\bullet$ & & & & & $\bullet\bullet\bullet$ & & & $\bullet\bullet$ & $\bullet\bullet\bullet$ & $\bullet$ \\
 \midrule
-Cause \& effect      & & & $\bullet\bullet\bullet$ & & $\bullet\bullet$ & $\bullet\bullet$ & & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ \\
-Pattern recognition  & $\bullet\bullet$ & & $\bullet\bullet$ & & $\bullet\bullet\bullet$ & & & & & $\bullet\bullet\bullet$ \\
-Spatial reasoning    & & & & $\bullet\bullet\bullet$ & & & & & & \\
-Sequential thinking  & $\bullet\bullet\bullet$ & & & $\bullet\bullet$ & & & & $\bullet\bullet$ & & $\bullet\bullet\bullet$ \\
-Problem solving      & & & & $\bullet\bullet\bullet$ & & & $\bullet$ & & & $\bullet\bullet$ \\
+Cause \& effect      & & & $\bullet\bullet\bullet$ & & $\bullet\bullet$ & $\bullet\bullet$ & & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ \\
+Pattern recognition  & $\bullet\bullet$ & & $\bullet\bullet$ & & $\bullet\bullet\bullet$ & & & & & $\bullet\bullet\bullet$ & $\bullet\bullet\bullet$ & $\bullet\bullet\bullet$ \\
+Spatial reasoning    & & & & $\bullet\bullet\bullet$ & & & & & & & & $\bullet$ \\
+Sequential thinking  & $\bullet\bullet\bullet$ & & & $\bullet\bullet$ & & & & $\bullet\bullet$ & & $\bullet\bullet\bullet$ & & $\bullet\bullet\bullet$ \\
+Problem solving      & & & & $\bullet\bullet\bullet$ & & & $\bullet$ & & & $\bullet\bullet$ & & $\bullet\bullet$ \\
 \midrule
-Fine motor           & $\bullet$ & $\bullet$ & $\bullet$ & $\bullet\bullet$ & $\bullet$ & $\bullet$ & $\bullet\bullet$ & $\bullet$ & $\bullet$ & $\bullet\bullet$ \\
-Hand--eye coord.     & $\bullet\bullet$ & $\bullet\bullet$ & & $\bullet\bullet$ & & & $\bullet\bullet$ & & $\bullet\bullet\bullet$ & $\bullet\bullet$ \\
-Auditory processing  & $\bullet\bullet$ & & & & & $\bullet\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ \\
-Visual processing    & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet\bullet$ & & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ \\
+Fine motor           & $\bullet$ & $\bullet$ & $\bullet$ & $\bullet\bullet$ & $\bullet$ & $\bullet$ & $\bullet\bullet$ & $\bullet$ & $\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ \\
+Hand--eye coord.     & $\bullet\bullet$ & $\bullet\bullet$ & & $\bullet\bullet$ & & & $\bullet\bullet$ & & $\bullet\bullet\bullet$ & $\bullet\bullet$ & & $\bullet$ \\
+Auditory processing  & $\bullet\bullet$ & & & & & $\bullet\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ \\
+Visual processing    & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet\bullet$ & & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet\bullet\bullet$ \\
 \midrule
-Listening comp.      & & & & & & $\bullet$ & $\bullet\bullet\bullet$ & $\bullet\bullet\bullet$ & & \\
-Bilingual exposure   & $\bullet$ & $\bullet$ & & $\bullet$ & $\bullet$ & $\bullet$ & $\bullet$ & $\bullet\bullet\bullet$ & $\bullet$ & $\bullet$ \\
+Listening comp.      & & & & & & $\bullet$ & $\bullet\bullet\bullet$ & $\bullet\bullet\bullet$ & & & $\bullet$ & $\bullet\bullet$ \\
+Bilingual exposure   & $\bullet$ & $\bullet$ & & $\bullet$ & $\bullet$ & $\bullet$ & $\bullet$ & $\bullet\bullet\bullet$ & $\bullet$ & $\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ \\
 \midrule
-Self-regulation      & $\bullet\bullet$ & $\bullet\bullet\bullet$ & & & $\bullet$ & & $\bullet\bullet$ & $\bullet$ & $\bullet\bullet$ & \\
-Persistence          & $\bullet\bullet$ & $\bullet$ & & $\bullet\bullet\bullet$ & & & $\bullet$ & $\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ \\
-Imaginative play     & & & & & & & $\bullet\bullet\bullet$ & $\bullet\bullet\bullet$ & & $\bullet\bullet$ \\
+Self-regulation      & $\bullet\bullet$ & $\bullet\bullet\bullet$ & & & $\bullet$ & & $\bullet\bullet$ & $\bullet$ & $\bullet\bullet$ & & $\bullet\bullet$ & $\bullet$ \\
+Persistence          & $\bullet\bullet$ & $\bullet$ & & $\bullet\bullet\bullet$ & & & $\bullet$ & $\bullet$ & $\bullet\bullet$ & $\bullet\bullet$ & $\bullet$ & $\bullet\bullet$ \\
+Imaginative play     & & & & & & & $\bullet\bullet\bullet$ & $\bullet\bullet\bullet$ & & $\bullet\bullet$ & & \\
 \midrule
-Open exploration     & & & $\bullet\bullet\bullet$ & & $\bullet\bullet\bullet$ & $\bullet\bullet\bullet$ & & & & \\
-Divergent thinking   & & & $\bullet\bullet\bullet$ & & $\bullet\bullet$ & & & & & $\bullet\bullet\bullet$ \\
-Creative expression  & & & & & $\bullet\bullet$ & $\bullet\bullet\bullet$ & & & & $\bullet\bullet\bullet$ \\
+Open exploration     & & & $\bullet\bullet\bullet$ & & $\bullet\bullet\bullet$ & $\bullet\bullet\bullet$ & & & & & $\bullet$ & $\bullet$ \\
+Divergent thinking   & & & $\bullet\bullet\bullet$ & & $\bullet\bullet$ & & & & & $\bullet\bullet\bullet$ & & $\bullet$ \\
+Creative expression  & & & & & $\bullet\bullet$ & $\bullet\bullet\bullet$ & & & & $\bullet\bullet\bullet$ & & \\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -489,15 +516,24 @@ Story Mode significantly improved three previously identified gaps: listening
 comprehension, bilingual exposure, and imaginative play each now have two
 primary-level features (Spaceship + Story Mode). The Sequencer filled the
 creative expression gap, and High-Five Friends added a dedicated hand-eye
-coordination mode. Remaining areas with limited coverage include:
+coordination mode. The two NFC modes that followed---Sortera and R\"akna---add
+a tangible manipulation layer and address two previously
+underserved domains: Sortera provides a tangible Dimensional Change Card Sort
+implementation \citep{zelazo2006dccs} that strengthens cognitive flexibility
+and inhibitory control, while R\"akna opens the early-mathematics
+domain that \citet{duncan2007school} identified as the single strongest
+predictor of later academic achievement. Remaining areas with limited coverage
+include:
 
 \begin{enumerate}[noitemsep]
-  \item \textbf{Spatial reasoning}: Currently addressed only by Fl\"ode. A
-    tangram or construction mode would add breadth.
-  \item \textbf{Problem solving}: Fl\"ode (primary) and Sequencer (debugging)
-    address this, but more puzzle types would strengthen the domain.
+  \item \textbf{Spatial reasoning}: Still primarily Fl\"ode; R\"akna's linear
+    number path contributes incidentally. A tangram or construction mode would
+    add breadth.
+  \item \textbf{Problem solving}: Fl\"ode (primary), Sequencer (debugging),
+    and R\"akna (equation building) now all contribute; a scavenger-hunt style
+    NFC puzzle mode would further broaden the domain.
   \item \textbf{Bilingual exposure}: Story Mode provides full narration in
-    both languages, and Sortera now offers active bilingual reinforcement
+    both languages, and Sortera and R\"akna add active bilingual reinforcement
     (dual-language labels and TTS on each card scan). A dedicated
     language-switching game could further leverage the bilingual advantage for
     EF development \citep{bialystok2011reshaping}.

--- a/docs/story_authoring.md
+++ b/docs/story_authoring.md
@@ -249,18 +249,56 @@ Good sources for age-appropriate stories:
 ```
 assets/stories/my_story/
     script.py               # story script (required)
+    recordings/             # optional hand-recorded narration (see below)
+        sv/
+            opening.wav
+            opening_choices.wav
+        en/
+            opening.wav
     sfx/                    # optional sound effects
         door_creak.wav
         splash.wav
 
 # After TTS generation:
-build/story_tts/
-    sv/story_my_story_opening.wav
-    sv/story_my_story_opening_choices.wav
-    en/story_my_story_opening.wav
-    en/story_my_story_opening_choices.wav
+build/story_tts_raw/my_story/
+    sv/opening.wav
+    sv/opening_choices.wav
+    en/opening.wav
+    en/opening_choices.wav
     ...
+
+# After audio conversion — self-contained SD packages:
+build/stories/my_story/
+    script.py
+    tts/
+        sv/opening.wav
+        sv/opening_choices.wav
+        en/...
+    recordings/             # normalised hand-recordings (if any)
+        sv/opening.wav
 ```
+
+`tools/sd-sync.py` copies each package under `build/stories/<id>/` to
+`/sd/stories/<id>/` on the card. At runtime the story module discovers stories
+by scanning the SD card, so adding a story is just dropping a new folder under
+`build/stories/` and re-syncing.
+
+## Hand-recorded narration
+
+Any narration or choice line can be replaced with a human recording — drop a
+WAV at `assets/stories/{story_id}/recordings/{lang}/{node}.wav` (or
+`{node}_choices.wav` for choice narration). Filenames must match node IDs
+exactly; otherwise the file is ignored.
+
+`tools/convert_audio.py` normalises recordings to 16 kHz mono PCM with loudnorm
+(same target as TTS) into `build/stories/{id}/recordings/{lang}/`.
+`sd-sync.py` ships them alongside the generated TTS, and on the device
+`bodn.assets.resolve_voice()` prefers recordings over TTS at each storage layer.
+
+Coverage is incremental — record one node, the rest stay on TTS. **Footgun:**
+if you change the script text after recording, the old recording silently
+shadows the regenerated TTS. Delete (or re-record) the affected file whenever
+you edit its corresponding node text.
 
 ## Testing
 


### PR DESCRIPTION
Brings the README in sync with the current state: adds Sortera and Räkna
NFC games to the feature list, expands the firmware tree with new modules
(assets/tts/pn532/stories/native_i2c/neo and the new UI screens), documents
the five cmodules (_audiomix, _spidma, _draw, _mcpinput, _neopixel),
updates the roadmap (PN532 and NFC games shipped, 12 game modes), refreshes
card-set and OpenMoji counts, and adds a Stories and TTS section covering
Piper pipelines and hand-recorded overrides.