### PR TITLE
refactor: drop dead Python LED pattern generators

### DIFF
--- a/firmware/bodn/patterns.py
+++ b/firmware/bodn/patterns.py
@@ -1,256 +1,44 @@
-# bodn/patterns.py — LED animation patterns (extracted from main.py)
+# bodn/patterns.py — shared LED buffer and helpers
 #
 # LED zones (defined in config.py):
 #   Stick A  — indices 0..7    (8 LEDs)
 #   Stick B  — indices 8..15   (8 LEDs)
 #   Lid Ring — indices 16..107 (92 LEDs, 144 LED/m strip around lid)
 #
-# Full-strip pattern functions (pattern_*) write the whole _led_buf.
-# Zone-aware helpers (zone_fill, zone_pattern) operate on a (start, count) slice.
+# Pattern generators (rainbow/pulse/chase/sparkle/bounce/wave/split/fill) now
+# live in the native _neopixel C module (see cmodules/neopixel/patterns.c).
+# Drive them from Python via `from bodn.neo import neo; neo.zone_pattern(...)`.
+#
+# What remains here is only what game-rule modules still need to compose their
+# own per-frame LED state in Python: the shared scratch buffer, the brightness
+# scaler, and LED-count constants.
 
 from micropython import const
-from bodn import config
 
 N_LEDS = const(108)  # config.NEOPIXEL_COUNT
 N_STICKS = const(16)  # config.LED_STICKS[1]
 
-# Zone constants re-exported for convenience
-ZONE_STICK_A = config.LED_STICK_A
-ZONE_STICK_B = config.LED_STICK_B
-ZONE_STICKS = config.LED_STICKS
-ZONE_LID_RING = config.LED_LID_RING
-
-# Pre-allocated LED buffer — reused by all pattern functions to avoid
-# creating a new list every frame.  Callers must treat the returned list
-# as read-only (or copy it) since the next call will overwrite it.
+# Pre-allocated LED buffer — reused by game rules to avoid creating a new list
+# every frame.  Callers must treat the returned list as read-only (or copy it)
+# since the next call will overwrite it.
 _led_buf = [(0, 0, 0)] * N_LEDS
 _BLACK = (0, 0, 0)
 
-
-def hsv_to_rgb(h, s, v):
-    """Convert HSV (0-255 each) to RGB tuple."""
-    if s == 0:
-        return (v, v, v)
-    region = (h * 6) >> 8
-    remainder = (h * 6) - (region << 8)
-    p = (v * (255 - s)) >> 8
-    q = (v * (255 - ((s * remainder) >> 8))) >> 8
-    t = (v * (255 - ((s * (255 - remainder)) >> 8))) >> 8
-    if region == 0:
-        return (v, t, p)
-    if region == 1:
-        return (q, v, p)
-    if region == 2:
-        return (p, v, t)
-    if region == 3:
-        return (p, q, v)
-    if region == 4:
-        return (t, p, v)
-    return (v, p, q)
+# Human-readable names for the C engine's PAT_* ids, in the same order as
+# _PAT_MAP in bodn/ui/demo.py.  Kept here so the demo UI can show a label
+# without pulling a string table out of C.
+PATTERN_NAMES = [
+    "Rainbow",
+    "Pulse",
+    "Chase",
+    "Sparkle",
+    "Bounce",
+    "Wave",
+    "Split",
+    "Fill",
+]
 
 
 def scale(rgb, bright):
     """Scale an RGB tuple by brightness (0-255)."""
     return ((rgb[0] * bright) >> 8, (rgb[1] * bright) >> 8, (rgb[2] * bright) >> 8)
