### PR TITLE
fix: make sync.sh robust against mpremote's 10s raw-REPL timeout

### DIFF
--- a/firmware/boot.py
+++ b/firmware/boot.py
@@ -56,8 +56,25 @@ except OSError:
 
 
 def _abort_boot():
-    """Ctrl-C during boot — exit immediately so REPL is available for mpremote."""
-    print("boot.py: interrupted — dropping to REPL")
+    """Ctrl-C during boot — skip main.py and speed up the next boot.
+
+    mpremote's raw-REPL entry does a Ctrl-D soft reset with a 10 s deadline.
+    Our normal boot (5 s safe window + WiFi + NTP + display init) easily
+    blows past that, causing ``could not enter raw repl`` on sync. Dropping
+    these flag files means:
+      * ``_skip_main`` stops main.py running in this session (shared globals).
+      * ``/skip_main``  makes the *next* boot go straight to REPL.
+      * ``/fast_boot``  makes the next boot skip WiFi/NTP.
+    Both files are one-shot — boot.py removes them as it reads them.
+    """
+    global _skip_main
+    _skip_main = True
+    try:
+        open("/skip_main", "w").close()
+        open("/fast_boot", "w").close()
+    except OSError:
+        pass
+    print("boot.py: interrupted — skipping main.py, next boot fast")
     _sys.exit()
 
 

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -1314,7 +1314,15 @@ if not _skip:
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
-        print("Bodn stopped.")
+        # Make the next boot fast + drop to REPL so mpremote (which does
+        # a Ctrl-D soft reset with a 10 s deadline) can enter raw REPL
+        # reliably. Mirror of boot.py's _abort_boot() behaviour.
+        try:
+            open("/skip_main", "w").close()
+            open("/fast_boot", "w").close()
+        except OSError:
+            pass
+        print("Bodn stopped — next boot fast.")
     except Exception as e:
         import sys
 

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -2,24 +2,37 @@
 # Sync firmware to the ESP32 device via mpremote.
 # Usage: ./tools/sync.sh [--clean] [--minimal]
 #   --clean    Wipe device filesystem before syncing
-#   --minimal  Flash only boot.py, main.py, and bodn/ (skip sounds, etc.)
-#              Useful when encoder IRQs block normal mpremote access —
-#              press RST on the devkit, then immediately run this.
+#   --minimal  Flash only boot.py, main.py, st7735.py, sdcard.py, and bodn/
+#              (skip firmware/sounds/). Useful when the device is hanging
+#              badly — press RST on the devkit, then run this immediately.
+#
+# Reliability notes
+# -----------------
+# mpremote's raw-REPL entry sends Ctrl-D (soft reset) then waits ≤ 10 s for
+# the `raw REPL` banner. Our normal boot (5 s safe-window + WiFi + NTP +
+# display init) exceeds that budget, so sync would fail with
+# `could not enter raw repl`.
+#
+# We sidestep the race by making the Ctrl-C path in boot.py / main.py drop
+# `/skip_main` and `/fast_boot` flag files. Once those are present the next
+# boot finishes in well under 10 s and mpremote can enter raw REPL reliably.
+# See firmware/boot.py `_abort_boot()` and firmware/main.py's
+# `except KeyboardInterrupt` handler.
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 MPREMOTE="uv run mpremote connect auto"
 
 if [ "${1:-}" = "--minimal" ]; then
-    echo "Deploying core files (boot.py, main.py, st7735.py, bodn/)..."
-    cd firmware
-    uv run mpremote connect auto \
+    echo "Deploying core files (boot.py, main.py, st7735.py, sdcard.py, bodn/)..."
+    cd "$ROOT/firmware"
+    $MPREMOTE \
         fs cp boot.py :boot.py + \
         fs cp main.py :main.py + \
         fs cp st7735.py :st7735.py + \
-        fs cp -r bodn :bodn
-    cd ..
-    echo "Rebooting..."
-    $MPREMOTE exec "import machine; machine.reset()" 2>/dev/null || true
+        fs cp sdcard.py :sdcard.py + \
+        fs cp -r bodn :bodn + \
+        reset
     echo "Done."
     exit 0
 fi
