### PR TITLE
docs: six more invokable skills for recurring workflows

### DIFF
--- a/.claude/skills/add-c-module/SKILL.md
+++ b/.claude/skills/add-c-module/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: add-c-module
+description: Add a native C user-module (cmodules/<name>/) to the custom MicroPython firmware. Use when CPU-bound work (audio mixing, DMA display, LED animation, deterministic input scanning) needs to escape the Python VM. Covers the cmake plumbing, Python binding boilerplate, build-firmware.sh workflow, and the one-time ESP-IDF setup.
+---
+
+# Add a native C module
+
+The Bodn firmware is stock MicroPython v1.27.0 plus a handful of C user-modules
+under `cmodules/`. Each module is compiled into the firmware image at build
+time and imported as `_<name>` from Python (the leading underscore marks it
+as an internal module with a thin Python wrapper on top).
+
+Existing modules: `_audiomix` (core-0 mixer), `_spidma` (DMA SPI displays),
+`_draw` (bitmap fonts + blit primitives), `_mcpinput` (I2C input scan +
+PCA9685 LED animation), `_neopixel` (pattern engine + RMT driver).
+
+## Directory layout
+
+```
+cmodules/
+├─ micropython.cmake              # top-level, `include()`s each sub-module
+└─ <name>/
+   ├─ micropython.cmake           # INTERFACE lib declaration
+   ├─ <name>_mod.c (or <name>.c)  # Python bindings: MP_REGISTER_MODULE, method table
+   ├─ <impl>.c/h                  # pure C implementation (testable without MP)
+   └─ ...
+```
+
+Minimal `<name>/micropython.cmake`:
+
+```cmake
+add_library(usermod_<name> INTERFACE)
+
+target_sources(usermod_<name> INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}/<name>_mod.c
+    ${CMAKE_CURRENT_LIST_DIR}/<impl>.c
+)
+
+target_include_directories(usermod_<name> INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_link_libraries(usermod INTERFACE usermod_<name>)
+```
+
+Then add one line to `cmodules/micropython.cmake`:
+
+```cmake
+include(${CMAKE_CURRENT_LIST_DIR}/<name>/micropython.cmake)
+```
+
+## Python binding skeleton
+
+`<name>_mod.c` registers the module and its method table. Minimal shape
+(see `cmodules/neopixel/neopixel_mod.c` for a full example):
+
+```c
+#include "py/runtime.h"
+#include "py/obj.h"
+
+static mp_obj_t mymod_do_thing(mp_obj_t arg) {
+    // ...
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(mymod_do_thing_obj, mymod_do_thing);
+
+static const mp_rom_map_elem_t mymod_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR__mymod) },
+    { MP_ROM_QSTR(MP_QSTR_do_thing), MP_ROM_PTR(&mymod_do_thing_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SOME_CONST), MP_ROM_INT(42) },
+};
+static MP_DEFINE_CONST_DICT(mymod_module_globals, mymod_module_globals_table);
+
+const mp_obj_module_t mymod_cmod_module = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&mymod_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR__mymod, mymod_cmod_module);
+```
+
+Argument parsing patterns:
+- `MP_DEFINE_CONST_FUN_OBJ_{0,1,2,3}` — fixed-arity functions.
+- `MP_DEFINE_CONST_FUN_OBJ_KW` + `mp_arg_parse_all` — keyword args.
+- Read buffers with `mp_get_buffer_raise()`; return with `mp_obj_new_bytearray`.
+
+## Building the firmware
+
+One-time prerequisites:
+
+```bash
+git submodule update --init --recursive      # micropython/micropython @ v1.27.0
+git clone -b v5.5.1 --recursive https://github.com/espressif/esp-idf.git ~/esp-idf
+~/esp-idf/install.sh esp32s3
+```
+
+Every terminal session:
+
+```bash
+source ~/esp-idf/export.sh       # once per session
+./tools/build-firmware.sh         # full build
+./tools/build-firmware.sh flash   # build + flash
+./tools/build-firmware.sh clean   # remove build-BODN_S3/
+```
+
+`build-firmware.sh` auto-sources ESP-IDF from `$IDF_PATH`, `~/esp-idf`,
+`~/esp/esp-idf`, or `/opt/esp-idf` if the toolchain isn't already in `$PATH`.
+
+## Core & task layout
+
+Rule of thumb from existing modules:
+
+- **Core 0** (protocol core) runs FreeRTOS tasks for real-time work —
+  `_audiomix` mixer + I2S pump, `_neopixel` pattern engine + RMT,
+  `_mcpinput` 500 Hz input scan.
+- **Core 1** runs the MicroPython VM and `asyncio` tasks.
+- Shared state uses lock-free SPSC ring buffers (`cmodules/audiomix/ringbuf.c`)
+  or atomic reads/writes of small state — **no mutexes** across the core
+  boundary.
+- For display data paths, prefer ISR-driven DMA (see `_spidma`) over
+  FreeRTOS tasks.
+- Keep task stacks tight (the NeoPixel engine uses 3 KB). ESP32-S3 PSRAM
+  **must not** be used for FreeRTOS stacks — DRAM only.
+
+## sdkconfig changes
+
+Board-specific sdkconfig layering lives in
+`boards/BODN_S3/sdkconfig.board`. If your module needs a non-default
+Kconfig (e.g. `CONFIG_FREERTOS_UNICORE=n`, IRAM-safe I2S), add it there.
+The layering order is set in `boards/BODN_S3/mpconfigboard.cmake`.
+
+## Python wrapper
+
+Typical pattern in `firmware/bodn/<name>.py`:
+
+```python
+import _mymod
+
+class MyEngine:
+    def __init__(self, pin):
+        _mymod.init(pin=pin)
+    def do_thing(self):
+        _mymod.do_thing()
+```
+
+There is **no Python fallback** in the current firmware — `audio.py`,
+`arcade.py`, `patterns.py`, and `st7735.py` all hard-import their C
+modules. If you want the device to run on stock MicroPython too, gate the
+import with `try: import _mymod; except ImportError: ...` and write a
+slow-path Python equivalent. CLAUDE.md still mentions a viper fallback for
+`_audiomix` — that path has been removed.
+
+## Verification
+
+1. `./tools/build-firmware.sh` succeeds and produces
+   `micropython/ports/esp32/build-BODN_S3/firmware.bin`.
+2. On-device REPL: `import _<name>; dir(_<name>)` lists the expected
+   functions.
+3. Host tests for the pure-C parts (if any) can run under the MicroPython
+   Unix port — see CLAUDE.md "MicroPython Unix port".
+
+## Invariants
+
+- `cmodules/<name>/micropython.cmake` must use `INTERFACE` libs and link
+  into the global `usermod` target, not a new target.
+- `MP_QSTR_*` identifiers must match exactly — typos silently produce an
+  `AttributeError` at runtime, not a compile error.
+- Committed firmware binaries (none currently) would need the same treatment
+  as the Wokwi `.wasm` — see the `wokwi-chip-rebuild` skill.
+- Performance-critical work belongs in C; UX glue belongs in MicroPython.
+  Don't port game logic to C — the rules engines stay host-testable.