-
-
-def pattern_rainbow(frame, speed, hue_off, bright):
-    """Smooth rainbow flowing across the strip."""
-    buf = _led_buf
-    n = N_LEDS
-    _scale = scale
-    _hsv = hsv_to_rgb
-    for i in range(n):
-        h = (hue_off + i * 255 // n + frame * speed) & 0xFF
-        buf[i] = _scale(_hsv(h, 255, 255), bright)
-    return buf
-
-
-def pattern_pulse(frame, speed, colour, bright):
-    """All LEDs pulse together in one colour."""
-    buf = _led_buf
-    phase = (frame * speed) & 0xFF
-    v = phase if phase < 128 else 255 - phase
-    v = (v * bright) >> 7
-    c = scale(colour, v)
-    for i in range(N_LEDS):
-        buf[i] = c
-    return buf
-
-
-def pattern_chase(frame, speed, colour, bright):
-    """A bright dot chases around the strip, leaving a fading tail."""
-    buf = _led_buf
-    n = N_LEDS
-    _scale = scale
-    black = _BLACK
-    pos = (frame * speed // 2) % n
-    for i in range(n):
-        dist = (pos - i) % n
-        if dist == 0:
-            buf[i] = _scale(colour, bright)
-        elif dist < 4:
-            buf[i] = _scale(colour, bright >> dist)
-        else:
-            buf[i] = black
-    return buf
-
-
-def pattern_sparkle(frame, speed, colour, bright):
-    """Random-ish sparkle — deterministic from frame number."""
-    buf = _led_buf
-    _scale = scale
-    black = _BLACK
-    bright_c = _scale(colour, bright)
-    for i in range(N_LEDS):
-        v = ((frame * speed * 7 + i * 53) * 131) & 0xFF
-        buf[i] = bright_c if v > 200 else black
-    return buf
-
-
-def pattern_bounce(frame, speed, colour, bright):
-    """A dot bounces back and forth."""
-    buf = _led_buf
-    n = N_LEDS
-    _scale = scale
-    black = _BLACK
-    cycle = (n - 1) * 2
-    pos = (frame * speed // 2) % cycle
-    if pos >= n:
-        pos = cycle - pos
-    for i in range(n):
-        dist = abs(i - pos)
-        if dist == 0:
-            buf[i] = _scale(colour, bright)
-        elif dist == 1:
-            buf[i] = _scale(colour, bright >> 1)
-        else:
-            buf[i] = black
-    return buf
-
-
-def pattern_wave(frame, speed, colour, bright):
-    """Sine-like wave of brightness across the strip."""
-    buf = _led_buf
-    n = N_LEDS
-    _scale = scale
-    for i in range(n):
-        phase = (i * 255 // n + frame * speed) & 0xFF
-        v = phase if phase < 128 else 255 - phase
-        v = (v * bright) >> 7
-        buf[i] = _scale(colour, v)
-    return buf
-
-
-def pattern_split(frame, speed, colour, bright):
-    """Two dots start from center and expand outward, then collapse."""
-    buf = _led_buf
-    n = N_LEDS
-    _scale = scale
-    black = _BLACK
-    for i in range(n):
-        buf[i] = black
-    mid = n // 2
-    cycle = mid + 1
-    pos = (frame * speed // 2) % (cycle * 2)
-    if pos >= cycle:
-        pos = cycle * 2 - pos - 1
-    for offset in range(min(pos + 1, mid + 1)):
-        v = bright if offset == pos else bright >> 2
-        a = mid + offset
-        b = mid - offset
-        if 0 <= a < n:
-            buf[a] = _scale(colour, v)
-        if 0 <= b < n:
-            buf[b] = _scale(colour, v)
-    return buf
-
-
-def pattern_fill(frame, speed, colour, bright):
-    """LEDs fill up one by one, then empty."""
-    buf = _led_buf
-    n = N_LEDS
-    _scale = scale
-    black = _BLACK
-    cycle = n * 2
-    pos = (frame * speed // 2) % cycle
-    fill = pos if pos < n else cycle - pos
-    c = _scale(colour, bright)
-    for i in range(n):
-        buf[i] = c if i < fill else black
-    return buf
-
-
-# --- Zone-aware helpers ---
-
-
-def zone_fill(zone, colour, bright=255):
-    """Fill a zone with a solid colour, optionally scaled by brightness."""
-    buf = _led_buf
-    start, count = zone
-    if bright < 255:
-        r = colour[0] * bright // 255
-        g = colour[1] * bright // 255
-        b = colour[2] * bright // 255
-        colour = (r, g, b)
-    for i in range(start, start + count):
-        buf[i] = colour
-
-
-def zone_clear(zone):
-    """Clear a zone to black. zone = (start, count)."""
-    zone_fill(zone, _BLACK)
-
-
-def zone_rainbow(zone, frame, speed, hue_off, bright):
-    """Rainbow pattern within a zone."""
-    buf = _led_buf
-    _scale = scale
-    _hsv = hsv_to_rgb
-    start, count = zone
-    for i in range(count):
-        h = (hue_off + i * 255 // count + frame * speed) & 0xFF
-        buf[start + i] = _scale(_hsv(h, 255, 255), bright)
-
-
-def zone_pulse(zone, frame, speed, colour, bright):
-    """Pulse pattern within a zone."""
-    buf = _led_buf
-    phase = (frame * speed) & 0xFF
-    v = phase if phase < 128 else 255 - phase
-    v = (v * bright) >> 7
-    c = scale(colour, v)
-    start, count = zone
-    for i in range(start, start + count):
-        buf[i] = c
-
-
-def zone_chase(zone, frame, speed, colour, bright):
-    """Chase pattern within a zone."""
-    buf = _led_buf
-    _scale = scale
-    black = _BLACK
-    start, count = zone
-    pos = (frame * speed // 2) % count
-    for i in range(count):
-        dist = (pos - i) % count
-        if dist == 0:
-            buf[start + i] = _scale(colour, bright)
-        elif dist < 4:
-            buf[start + i] = _scale(colour, bright >> dist)
-        else:
-            buf[start + i] = black
-
-
-PATTERNS = [
-    ("Rainbow", pattern_rainbow),
-    ("Pulse", pattern_pulse),
-    ("Chase", pattern_chase),
-    ("Sparkle", pattern_sparkle),
-    ("Bounce", pattern_bounce),
-    ("Wave", pattern_wave),
-    ("Split", pattern_split),
-    ("Fill", pattern_fill),
-]
-
-PATTERN_NAMES = [name for name, _ in PATTERNS]

--- a/firmware/bodn/ui/demo.py
+++ b/firmware/bodn/ui/demo.py
@@ -10,7 +10,7 @@ from bodn.ui.screen import Screen
 from bodn.ui.input import BrightnessControl
 from bodn.ui.widgets import draw_progress_bar
 from bodn.ui.pause import PauseMenu
-from bodn.patterns import PATTERNS, PATTERN_NAMES
+from bodn.patterns import PATTERN_NAMES
 from bodn.i18n import t
 from bodn.neo import neo
 
@@ -18,7 +18,7 @@ NAV = config.ENC_NAV
 ENC_A = config.ENC_A
 ENC_B = config.ENC_B
 
-# Map Python PATTERNS index → C _neopixel pattern ID
+# Demo pattern index → C _neopixel pattern ID (parallels PATTERN_NAMES)
 _PAT_MAP = [
     neo.PAT_RAINBOW,  # 0: Rainbow
     neo.PAT_PULSE,  # 1: Pulse
@@ -162,7 +162,7 @@ class DemoScreen(Screen):
         n_btn = len(inp.btn_held)
         for i in range(n_btn):
             if g.tap[i]:
-                self._active_pattern = i % len(PATTERNS)
+                self._active_pattern = i % len(PATTERN_NAMES)
                 ds |= _D_HEADER
                 self._neo_dirty = True
                 break
@@ -183,7 +183,7 @@ class DemoScreen(Screen):
 
         # Encoder A button → cycle pattern
         if inp.enc_btn_pressed[ENC_A]:
-            self._active_pattern = (self._active_pattern + 1) % len(PATTERNS)
+            self._active_pattern = (self._active_pattern + 1) % len(PATTERN_NAMES)
             ds |= _D_HEADER
             self._neo_dirty = True
 


### PR DESCRIPTION
The rainbow/pulse/chase/sparkle/bounce/wave/split/fill generators in
patterns.py have no runtime callers — the per-pixel HSV→RGB + brightness
math for all 108 LEDs runs entirely in the native _neopixel C module
(cmodules/neopixel/patterns.c), and demo.py already dispatches via
neo.zone_pattern(...).

Remove the dead pattern_* / zone_* / hsv_to_rgb / PATTERNS / ZONE_*
re-exports. Keep the pieces game-rule modules still use (N_LEDS,
N_STICKS, _led_buf, _BLACK, scale) plus PATTERN_NAMES for the demo UI
label. demo.py now sizes its pattern cycle from PATTERN_NAMES.

https://claude.ai/code/session_01QKJX3jDRizy2CkkRxorkFL