### PR TITLE
feat: add launcher card for Ljudlabb / tone_explorer

### DIFF
--- a/assets/nfc/launcher.json
+++ b/assets/nfc/launcher.json
@@ -14,6 +14,7 @@
     {"id": "garden",     "label_sv": "trädgården",    "label_en": "garden",     "icon": "1F331"},
     {"id": "soundboard", "label_sv": "ljudbräda",     "label_en": "soundboard", "icon": "1F50A"},
     {"id": "sequencer",  "label_sv": "sekvens",       "label_en": "sequencer",  "icon": "1F941"},
+    {"id": "tone_explorer", "label_sv": "ljudlabb",   "label_en": "tone lab",   "icon": "1F3B9"},
     {"id": "blippa",     "label_sv": "blippa",        "label_en": "blip",       "icon": "1F50D"},
     {"id": "sortera",    "label_sv": "sortera",       "label_en": "sort it",    "icon": "1F9E9"},
     {"id": "rakna",      "label_sv": "räkna",         "label_en": "count",      "icon": "1F9EE"},


### PR DESCRIPTION
## Summary
- The `tone_explorer` mode (merged in #152) was registered in the home carousel but missing from `assets/nfc/launcher.json`, so no NFC launcher tag could open it.
- Added an entry between Sequencer and Blippa to match the carousel order in `firmware/main.py`.
- Icon `1F3B9` (🎹 Musical Keyboard) matches the on-device icon already declared in `assets/images/emoji_manifest.json`; labels match the i18n strings (`ljudlabb` / `tone lab`).

## Test plan
- [ ] `uv run python tools/generate_cards.py --set launcher` produces a PDF that includes the new Ljudlabb card
- [ ] Program a blank tag with the new card via the NFC provisioning UI
- [ ] Scan the tag from the home screen and confirm it launches Tone Explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)