--- a/.claude/skills/add-nfc-card-set/SKILL.md
+++ b/.claude/skills/add-nfc-card-set/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: add-nfc-card-set
+description: Add a new NFC card set (e.g. fruit, flowers, clothing) or a new card to an existing set. Use when expanding Sortera/Räkna card collections, adding launcher tags, or introducing a new NFC-driven mode. Covers the JSON schema, OpenMoji icons, printable PDF generation, SD sync, web mirror, and on-device provisioning.
+---
+
+# Add an NFC card set
+
+Card sets are the unit of content for NFC-driven modes (Sortera, Räkna,
+launcher). Each set is a single JSON file that drives three downstream
+artefacts — the firmware runtime, a printable PDF, and the web landing page
+at `bodn.thias.se`. Keep the JSON authoritative; everything else regenerates
+from it.
+
+## The source of truth
+
+`assets/nfc/{mode}.json` — one file per set.
+
+```json
+{
+  "mode": "sortera",
+  "version": 1,
+  "dimensions": ["animal", "vehicle", "colour"],
+  "cards": [
+    {"id": "cat_red", "category": "animal", "animal": "cat",
+     "colour": "red", "label_sv": "katt", "label_en": "cat",
+     "icon": "1F431"}
+  ]
+}
+```
+
+- `mode` matches the filename (used in the NDEF URL path).
+- `dimensions` are the sortable attributes — each card must carry a value
+  for every listed dimension.
+- `id` is unique within the set; used both in the URL
+  (`https://bodn.thias.se/1/sortera/cat_red`) and as the dict key on the
+  device.
+- `icon` is an OpenMoji Unicode codepoint (hex, uppercase, no prefix). The
+  card generator looks up `~/openmoji/color/svg/{icon}.svg`.
+- `label_sv` / `label_en` live **inside the card JSON**, not in
+  `firmware/bodn/lang/`. Card-set text is not routed through `i18n.t()`.
+
+Special sets:
+
+| File | Purpose |
+|---|---|
+| `launcher.json` | Tags that start a game mode (no card id in URL after mode) |
+| `sortera.json` | Classification cards with `category` + other dimensions |
+| `rakna.json` | Counting/math cards |
+
+## Checklist
+
+1. **Create or edit the JSON** in `assets/nfc/{mode}.json`. Validate every
+   card carries the full set of `dimensions` keys plus `id`, `label_sv`,
+   `label_en`, `icon`.
+2. **Generate printable PDFs** (A4 sheets, 48×80 mm card faces):
+   ```bash
+   uv run python tools/generate_cards.py --set {mode}
+   uv run python tools/generate_cards.py --dry-run            # preview only
+   ```
+   Requires OpenMoji SVGs at `~/openmoji` (or `$OPENMOJI_DIR`). Output lands
+   in `build/cards/{mode}.pdf`.
+3. **Sync to SD card** — `tools/sd-sync.py` already maps `assets/nfc/` to
+   `/sd/nfc/`, so a normal sync carries the change:
+   ```bash
+   uv run python tools/sd-sync.py /Volumes/BODN_SD
+   ```
+4. **Program the physical tags** on the device:
+   - Home → Settings → NFC card set viewer.
+   - Pick the set, scroll to a card, tap a blank tag to write its NDEF URL
+     record. See `firmware/bodn/ui/nfc_provision.py`.
+5. **Rebuild the web container** if the set should appear on
+   `bodn.thias.se`:
+   ```bash
+   cd web && docker compose up --build
+   ```
+   `web/Dockerfile` bakes `assets/nfc/` into the image at build time, so
+   fresh JSONs need a rebuild, not a restart.
+
+## NDEF URL scheme
+
+Tags store an NDEF URI Record with prefix `0x04` (`https://`). The device
+parses the URL path:
+
+```
+https://bodn.thias.se/1/sortera/cat_red
+                       │ │       └─ card id (optional)
+                       │ └─ mode (matches filename)
+                       └─ schema version
+```
+
+See `docs/nfc.md` for the full format, legacy Text Record fallback, and
+special admin/launcher URLs.
+
+## Firmware integration
+
+```python
+from bodn.nfc import load_card_set, lookup_card, list_card_sets
+
+cs = load_card_set("sortera")      # SD first, flash fallback; None on error
+card = lookup_card("sortera", "cat_red")
+for mode in list_card_sets():      # scans /sd/nfc/ then /nfc/
+    ...
+```
+
+If a mode filters to only programmed tags, use `UIDCache()` + the
+`_filter_by_cache()` pattern in `firmware/bodn/ui/sortera.py:89` — copy it,
+don't reinvent.
+
+## Related follow-ups
+
+- **New game mode driven by the set** → see the `add-game-mode` skill for
+  the developmental-science docs update.
+- **Spoken card labels** → allowlist the keys and run the `tts-pipeline`
+  skill.
+- **New OpenMoji glyph on the home screen** → `tools/convert_icons.py`
+  regenerates BDF sprites (run automatically by `sd-sync.py`).
+
+## Invariants
+
+- JSON is authoritative. Never add card data in firmware code paths —
+  always via `assets/nfc/*.json`.
+- `id` must be stable once printed. Renaming breaks already-written tags.
+- OpenMoji is CC-BY-SA; keep attribution intact. Do not substitute a
+  different emoji set without checking the licence.
+- The web mirror is public. Do not put anything in card labels you would
+  not want on the open internet.