@@ -45,35 +58,37 @@ print('Device wiped.')
 "
 fi
 
-echo "Cleaning build artifacts..."
-find firmware -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
-find firmware -name '.DS_Store' -delete 2>/dev/null || true
-find firmware -name '*.mpy' -delete 2>/dev/null || true
-find firmware -name '*.bak' -delete 2>/dev/null || true
-
-echo "Removing old boot/main to prevent boot loops if sync fails..."
-$MPREMOTE fs rm :/boot.py 2>/dev/null || true
-$MPREMOTE fs rm :/main.py 2>/dev/null || true
+echo "Cleaning local build artifacts..."
+find "$ROOT/firmware" -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+find "$ROOT/firmware" -name '.DS_Store' -delete 2>/dev/null || true
+find "$ROOT/firmware" -name '*.mpy' -delete 2>/dev/null || true
+find "$ROOT/firmware" -name '*.bak' -delete 2>/dev/null || true
+# Stale .ota-hashes.json inside firmware/ would leak to the device
+rm -f "$ROOT/firmware/.ota-hashes.json"
 
 echo "Deploying firmware..."
-cd firmware && uv run mpremote connect auto fs cp -r . :/ && cd ..
+# Everything in one mpremote invocation = one raw-REPL entry.
+# `fs cp -r . :/` overwrites existing files, so we don't need to rm first.
+# Final `machine.reset()` kills the connection → mpremote exits non-zero,
+# which is expected.
+cd "$ROOT/firmware"
+$MPREMOTE \
+    fs cp -r . :/ + \
+    reset
+cd "$ROOT"
 
-# Update OTA hashes so next ota-push.py won't re-upload everything
+# Update OTA hashes so ota-push.py / ftp-sync.py won't re-upload everything.
 echo "Updating OTA hashes..."
 uv run python -c "
 import hashlib, json
 from pathlib import Path
-fw = Path('firmware')
+fw = Path('$ROOT/firmware')
 hashes = {}
 for p in sorted(fw.rglob('*.py')):
     if '__pycache__' not in p.parts:
         hashes[str(p.relative_to(fw))] = hashlib.md5(p.read_bytes()).hexdigest()
-Path('.ota-hashes.json').write_text(json.dumps(hashes, indent=2) + '\n')
+Path('$ROOT/.ota-hashes.json').write_text(json.dumps(hashes, indent=2) + '\n')
 print(f'  {len(hashes)} files hashed')
 "
 
-# Reboot the device — machine.reset() kills the connection so mpremote
-# will return non-zero, which is expected.
-echo "Rebooting device..."
-$MPREMOTE exec "import machine; machine.reset()" 2>/dev/null || true
 echo "Done."


### PR DESCRIPTION
## Summary

- `./tools/sync.sh` was failing with `could not enter raw repl`, requiring a manual Ctrl-C spam + delete boot.py/main.py + reset dance before each sync.
- Root cause: mpremote's raw-REPL entry does a Ctrl-D soft reset with a 10s deadline, but our boot (5s safe window + WiFi + NTP + display init) easily exceeds that.
- Fix: have `boot.py._abort_boot()` and `main.py`'s `except KeyboardInterrupt` drop `/skip_main` + `/fast_boot` flag files. Both are one-shot (consumed on the next boot), so mpremote's internal soft reset now finishes in ~1s and lands in raw REPL within budget.
- Also: collapse `sync.sh` into a single chained mpremote invocation (one raw-REPL entry instead of three), use the built-in `reset` subcommand instead of `exec "machine.reset()"` (the latter hung in follow mode waiting for an EOT that never arrives), move the stray `.ota-hashes.json` from `firmware/` to project root, and stop swallowing stderr so real errors stay diagnosable.

## Test plan

- [x] Host tests pass (`uv run pytest` — 857 passed)
- [x] `uv run ruff check firmware/` clean
- [x] `./tools/sync.sh` runs end-to-end on real hardware (ESP32-S3 + CP2102, macOS)
- [x] Device boots normally after sync (no lingering `/skip_main` or `/fast_boot`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)