### PR TITLE
fix: pause _mcpinput scan task across light sleep + swallow wake button

### DIFF
--- a/cmodules/mcpinput/mcpinput.c
+++ b/cmodules/mcpinput/mcpinput.c
@@ -70,6 +70,49 @@ static mp_obj_t mcpinput_deinit(void) {
 static MP_DEFINE_CONST_FUN_OBJ_0(mcpinput_deinit_obj, mcpinput_deinit);
 
 // ---------------------------------------------------------------------------
+// _mcpinput.scan_pause() / scan_resume()
+//
+// Suspend just the I2C polling work in the scan task without tearing down
+// the bus or PCA9685 device handle.  PowerManager calls scan_pause() before
+// machine.lightsleep() so the 500 Hz I2C polling does not run across the
+// sleep transition (which wedges the bus and trips RTC_WDT).  Python I2C
+// calls (mcp.refresh, etc.) still work because the mutex stays valid.
+// ---------------------------------------------------------------------------
+
+static mp_obj_t mcpinput_scan_pause(void) {
+    if (mcpinput_state != NULL) {
+        mcpinput_state->paused = 1;
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(mcpinput_scan_pause_obj, mcpinput_scan_pause);
+
+static mp_obj_t mcpinput_scan_resume(void) {
+    if (mcpinput_state != NULL) {
+        mcpinput_state->paused = 0;
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(mcpinput_scan_resume_obj, mcpinput_scan_resume);
+
+// ---------------------------------------------------------------------------
+// _mcpinput.suppress_held()
+//
+// After lightsleep, primes each pin's debouncer to its live state so a
+// button still held from the wake press doesn't fire a fresh PRESS edge
+// into the menu/game.  Also drops any queued events.  Safe to call while
+// the scan task is paused.
+// ---------------------------------------------------------------------------
+
+static mp_obj_t mcpinput_suppress_held(void) {
+    if (mcpinput_state != NULL) {
+        scanner_suppress_held(mcpinput_state);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(mcpinput_suppress_held_obj, mcpinput_suppress_held);
+
+// ---------------------------------------------------------------------------
 // _mcpinput.get_events() -> list of (type, pin, time_ms) tuples
 // ---------------------------------------------------------------------------
 
@@ -487,6 +530,9 @@ static const mp_rom_map_elem_t mcpinput_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),    MP_ROM_QSTR(MP_QSTR__mcpinput) },
     { MP_ROM_QSTR(MP_QSTR_init),        MP_ROM_PTR(&mcpinput_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit),      MP_ROM_PTR(&mcpinput_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_scan_pause),  MP_ROM_PTR(&mcpinput_scan_pause_obj) },
+    { MP_ROM_QSTR(MP_QSTR_scan_resume), MP_ROM_PTR(&mcpinput_scan_resume_obj) },
+    { MP_ROM_QSTR(MP_QSTR_suppress_held), MP_ROM_PTR(&mcpinput_suppress_held_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_events),  MP_ROM_PTR(&mcpinput_get_events_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_state),  MP_ROM_PTR(&mcpinput_read_state_obj) },
     { MP_ROM_QSTR(MP_QSTR_i2c_write),   MP_ROM_PTR(&mcpinput_i2c_write_obj) },

--- a/cmodules/mcpinput/mcpinput.h
+++ b/cmodules/mcpinput/mcpinput.h
@@ -117,6 +117,7 @@ typedef struct {
 
     // Task control
     volatile uint8_t        running;
+    volatile uint8_t        paused;         // 1 = scan loop skips all I2C work
 
     // PCA9685 LED control (optional, initialized by led_init)
     i2c_master_dev_handle_t pca_dev;        // NULL if not initialized

--- a/cmodules/mcpinput/scanner.c
+++ b/cmodules/mcpinput/scanner.c
@@ -284,6 +284,13 @@ static void scan_task(void *arg) {
     while (s->running) {
         vTaskDelay(pdMS_TO_TICKS(POLL_INTERVAL_MS));
 
+        // While paused (e.g. PowerManager light-sleep window) the task stays
+        // alive but does no I2C — touching the bus across lightsleep entry/exit
+        // wedges peripheral state and trips the RTC watchdog.
+        if (s->paused) {
+            continue;
+        }
+
         // Read both MCP ports under mutex
         xSemaphoreTake(s->i2c_mutex, portMAX_DELAY);
         err = mcp_read_ports(s, port_buf);
@@ -464,6 +471,43 @@ void scanner_deinit(mcpinput_state_t *state) {
 
     heap_caps_free(state);
     ESP_LOGI(TAG, "deinit complete");
+}
+
+void scanner_suppress_held(mcpinput_state_t *state) {
+    if (state == NULL || state->mcp_dev == NULL) return;
+
+    uint8_t buf[2];
+    xSemaphoreTake(state->i2c_mutex, portMAX_DELAY);
+    esp_err_t err = mcp_read_ports(state, buf);
+    xSemaphoreGive(state->i2c_mutex);
+
+    if (err != ESP_OK) {
+        // Couldn't read — still drop queued events so a stale press from
+        // before sleep doesn't leak through.
+        state->events.rd = state->events.wr;
+        return;
+    }
+
+    uint16_t raw = (uint16_t)buf[0] | ((uint16_t)buf[1] << 8);
+    uint32_t now = (uint32_t)(esp_timer_get_time() / 1000);
+    uint16_t port_state = 0;
+
+    for (int i = 0; i < MCPINPUT_NUM_PINS; i++) {
+        uint8_t bit = (raw >> i) & 1;
+        state->buttons[i].raw = bit;
+        // Active-low: bit=0 means pressed.  Force the debounced state to
+        // match the live reading so the next scan sees no edge.
+        state->buttons[i].state = (bit == 0) ? 1 : 0;
+        state->buttons[i].last_change_ms = now;
+        if (state->buttons[i].state) {
+            port_state |= (1 << i);
+        }
+    }
+    state->port_state = port_state;
+
+    // Drop any events that snuck into the ring while we were entering /
+    // leaving sleep so the menu/game doesn't see the wake press.
+    state->events.rd = state->events.wr;
 }
 
 // ---------------------------------------------------------------------------

--- a/cmodules/mcpinput/scanner.h
+++ b/cmodules/mcpinput/scanner.h
@@ -23,6 +23,13 @@ const char *scanner_init(const scanner_config_t *cfg, mcpinput_state_t **state_o
 // Stop task, release I2C, free state.
 void scanner_deinit(mcpinput_state_t *state);
 
+// Read current MCP port state, prime each pin's debouncer to match (so any
+// pin held when this is called registers as "already pressed" — no fresh
+// PRESS edge will fire), and drop any queued events.  Used by PowerManager
+// after lightsleep so the button that woke the device isn't replayed into
+// the menu/game on wake.
+void scanner_suppress_held(mcpinput_state_t *state);
+
 // Mutex-protected I2C write: addr + memaddr + data.
 // Returns ESP_OK on success.
 int scanner_i2c_write(mcpinput_state_t *state, uint8_t addr,

--- a/firmware/bodn/power.py
+++ b/firmware/bodn/power.py
@@ -110,6 +110,18 @@ class PowerManager:
         except Exception:
             pass
 
+        # Pause the _mcpinput C scan task: it polls MCP1 over I2C at 500 Hz
+        # from core 0.  Letting it touch the bus across machine.lightsleep()
+        # entry/exit wedges peripheral state and trips RTC_WDT (rst:0x10).
+        # The mutex stays valid so Python I2C calls (mcp.refresh in the
+        # poll-sleep loop, MCP2 toggles) keep working.
+        try:
+            import _mcpinput
+
+            _mcpinput.scan_pause()
+        except (ImportError, AttributeError):
+            pass
+
     def enter_light_sleep(self):
         """Configure wake sources and enter machine.lightsleep()."""
         import machine
@@ -164,6 +176,20 @@ class PowerManager:
     def post_wake(self):
         """Restore peripherals after waking from light sleep."""
         from bodn import config
+
+        # Suppress the wake-button press: read the live MCP state and lock
+        # any held pins into "already pressed" so the first scan cycle after
+        # resume sees no edge.  Done while the task is still paused to avoid
+        # racing the first poll, then resume.  Without this, holding a
+        # button to wake the device replays a fresh PRESS into the menu and
+        # launches whatever mode the carousel is sitting on.
+        try:
+            import _mcpinput
+
+            _mcpinput.suppress_held()
+            _mcpinput.scan_resume()
+        except (ImportError, AttributeError):
+            pass
 
         # Clear MCP23017 interrupt state and disable interrupts
         if self._mcp:


### PR DESCRIPTION
## Summary
- **Root fix for `RTCWDT_RTC_RST` after sleep:** the `_mcpinput` C scan task on core 0 was hammering MCP1 over I²C at 500 Hz right through `machine.lightsleep()` entry/exit, wedging peripheral state and tripping the RTC watchdog after the first sleep cycle. Added `paused` flag + `_mcpinput.scan_pause()` / `scan_resume()` and wired them into `PowerManager.pre_sleep()` / `post_wake()`.
- **Wake button no longer launches the highlighted mode:** when a button was held to wake the device, the scan task resumed and the debouncer saw the held pin as a fresh edge, replaying a PRESS into the menu. Added `_mcpinput.suppress_held()` which reads MCP ports and primes each pin's debouncer to match live state (so held pins are "already pressed" — no edge fires). Drops queued events too. Called from `post_wake()` while still paused, before `scan_resume()`, to avoid racing the first poll cycle.

## Test plan
- [ ] Rebuild firmware: `source ~/esp-idf/export.sh && ./tools/build-firmware.sh flash`
- [ ] Idle the device past `sleep_timeout_s` (default 5 min) and confirm no `rst:0x10 (RTCWDT_RTC_RST)` in serial log
- [ ] Trigger sleep via settings menu → confirm clean wake on button press, no `i2c.master: unexpected nack` lines
- [ ] On the home screen, hold a non-launcher button to wake → verify the carousel does **not** advance into the highlighted mode
- [ ] Repeat with each MCP1 input source (8 push buttons, 5 arcade buttons)
- [ ] Verify normal post-wake operation: backlight, NeoPixels, NFC all come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)