--- a/.claude/skills/add-screen/SKILL.md
+++ b/.claude/skills/add-screen/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: add-screen
+description: Add a new UI screen (game mode, settings page, overlay, secondary content) that plugs into ScreenManager. Use whenever a mode needs its own primary-display view or secondary-display content. Covers the Screen lifecycle, dirty tracking, sprite caching in enter(), section bitmasks for multi-region screens, and the NFC tag hook. Complements add-game-mode (science docs) and perf-review (hot-path rules).
+---
+
+# Add a UI screen
+
+Every interactive view in Bodn is a `Screen` subclass managed by
+`ScreenManager` (see `firmware/bodn/ui/screen.py`). The manager runs in two
+phases: `update()` for logic, `render()` for drawing, and skips the SPI push
+entirely when no screen reports dirty state.
+
+## Lifecycle
+
+```python
+class MyScreen(Screen):
+    def enter(self, manager):        # pre-render sprites, allocate buffers
+        ...
+    def exit(self):                   # free long-lived allocations
+        ...
+    def on_reveal(self):              # revealed after pop — default sets _full_clear
+        ...
+    def update(self, inp, frame):    # state + input; NEVER draw here
+        ...
+    def needs_redraw(self):           # return True only when something changed
+        return self._dirty
+    def render(self, tft, theme, frame):  # draw; only called when dirty
+        ...
+```
+
+`enter()` receives the `ScreenManager` — stash it as `self._manager` if you
+need `manager.push/pop/replace/invalidate`.
+
+## Registering the screen
+
+1. **Mode screens** go in `firmware/bodn/ui/<mode>.py`.
+2. Register in `firmware/bodn/ui/home.py`'s mode carousel (via the
+   `mode_screens` dict passed to `HomeScreen`).
+3. If the mode needs an icon on the home carousel, add it to
+   `firmware/bodn/ui/icons.py` (`MODE_ICONS`).
+4. All user-facing labels go through `i18n.t("key")` — see the
+   `add-i18n-string` skill.
+
+## Dirty state
+
+One `_dirty` flag is fine for single-region screens (`home.py`, most
+settings pages). **Multi-region screens must use a section bitmask.**
+Reference pattern from `firmware/bodn/ui/demo.py:33`:
+
+```python
+_D_HEADER  = const(1)
+_D_BUTTONS = const(2)
+_D_ARCADE  = const(4)
+_D_ALL     = const(7)
+
+def enter(self, manager):
+    self._dirty_sections = _D_ALL
+
+def needs_redraw(self):
+    return self._dirty_sections != 0
+
+def update(self, inp, frame):
+    if pressed:
+        self._dirty_sections |= _D_BUTTONS   # redraw only that region
+
+def render(self, tft, theme, frame):
+    ds = self._dirty_sections
+    if ds & _D_HEADER:  self._draw_header(tft, theme)
+    if ds & _D_BUTTONS: self._draw_buttons(tft, theme)
+    if ds & _D_ARCADE:  self._draw_arcade(tft, theme)
+    self._dirty_sections = 0
+```
+
+A single boolean forces a full-screen redraw on every button press — that
+is the most common perf regression in this codebase (§3.05 in
+`docs/PERFORMANCE_GUIDELINES.md`).
+
+## Sprite caching (almost always needed)
+
+Never draw scaled icons or long text pixel-by-pixel inside `render()`.
+Pre-render once in `enter()`:
+
+```python
+from bodn.ui.widgets import make_icon_sprite, make_label_sprite, blit_sprite
+
+def enter(self, manager):
+    self._icon = make_icon_sprite(emoji, scale=4, color=theme.WHITE)
+    self._label = make_label_sprite(t("my_screen_title"), scale=2)
+
+def render(self, tft, theme, frame):
+    blit_sprite(tft, self._icon, 80, 40)
+    blit_sprite(tft, self._label, 40, 120)
+```
+
+A scale-4 icon via `fill_rect` costs ~30 ms; `blit_sprite()` costs ~0.1 ms.
+Sprite buffers >8 KB go to PSRAM automatically. `home.py` has the
+reference pattern with per-mode sprite dicts. See the `sprite-cache-convert`
+skill if retrofitting an existing screen.
+
+## Animating in a narrow band
+
+The `_spidma` module pushes 32 KB DMA chunks at 40 MHz. A dirty rect that
+fits in **one chunk (≤50 full-width rows on the primary display)** costs
+~1 ms; each extra chunk adds ~6.5 ms of blocking. Design animations to
+stay within a narrow horizontal band, and call
+`manager.request_show(x, y, w, h)` for small partial pushes that don't
+need a re-render.
+
+## Secondary display content
+
+The 128×160 ST7735 is split into a 128×128 content zone (`y < 128`) and a
+32-row status strip (`y ≥ 128`). Content screens live in
+`firmware/bodn/ui/<mode>_secondary.py` and are registered via
+`SecondaryManager.set_content(screen)` — see `firmware/bodn/ui/secondary.py`
+and `firmware/bodn/ui/garden_secondary.py` for the pattern. Secondary
+screens must stay within their zone bounds; crossing into the status strip
+corrupts the battery/session indicator.
+
+## NFC tag routing
+
+Screens that react to NFC cards (Sortera, Räkna, launcher-style starts)
+override two class attributes and one method:
+
+```python
+class MyScreen(Screen):
+    nfc_modes = frozenset({"sortera"})   # tag modes this screen consumes
+    nfc_low_priority = False             # True → background scanner polls slower
+
+    def on_nfc_tag(self, parsed):
+        # parsed = {"prefix": 1, "version": 1, "mode": "sortera", "id": "cat_red"}
+        return True                      # True = consumed, False = fall through
+```
+
+Cooperative scanning across all modes is wired in the main loop — you only
+implement the hook. See PR #143 and `firmware/bodn/nfc.py` for the scanner.
+
+## Verification
+
+- Pytest: pure-logic modules (rules engines, state machines) go in
+  `firmware/bodn/<mode>_rules.py` and get unit-tested on the host.
+- On-device: `tools/sync.sh` + REPL `import main; main.run()`.
+- Perf: enable `manager.debug_perf = True` in `boot.py`; it prints
+  drawn/skipped frame ratios every ~1.5 s.
+
+## Invariants (from perf-review)
+
+- State updates belong in `update()`, never `render()`. `render()` can be
+  skipped when the frame budget is tight — state written there gets lost.
+- No `import` inside hot loops; no per-frame allocations in `update` or
+  `render`. Reuse buffers, cache `self.*` and module attributes as locals.
+- No `tft.fill(BLACK)` in `render()` — the manager handles full clears on
+  transitions. Use `fill_rect()` for the changed sub-region only.
+- Multi-region screens → section bitmask, not a single `_dirty`.
+- Sprites for anything drawn at >1× scale or with non-trivial glyphs.
+- If the mode introduces a new developmental focus, run the
+  `add-game-mode` skill to update `docs/science/`.

