### PR TITLE
fix: crash when starting Garden of Life evolution

### DIFF
--- a/cmodules/life/life_mod.c
+++ b/cmodules/life/life_mod.c
@@ -45,9 +45,10 @@ static mp_obj_t life_step_fn(size_t n_args, const mp_obj_t *args) {
     int pal_len = pal_buf.len / 3;
 
     // Output grid — a fresh bytearray the Python caller can hold onto.
-    mp_obj_t new_grid_obj = mp_obj_new_bytearray(total, NULL);
-    mp_buffer_info_t new_buf;
-    mp_get_buffer_raise(new_grid_obj, &new_buf, MP_BUFFER_WRITE);
+    // Use the by-ref constructor with a GC-tracked buffer; passing NULL to the
+    // copying mp_obj_new_bytearray memcpys from address 0 and crashes.
+    uint8_t *new_buf = m_new(uint8_t, total);
+    mp_obj_t new_grid_obj = mp_obj_new_bytearray_by_ref(total, new_buf);
 
     // Scratch buffers for births/deaths — at most w*h events each.
     uint8_t *births_buf = m_new(uint8_t, 2 * total);
@@ -57,7 +58,7 @@ static mp_obj_t life_step_fn(size_t n_args, const mp_obj_t *args) {
 
     life_step(
         (const uint8_t *)grid_buf.buf,
-        (uint8_t *)new_buf.buf,
+        new_buf,
         w, h,
         (uint16_t)birth_mask,
         (uint16_t)survive_mask,

--- a/firmware/bodn/ui/garden.py
+++ b/firmware/bodn/ui/garden.py
@@ -129,7 +129,9 @@ class GardenScreen(Screen):
         self._plant_count = 0  # user-planted cells (not from evolution)
         self._last_plant_ms = 0  # for idle detection
 
-        # Rule modifiers (from toggle switches)
+        # Rule modifiers (from toggle switches) — seeded here so render() works
+        # even if update() hasn't run yet (e.g. pause menu open on first frame).
+        self._speed_ms = SPEED_DEFAULT_MS
         self._friendly = False
         self._wrap = False
 


### PR DESCRIPTION
## Summary

Two bugs hidden behind each other in the Garden of Life screen, both triggered by pressing the right encoder button (toggle-run):

- **`GardenScreen._speed_ms` uninitialised** — only assigned inside `update()`, after the pause-menu early return. If `render()` ran before `update()` wrote it, the HUD path raised `AttributeError`. Seed it in `__init__` alongside the other rule modifiers.
- **Null-pointer memcpy in `_life.step`** — `cmodules/life/life_mod.c` allocated its output grid with `mp_obj_new_bytearray(total, NULL)`. MicroPython's implementation unconditionally `memcpy`s from `items`, so NULL dereferences address 0 (`LoadProhibited`, `EXCVADDR=0`, PC in ROM memcpy loop). Fires the first time `_evolve()` calls `_life.step()`. Switch to `m_new` + `mp_obj_new_bytearray_by_ref` — `life_step` writes every cell, so zero-init isn't needed.

The `_speed_ms` AttributeError had been masking the native crash; fixing the first surfaced the second.

## Test plan

- [x] `uv run pytest tests/test_life_rules.py` — 19 pass (host uses pure-Python fallback)
- [ ] Rebuild firmware (`./tools/build-firmware.sh flash`) and open Garden of Life
- [ ] Press right encoder button with empty grid — should toggle run/pause without crashing
- [ ] Plant cells, press right encoder — evolution steps run without Guru Meditation
- [ ] Open pause menu on first frame after entering Garden — HUD renders without AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)