### PR TITLE
fix: hold NeoPixel data line low during light sleep

### DIFF
--- a/firmware/bodn/power.py
+++ b/firmware/bodn/power.py
@@ -77,10 +77,17 @@ class PowerManager:
         """Turn off power-hungry peripherals before entering light sleep."""
         from bodn import config
 
-        # Turn off NeoPixels
+        # Flush NeoPixels to black, stop the C engine, and hold the data line
+        # low through sleep.  Without this the RMT peripheral is clock-gated
+        # during lightsleep and the WS2812B data pin goes floating — ambient
+        # noise then occasionally latches garbage frames into the chain.
         from bodn.neo import neo
+        from machine import Pin
 
-        neo.all_off()
+        neo.set_override(neo.OVERRIDE_BLACK)
+        time.sleep_ms(50)  # let the engine transmit at least one black frame
+        neo.deinit()
+        Pin(config.NEOPIXEL_PIN, Pin.OUT, value=0)
 
         # Turn off display backlight via PCA9685 PWM channel
         if self._pwm:
@@ -170,6 +177,13 @@ class PowerManager:
         # Restore backlight via PCA9685 PWM channel
         if self._pwm:
             self._pwm.set_duty(config.PWM_CH_BACKLIGHT, 4095)
+
+        # Restart the NeoPixel engine and drop the OVERRIDE_BLACK set in
+        # pre_sleep.  init() reclaims the GPIO from the Pin.OUT hold.
+        from bodn.neo import neo
+
+        neo.init()
+        neo.clear_override()
 
         # Restore PN532 power and reinitialize
         try:


### PR DESCRIPTION
## Summary

- Flushes the NeoPixel engine to black, deinits the RMT, and drives the data GPIO low as a plain output before entering `machine.lightsleep()` — stopping ambient EMI from latching garbage frames into the chain while the device is supposedly idle.
- Restarts the engine and clears the override in `post_wake()`; `neo.init()` reclaims the pin from the `Pin.OUT` hold.
- Adds ~150 ms to the sleep transition (50 ms black-frame flush + 100 ms `engine_deinit` vTaskDelay). Sleeps are rare, so this is acceptable.

Observed symptoms before the fix, with the device sitting idle on the home screen: a handful of stick-A pixels stuck bright (e.g. "3 white + 1 yellow") with ~250 ms black blinks at irregular 1–3 s intervals, plus rare white/blue flashes on the tail pixel of the second stick. Confirmed gone after flashing.

Hardware belt-and-suspenders (10 kΩ pull-down + 220–330 Ω series resistor) tracked separately in #153.

## Test plan

- [x] 835 host tests pass (`uv run pytest`)
- [x] `ruff check` + `black --check` clean on `firmware/bodn/power.py`
- [x] Flashed and verified on device: home-screen idle-timeout no longer produces flashing pixels
- [ ] Verify after exiting a game screen with per-pixel overrides (e.g. Simon, Flöde) — overrides should be cleared cleanly through sleep
- [ ] Verify `sleep_until_master_on` path once the master switch is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)