--- a/.claude/skills/add-story/SKILL.md
+++ b/.claude/skills/add-story/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: add-story
+description: Author a new branching narrative for Story Mode, or add recorded narration to an existing one. Use when writing a new story script, porting a public-domain tale, or replacing Piper TTS lines with human recordings. Covers the script.py schema, TTS generation, hand-recorded overrides, and the SD package layout the device expects.
+---
+
+# Add a story
+
+Story Mode is a data-driven branching narrative engine. Each story is a
+self-contained package on the SD card: one `script.py` describing nodes
+and choices, plus pre-generated (or hand-recorded) audio per node per
+language. The device discovers stories by scanning `/sd/stories/*/` at
+startup.
+
+## Directory layout
+
+```
+assets/stories/<story_id>/
+├─ script.py                            # STORY dict (authoritative)
+└─ recordings/
+   └─ {sv,en}/
+      ├─ <node_id>.wav                  # hand-recorded narration (optional)
+      └─ <node_id>_choices.wav           # hand-recorded choice prompts (optional)
+
+build/stories/<story_id>/                # assembled by convert_audio.py
+├─ script.py                             # copied as-is
+├─ tts/{sv,en}/<node_id>.wav             # 16 kHz mono PCM
+├─ tts/{sv,en}/<node_id>_choices.wav
+└─ recordings/{sv,en}/...                # normalised recordings (if any)
+```
+
+`sd-sync.py` copies `build/stories/` to `/sd/stories/`. The device resolves
+audio as `recording > TTS` within each storage layer (SD first, flash
+second).
+
+## script.py schema
+
+```python
+STORY = {
+    "id": "peter_rabbit",                # unique; becomes directory name
+    "version": 1,
+    "title": {"sv": "Pelle Kanin", "en": "Peter Rabbit"},
+    "author": "Beatrix Potter",          # optional — credit public-domain sources
+    "age_min": 3,
+    "age_max": 6,
+    "estimated_minutes": 4,
+    "narrate_choices": True,             # speak "press green to…" between scenes
+    "start": "home",                     # node id to begin at
+    "nodes": {
+        "home": {
+            "text": {
+                "sv": "Pelle Kanin bodde...",
+                "en": "Peter Rabbit lived...",
+            },
+            "mood": "warm",              # warm|happy|wonder|tense|scary|…
+            "choices": [
+                {"label": {"sv": "Gå till trädgården",
+                           "en": "Go to the garden"},
+                 "next": "garden_gate"},
+                {"label": {"sv": "Plocka bär",
+                           "en": "Pick berries"},
+                 "next": "berries"},
+            ],
+        },
+        "berry_end": {
+            "text": {"sv": "...", "en": "..."},
+            "mood": "happy",
+            "ending": True,              # terminal node
+            "ending_type": "happy",
+        },
+        # ...
+    },
+}
+```
+
+- **`nodes`** is a flat dict — no nesting. `choices[].next` references
+  another node id; ending nodes set `ending: True`.
+- **`mood`** drives a colour wash on the top third of the primary display
+  and a palette for LEDs. Re-use existing values before inventing new ones.
+- **`narrate_choices`** toggles whether the TTS pipeline also generates a
+  `<node>_choices.wav` that reads the choice prompts aloud (arcade-button
+  colour names are injected in the user's language).
+- **Keep nodes short** (1–3 sentences for 3–5-year-olds). `{pause}` or
+  `{pause 1.2}` markers insert silence for dramatic effect. See the Peter
+  Rabbit sample.
+- **Public-domain sources only** unless you've cleared the rights. Credit
+  the original author in `author`.
+
+## Authoring workflow
+
+1. Create `assets/stories/<story_id>/script.py` with the STORY dict.
+2. Preview the structure in a terminal:
+   ```bash
+   uv run python tools/story_preview.py <story_id>
+   ```
+3. Generate TTS audio:
+   ```bash
+   uv run python tools/generate_story_tts.py --story <story_id>
+   uv run python tools/generate_story_tts.py --dry-run       # preview
+   uv run python tools/generate_story_tts.py                  # all stories
+   ```
+   Output: `build/story_tts_raw/<story_id>/{sv,en}/*.wav` at Piper's
+   native sample rate.
+4. Convert to device format (16 kHz mono PCM) and assemble the package:
+   ```bash
+   uv run python tools/convert_audio.py
+   ```
+   This also copies `script.py` into `build/stories/<story_id>/`.
+5. Sync to SD:
+   ```bash
+   uv run python tools/sd-sync.py /Volumes/BODN_SD
+   ```
+   (`sd-sync.py` runs steps 3–4 internally; use `--no-build` to skip.)
+6. On the device, Story Mode's picker auto-discovers the new story —
+   no registration code needed.
+
+## Hand-recorded narration
+
+Any node can be replaced by a human recording, per language, without
+touching the script. Drop a WAV at:
+
+```
+assets/stories/<story_id>/recordings/{sv,en}/<node_id>.wav
+assets/stories/<story_id>/recordings/{sv,en}/<node_id>_choices.wav
+```
+
+Filenames must match the node id exactly. `convert_audio.py` normalises
+the recording to 16 kHz mono PCM with the same `loudnorm` filter as the
+TTS pipeline, so levels stay consistent. Coverage is incremental — record
+one node, the rest stay on TTS.
+
+**Footgun**: if you change `text` in the script after recording, the old
+recording silently shadows the regenerated TTS. Delete or re-record the
+affected file.
+
+## Tuning prose for TTS
+
+Piper reads punctuation literally; short sentences sound better than long
+ones. Defaults in `tools/generate_story_tts.py`:
+
+- `length_scale = 1.2` (gentle storytelling pace)
+- `0.4 s` silence between sentences
+- `0.8 s` silence at `{pause}` markers
+
+Override per story by adding `prosody` keys to the STORY dict only if a
+story needs a different feel.
+
+## Invariants
+
+- **Node ids stable once released.** Renaming a node invalidates any
+  hand-recording using the old filename.
+- **`id` matches directory name** — both firmware discovery and the TTS
+  pipeline rely on it.
+- **Every node appears in `nodes`** — a dangling `next` reference will
+  dead-end the playthrough. The story engine does not auto-validate.
+- **Bilingual parity**: every node must supply both `sv` and `en` `text`
+  and labels. Story Mode picks the active UI language at runtime.
+- Public-domain vocabulary only. Keep sentences short, concrete, and age
+  3–5 friendly; follow `docs/UX_GUIDELINES.md`.
+- If Story Mode gets new mechanics (timer, inventory, multi-choice
+  combos), run the `add-game-mode` skill to update `docs/science/`.

--- a/.claude/skills/deploy-firmware/SKILL.md
+++ b/.claude/skills/deploy-firmware/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: deploy-firmware
+description: Pick the right path to get firmware onto the device (USB, WiFi, FTP, Wokwi) or rebuild the custom MicroPython image. Use when iterating on firmware, deploying to real hardware, debugging in the simulator, or after adding a C user-module. Summarises prerequisites and trade-offs so you don't pick a slow path when a fast one is available.
+---
+
+# Deploy firmware
+
+The Bodn toolchain has five deploy paths. Each exists for a specific
+situation — pick the wrong one and you wait minutes per iteration, or fail
+to reach the device at all.
+
+## Quick picker
+
+| Situation | Tool | Why |
+|---|---|---|
+| Simulator (Wokwi running locally) | `tools/wokwi-sync.py` | Raw TCP REPL, no USB needed |
+| USB-attached hardware, fresh flash | `tools/sync.sh --clean` | Wipes FS first, full upload |
+| USB-attached hardware, iterative dev | `tools/sync.sh` | Fast path if `mpremote` is responsive |
+| Hardware on home network (STA mode) | `tools/ftp-sync.py <ip>` | Fastest OTA — single FTP session + hash-verified commit |
+| Hardware on own AP (no home WiFi) | `tools/ota-push.py <ip>` | HTTP per-file; works on `192.168.4.1` |
+| Added a C user-module / first time | `tools/build-firmware.sh flash` | Rebuilds MicroPython + flashes via esptool |
+| Encoder IRQs are blocking mpremote | `tools/sync.sh --minimal` | Reset device, immediately push core files only |
+
+## USB (`mpremote`)
+
+```bash
+./tools/sync.sh            # push firmware/ and soft-reset
+./tools/sync.sh --clean    # wipe FS first (use after renaming/removing files)
+./tools/sync.sh --minimal  # only boot.py, main.py, st7735.py, bodn/
+uv run mpremote connect auto repl    # REPL
+```
+
+`--minimal` is the rescue path when encoder interrupts saturate the REPL
+after a soft-reboot — press the board's **RST** button, then run
+`sync.sh --minimal` within a second or two.
+
+## Wokwi simulator
+
+```bash
+uv run python tools/wokwi-sync.py         # watch mode, recommended
+uv run python tools/wokwi-sync.py --once  # one-shot sync
+```
+
+Connects to `localhost:5555` (override via first CLI arg). Keeps the TCP
+session open because Wokwi allows only one client at a time and a new
+connection cannot interrupt running code. Ctrl-C resyncs; Ctrl-C twice
+exits.
+
+## OTA over HTTP (AP mode)
+
+```bash
+uv run python tools/ota-push.py                  # AP default 192.168.4.1
+uv run python tools/ota-push.py 192.168.1.42     # specific IP
+uv run python tools/ota-push.py --wokwi          # localhost:9080
+uv run python tools/ota-push.py --force          # ignore hash cache
+uv run python tools/ota-push.py --token SECRET   # with OTA auth
+```
+
+Uploads changed files via the device's HTTP API. Hashes cached in
+`.ota-hashes.json` so unchanged files are skipped.
+
+## OTA over FTP (STA mode — fastest)
+
+```bash
+uv run python tools/ftp-sync.py 192.168.1.42
+uv run python tools/ftp-sync.py 192.168.1.42 --force
+uv run python tools/ftp-sync.py --user U --pass P
+```
+
+One FTP session uploads all dirty files to `/.ota/`, then an HTTP commit
+verifies MD5s against a MANIFEST before activating — a truncated transfer
+leaves staging intact and refuses the commit. Much faster than `ota-push`
+for any non-trivial change set, but only works on the home network (device
+in STA mode). Default FTP creds are `bodn` / `bodn` — override via
+`ftp_user` / `ftp_pass` in device settings.
+
+## Custom firmware build (C modules)
+
+```bash
+source ~/esp-idf/export.sh            # once per terminal session
+./tools/build-firmware.sh              # build
+./tools/build-firmware.sh flash        # build + flash via esptool
+./tools/build-firmware.sh clean        # rm build-BODN_S3/
+```
+
+One-time setup (MicroPython submodule + ESP-IDF v5.5.1) is documented in
+the `add-c-module` skill and the script's own header. After a flash the
+device has stock MicroPython + Bodn's C modules (`_audiomix`, `_spidma`,
+`_draw`, `_mcpinput`, `_neopixel`). You still need to push the Python
+firmware with one of the sync tools after flashing.
+
+## SD card asset sync (separate pipeline)
+
+Not deploying code, but often confused with it. SD card assets (sounds,
+TTS, stories, card set JSONs, sprites) are built and copied by a single
+command:
+
+```bash
+uv run python tools/sd-sync.py /Volumes/BODN_SD
+uv run python tools/sd-sync.py --build-only
+uv run python tools/sd-sync.py --no-build /Volumes/BODN_SD
+```
+
+See the `tts-pipeline` skill for the generation steps that feed this.
+
+## Invariants
+
+- **Never** flash with `esptool` directly; go through `build-firmware.sh
+  flash` so the board definition layering is respected.
+- **Never** commit `.ota-hashes.json` — it is a local deploy cache.
+- Wokwi sync auto-discovers all `.py` under `firmware/` — no file list to
+  maintain. New C modules still require a firmware rebuild.
+- After changing `firmware/bodn/config.py`, run the `wiring-sync` skill
+  before committing — the pre-commit hook rejects the commit otherwise.
+- When the Wokwi custom chip C source changes, run the
+  `wokwi-chip-rebuild` skill; `tools/wokwi-sync.py` alone does not
+  recompile the `.wasm`.

--- a/.claude/skills/sprite-cache-convert/SKILL.md
+++ b/.claude/skills/sprite-cache-convert/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: sprite-cache-convert
+description: Convert a screen from per-frame fill_rect/text drawing into pre-rendered sprites cached in enter() and blit per frame. Use when a screen has visible jank, dropped frames, or when perf logs show it dominating frame time. Apply mechanically — no design decisions, just a recipe with measurable wins.
+---
+
+# Sprite cache conversion
+
+The single biggest perf win on the primary display is replacing
+per-frame scaled draws (`fill_rect` per pixel, `text()` per char) with a
+pre-rendered sprite that blits in one call. A scale-4 icon rendered via
+`fill_rect` costs ~30 ms; `blit_sprite()` costs ~0.1 ms.
+
+`firmware/bodn/ui/home.py` is the reference pattern. Apply the recipe to
+any screen that draws scaled icons, large text, or repeated bitmap glyphs
+every frame.
+
+## When to apply
+
+- Perf report shows a screen with a low drawn-to-skipped ratio or visibly
+  stutters during animations.
+- `render()` contains any of: `draw_scaled_icon`, `draw_scaled_text`,
+  nested loops over pixels, or repeated `tft.text()` at scale>1.
+- A screen calls `fill_rect` hundreds of times per frame to build a single
+  logical element (icon, label, big counter).
+
+Issue #111 and PR #118 document the pattern being rolled out across the
+game screens; the skill exists so the remaining conversions stay
+consistent.
+
+## API
+
+```python
+from bodn.ui.widgets import (
+    make_icon_sprite,
+    make_label_sprite,
+    make_emoji_sprite,
+    blit_sprite,
+)
+
+#   make_icon_sprite(bitmap_data, w, h, color, scale=1)
+#   make_label_sprite(text, color, scale=1)
+#   make_emoji_sprite(name, size=48, pad=4)   # OpenMoji via _draw + SD
+#
+# All three return (framebuf, pixel_width, pixel_height).
+# blit_sprite(tft, sprite, x, y) handles transparency via a magenta key.
+```
+
+`blit_sprite()` also calls `tft.mark_dirty(x, y, pw, ph)` for you — no
+extra bookkeeping needed.
+
+## Recipe
+
+### 1. Pre-render in `enter()`
+
+Everything that depends only on theme/content goes here. Do it once per
+screen push, not once per frame.
+
+```python
+def enter(self, manager):
+    theme = manager.theme
+    self._icon_sprite = make_icon_sprite(
+        MODE_ICONS["simon"], 16, 16, theme.CYAN, scale=4,
+    )
+    self._title_sprite = make_label_sprite(t("simon_title"), theme.WHITE, scale=2)
+    # For OpenMoji: falls back to None if _draw/SD unavailable
+    self._emoji_sprite = make_emoji_sprite("cat", size=64)
+```
+
+### 2. Blit in `render()`
+
+```python
+def render(self, tft, theme, frame):
+    fb, pw, ph = self._icon_sprite
+    blit_sprite(tft, self._icon_sprite, (320 - pw) // 2, 40)
+    blit_sprite(tft, self._title_sprite, 20, 120)
+```
+
+### 3. Invalidate the cache when inputs change
+
+If the sprite depends on theme, language, selection, or any other input
+that can change, rebuild it in response — not every frame.
+
+```python
+def _rebuild_sprites(self, theme):
+    self._icon_sprite = make_icon_sprite(...)
+    self._label_sprite = make_label_sprite(t(self._label_key), ...)
+
+def on_reveal(self):
+    super().on_reveal()
+    self._rebuild_sprites(self._theme)    # theme or i18n may have changed
+```
+
+The home screen lazy-builds per-mode sprites into `self._icon_sprites = {}`
+on first render — follow that pattern for carousels.
+
+## Memory cost
+
+Sprite buffers are `pixel_width * pixel_height * 2` bytes (RGB565). A
+scale-4 16×16 icon is 64×64 × 2 = 8 KB. Anything over 8 KB goes to PSRAM
+automatically via MicroPython's bytearray allocator, but keep an eye on
+totals for screens with many pre-rendered variants. Free large buffers in
+`exit()` if needed — the default is to let them GC when the screen is
+popped.
+
+## Verification
+
+1. Enable `manager.debug_perf = True` in `boot.py` and watch the
+   `drawn/total` ratio improve on the converted screen.
+2. Check that `render()` has no nested pixel loops and no `fill_rect`
+   calls inside a tight per-element loop (outside of the sprite pre-render
+   in `enter()`).
+3. Scroll or animate the screen on hardware (not just Wokwi — DMA SPI
+   timing differs).
+
+## Invariants
+
+- **Never** call `make_*_sprite()` inside `render()` or `update()`. It
+  allocates a fresh FrameBuffer each time and undoes the whole point of
+  caching.
+- `blit_sprite()` uses magenta (`0x1FF8`) as the transparency key. Do not
+  use that exact colour in sprite content — it will be punched through.
+- Sprites are RGB565. If the display was configured in a different colour
+  mode the blit colours will be wrong; ST7735 defaults in this project
+  are fine.
+- OpenMoji emoji sprites require the `_draw` C module and SD-card BDF
+  assets. On stock MicroPython or a device with no SD, `make_emoji_sprite`
+  returns `None` — code must handle the fallback (home.py falls back to
+  `make_icon_sprite`).
+- This conversion never adds features — it is a mechanical perf change.
+  Review the `perf-review` skill checklist once done.


### PR DESCRIPTION
## Summary

Follow-up to #145. Extracts six more multi-step workflows into `.claude/skills/` — all identified by scanning the last 30 PRs and open issues for patterns that recur and are easy to get wrong.

- **add-nfc-card-set** — JSON schema + `generate_cards.py` PDFs + SD/web sync + on-device provisioning. Directly unblocks #134 (more card categories).
- **add-c-module** — `cmodules/<name>/` layout, cmake plumbing, Python binding skeleton, `build-firmware.sh` + ESP-IDF setup. Covers the pattern used by `_audiomix`, `_spidma`, `_draw`, `_mcpinput`, `_neopixel`.
- **add-screen** — `Screen` lifecycle, section-level dirty bitmasks, sprite caching in `enter()`, secondary-display zone rules, NFC tag hook.
- **deploy-firmware** — Picker for `sync.sh` / `wokwi-sync.py` / `ota-push.py` / `ftp-sync.py` / `build-firmware.sh` based on USB vs AP vs STA vs simulator vs C-module rebuild.
- **sprite-cache-convert** — Mechanical recipe for converting per-frame `fill_rect`/`text` into pre-rendered sprites (issue #111 / PR #118 pattern).
- **add-story** — `script.py` schema for branching narratives, `generate_story_tts.py` flow, hand-recorded overrides, SD package layout.

No changes to `CLAUDE.md` — these are all new workflows surfaced on demand.

## Test plan

- [ ] `ls .claude/skills/` shows all 12 skill directories (6 from #145 + 6 new)
- [ ] Each new SKILL.md parses as valid frontmatter (`name`, `description`, `type` not required for project skills)
- [ ] Invoke each skill via `/<name>` and verify it surfaces at the right trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)