### PR TITLE
feat: deploy.sh + mDNS + OTA space fix + firmware size trim + size-review skill

### DIFF
--- a/.claude/skills/deploy-firmware/SKILL.md
+++ b/.claude/skills/deploy-firmware/SKILL.md
@@ -1,38 +1,49 @@
 ---
 name: deploy-firmware
-description: Pick the right path to get firmware onto the device (USB, WiFi, FTP, Wokwi) or rebuild the custom MicroPython image. Use when iterating on firmware, deploying to real hardware, debugging in the simulator, or after adding a C user-module. Summarises prerequisites and trade-offs so you don't pick a slow path when a fast one is available.
+description: Pick the right path to get firmware onto the device (USB, WiFi, Wokwi) or rebuild the custom MicroPython image, including the repartition-and-erase procedure. Use when iterating on firmware, deploying to real hardware, debugging in the simulator, after adding a C user-module, or when reallocating flash between OTA slots and VFS. Summarises prerequisites and trade-offs so you don't pick a slow path when a fast one is available, and so you don't brick the device when changing the partition table.
 ---
 
 # Deploy firmware
 
-The Bodn toolchain has five deploy paths. Each exists for a specific
-situation — pick the wrong one and you wait minutes per iteration, or fail
-to reach the device at all.
+The Bodn toolchain has one entry point (`deploy.sh`) that picks the right
+underlying tool automatically, plus a full-reflash path for firmware
+rebuilds and partition-table changes.
 
 ## Quick picker
 
 | Situation | Tool | Why |
 |---|---|---|
-| Simulator (Wokwi running locally) | `tools/wokwi-sync.py` | Raw TCP REPL, no USB needed |
-| USB-attached hardware, fresh flash | `tools/sync.sh --clean` | Wipes FS first, full upload |
-| USB-attached hardware, iterative dev | `tools/sync.sh` | Fast path if `mpremote` is responsive |
-| Hardware on home network (STA mode) | `tools/ftp-sync.py <ip>` | Fastest OTA — single FTP session + hash-verified commit |
-| Hardware on own AP (no home WiFi) | `tools/ota-push.py <ip>` | HTTP per-file; works on `192.168.4.1` |
-| Added a C user-module / first time | `tools/build-firmware.sh flash` | Rebuilds MicroPython + flashes via esptool |
-| Encoder IRQs are blocking mpremote | `tools/sync.sh --minimal` | Reset device, immediately push core files only |
+| **Any normal Python-file deploy** | `tools/deploy.sh` | Auto-detects WiFi (via `bodn.local`) vs USB and dispatches |
+| Live iteration over USB (no copying) | `tools/deploy.sh --mount` | Mounts `firmware/` as `/remote`; edits are instant but device depends on host |
+| Added a C user-module / rebuilt firmware | `tools/build-firmware.sh flash` | Rebuilds MicroPython + flashes via esptool |
+| Wokwi simulator | `tools/wokwi-sync.py` | Raw TCP REPL — Wokwi doesn't expose USB |
+| Encoder IRQs blocking `mpremote` | `tools/sync.sh --minimal` | Reset board, push only boot/main/bodn/ within the safe-boot window |
+| Repartitioning the flash layout | Erase + full reflash | See §"Repartitioning" — very intentional path |
 
-## USB (`mpremote`)
+## `tools/deploy.sh` (normal path)
 
 ```bash
-./tools/sync.sh            # push firmware/ and soft-reset
-./tools/sync.sh --clean    # wipe FS first (use after renaming/removing files)
-./tools/sync.sh --minimal  # only boot.py, main.py, st7735.py, bodn/
-uv run mpremote connect auto repl    # REPL
+./tools/deploy.sh                        # auto (WiFi if bodn.local, else USB)
+./tools/deploy.sh --usb                  # force USB (mpremote)
+./tools/deploy.sh --wifi 192.168.1.42    # force WiFi HTTP push to an IP
+./tools/deploy.sh --mount                # live-mount (no copy, requires USB session)
+./tools/deploy.sh --force                # re-upload all files (WiFi path)
 ```
 
-`--minimal` is the rescue path when encoder interrupts saturate the REPL
-after a soft-reboot — press the board's **RST** button, then run
-`sync.sh --minimal` within a second or two.
+Under the hood it calls `tools/sync.sh` (USB via `mpremote`) or
+`tools/ota-push.py` (WiFi via HTTP). Both are delta-aware via
+`.ota-hashes.json`.
+
+- **USB** (`sync.sh`): one `mpremote fs cp -r . :/` + `reset`. Slow per-file
+  roundtrip but always works when a cable is attached.
+- **WiFi HTTP** (`ota-push.py`): per-file POST to `/api/upload` with retry,
+  writes directly to the live path (no `/.ota/` staging) so the VFS
+  partition doesn't need headroom for a second copy. Fastest for
+  few-files-changed typical edits.
+
+`tools/ftp-sync.py` still exists for bulk uploads with MANIFEST-verified
+cross-file atomicity, but is effectively legacy — HTTP handles everything
+smaller deploys need without FTP's per-file timeout cliffs.
 
 ## Wokwi simulator
 
@@ -41,53 +52,139 @@ uv run python tools/wokwi-sync.py         # watch mode, recommended
 uv run python tools/wokwi-sync.py --once  # one-shot sync
 ```
 
-Connects to `localhost:5555` (override via first CLI arg). Keeps the TCP
-session open because Wokwi allows only one client at a time and a new
-connection cannot interrupt running code. Ctrl-C resyncs; Ctrl-C twice
-exits.
+Connects to `localhost:5555` (override via first CLI arg). Wokwi allows
+only one client at a time; new connections cannot interrupt running code.
+Ctrl-C resyncs; Ctrl-C twice exits.
 
-## OTA over HTTP (AP mode)
-
-```bash
-uv run python tools/ota-push.py                  # AP default 192.168.4.1
-uv run python tools/ota-push.py 192.168.1.42     # specific IP
-uv run python tools/ota-push.py --wokwi          # localhost:9080
-uv run python tools/ota-push.py --force          # ignore hash cache
-uv run python tools/ota-push.py --token SECRET   # with OTA auth
-```
-
-Uploads changed files via the device's HTTP API. Hashes cached in
-`.ota-hashes.json` so unchanged files are skipped.
-
-## OTA over FTP (STA mode — fastest)
-
-```bash
-uv run python tools/ftp-sync.py 192.168.1.42
-uv run python tools/ftp-sync.py 192.168.1.42 --force
-uv run python tools/ftp-sync.py --user U --pass P
-```
-
-One FTP session uploads all dirty files to `/.ota/`, then an HTTP commit
-verifies MD5s against a MANIFEST before activating — a truncated transfer
-leaves staging intact and refuses the commit. Much faster than `ota-push`
-for any non-trivial change set, but only works on the home network (device
-in STA mode). Default FTP creds are `bodn` / `bodn` — override via
-`ftp_user` / `ftp_pass` in device settings.
-
-## Custom firmware build (C modules)
+## Custom firmware build (C modules / IDF config change)
 
 ```bash
 source ~/esp-idf/export.sh            # once per terminal session
 ./tools/build-firmware.sh              # build
-./tools/build-firmware.sh flash        # build + flash via esptool
+./tools/build-firmware.sh flash        # build + flash via esptool (USB)
 ./tools/build-firmware.sh clean        # rm build-BODN_S3/
 ```
 
-One-time setup (MicroPython submodule + ESP-IDF v5.5.1) is documented in
-the `add-c-module` skill and the script's own header. After a flash the
-device has stock MicroPython + Bodn's C modules (`_audiomix`, `_spidma`,
-`_draw`, `_mcpinput`, `_neopixel`). You still need to push the Python
-firmware with one of the sync tools after flashing.
+Rebuild triggers:
+
+- Added / modified a C module in `cmodules/` (see `add-c-module` skill).
+- Changed anything under `boards/BODN_S3/` — `sdkconfig.board`,
+  `mpconfigboard.h`, `mpconfigboard.cmake`, partition CSV.
+- Upgraded MicroPython submodule or ESP-IDF.
+
+After a plain firmware flash the board still needs the Python code —
+`deploy.sh` picks that up on the next run.
+
+Before committing any `boards/BODN_S3/` change, run `tools/size-review.py`
+(see the `size-review` skill) to catch imports of features you just
+disabled and to surface new optimisation leads.
+
+## Repartitioning
+
+Partition-table changes are uncommon but occasionally worth doing — the
+typical reason is reclaiming OTA-slot headroom for VFS after a trim round
+reduces firmware size. This is the only deploy operation in the toolchain
+that can brick the device if interrupted, and it always loses everything
+in VFS. Read this section before touching it.
+
+### When to bother
+
+Compute the ratio `firmware-bodn.bin / ota_slot_size`:
+
+- ≥ 90%: you're full and an added game mode will bounce the OTA. Trim
+  more (`size-review`) before repartitioning — shrinking slots doesn't
+  help if the firmware won't fit in them either.
+- 70-85%: healthy. Repartitioning nets maybe 0.5-1.0 MB of VFS and is
+  worth it if VFS is tight (current steady-state + 20% headroom).
+- ≤ 60%: slots are oversized. Repartitioning is a big win.
+
+Decide the new slot size with **at least 15% headroom** over today's
+firmware size, and round up to a 64 KiB boundary (`0x10000`) — IDF
+partition offsets have to be 4 KiB aligned but 64 KiB is cleaner and
+matches the flash sector-erase granularity.
+
+### Partition CSV
+
+Committed CSVs live in `boards/BODN_S3/`. They layer on top of the
+upstream defaults in `micropython/ports/esp32/`. Example for 2.06 MiB
+OTA slots + 3.81 MiB VFS on 8 MiB flash:
+
+```
+# Name,   Type, SubType, Offset,   Size,     Flags
+nvs,      data, nvs,     0x9000,   0x4000,
+otadata,  data, ota,     0xd000,   0x2000,
+phy_init, data, phy,     0xf000,   0x1000,
+ota_0,    app,  ota_0,   0x10000,  0x210000,
+ota_1,    app,  ota_1,   0x220000, 0x210000,
+vfs,      data, fat,     0x430000, 0x3D0000,
+```
+
+The vfs entry must be explicit when slots shrink below the stock
+`partitions-8MiBplus-ota.csv` sizes — the upstream CSV leaves vfs
+implicit by ending before end-of-flash, and the MicroPython esp32 port
+only auto-mounts the implicit remainder.
+
+Point `sdkconfig.board` at the new file:
+
+```
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-bodn-8MiB.csv"
+```
+
+### Safe reflash procedure
+
+```bash
+# 0. Sanity: firmware fits in the new slot?
+./tools/build-firmware.sh                       # rebuild with new CSV
+ls -l build/firmware-bodn.bin                   # must be ≤ new ota_0 size
+uv run python tools/size-review.py              # no hard fails
+
+# 1. Everything important on device is committed / synced off?
+#    - settings you care about exported via /api/settings
+#    - any /data/boot_log.json or session history you want to keep
+#    - any hand-recorded voices you've only got on the device
+
+# 2. Erase the whole flash. Required — a partial flash leaves old
+#    partition remnants that confuse the new layout.
+esptool.py --chip esp32s3 erase-flash
+
+# 3. Flash the new image. This writes bootloader, partition table, and
+#    ota_0 in one go.
+./tools/build-firmware.sh flash
+
+# 4. Push Python firmware + sounds. VFS is empty; this is a fresh start.
+./tools/deploy.sh --usb
+
+# 5. Re-sync SD card assets if needed (sprites, story TTS, card sets).
+uv run python tools/sd-sync.py
+```
+
+### What goes wrong
+
+- **Device boots straight into the bootloader (flashing failed)**: power
+  cycle, hold BOOT while pressing RESET, retry `build-firmware.sh flash`.
+  The erase succeeded; only step 3 has to repeat.
+- **Boot log shows `Partition table CRC mismatch`**: you ran step 3
+  without step 2. Erase and retry.
+- **Device boots but VFS errors on mount**: the old VFS partition sector
+  range overlaps the new layout. `os.umount('/')` + `os.VfsFat.mkfs(...)`
+  in REPL, or erase-flash + redo from step 2.
+- **`esp_ota_get_running_partition` returns null / OTA API errors at
+  runtime**: ota_0 and ota_1 have to be the same size. Re-check the CSV.
+
+### What the erase actually loses
+
+Everything in `/` that isn't re-uploaded by `deploy.sh`:
+
+- `settings.json` (WiFi creds, PIN, OTA token, hostname)
+- `session_history.json`
+- `/data/boot_log.json`
+- `/.ota/` staging leftovers (good riddance)
+- Any hand-recorded voices under `firmware/recordings/` — these live on
+  SD, not flash, so they *survive* unless you also wipe the SD card.
+
+A fresh device shows `wifi_mode=ap`, no PIN, default hostname. Recovery
+path: connect phone to the `Bodn` AP, visit `http://192.168.4.1`,
+reconfigure.
 
 ## SD card asset sync (separate pipeline)
 
@@ -105,9 +202,11 @@ See the `tts-pipeline` skill for the generation steps that feed this.
 
 ## Invariants
 
-- **Never** flash with `esptool` directly; go through `build-firmware.sh
-  flash` so the board definition layering is respected.
-- **Never** commit `.ota-hashes.json` — it is a local deploy cache.
+- **Never** flash with raw `esptool` for a firmware update; always go
+  through `build-firmware.sh flash` so the board definition layering,
+  partition table, and cmodules are respected. The only direct esptool
+  call in this skill is `erase-flash` during repartitioning.
+- **Never** commit `.ota-hashes.json` — it's a local deploy cache.
 - Wokwi sync auto-discovers all `.py` under `firmware/` — no file list to
   maintain. New C modules still require a firmware rebuild.
 - After changing `firmware/bodn/config.py`, run the `wiring-sync` skill
@@ -115,3 +214,5 @@ See the `tts-pipeline` skill for the generation steps that feed this.
 - When the Wokwi custom chip C source changes, run the
   `wokwi-chip-rebuild` skill; `tools/wokwi-sync.py` alone does not
   recompile the `.wasm`.
+- After changing anything in `boards/BODN_S3/`, run the `size-review`
+  skill / `tools/size-review.py` before committing.

--- a/.claude/skills/size-review/SKILL.md
+++ b/.claude/skills/size-review/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: size-review
+description: Audit the custom MicroPython firmware for size footprint — find features that are compiled in but never imported, and catch imports of features that have been disabled. Use when modifying boards/BODN_S3/ sdkconfig or mpconfigboard files, when adding a new firmware Python import that may pull in an IDF component, or when triaging "not enough space on device" OTA failures. Complements perf-review but for flash usage instead of frame time.
+---
+
+# Size review (ESP32-S3 custom firmware)
+
+MicroPython's ESP32 port is **not minimal by default** — it inherits a long
+list of ESP-IDF components (BLE stack, full TLS, PPP, cert bundles, TinyUSB
+on S3) that the Bodn firmware never touches. Every enabled-but-unused feature
+eats into the 2.4 MB OTA app slot and leaves less room in the VFS for Python
+code + OTA staging, which is what caused the "not enough space" failures.
+
+The authoritative tool is:
+
+```bash
+uv run python tools/size-review.py            # report, non-zero on hard fails
+uv run python tools/size-review.py --strict   # warnings fail too
+```
+
+It scans every `import` in `firmware/` and the effective sdkconfig merged
+from `boards/BODN_S3/mpconfigboard.cmake`'s `SDKCONFIG_DEFAULTS`. The
+pre-commit hook runs it when `boards/BODN_S3/**` or `firmware/**/*.py` is
+staged.
+
+## Two kinds of mismatch
+
+1. **Imported but disabled — HARD FAIL** (exit 1)
+   A Python file imports a module whose backing feature has been turned off.
+   The device will raise `ImportError` on boot. Either re-enable the
+   feature (and accept the size cost) or remove the import.
+
+2. **Enabled but unused — WARNING**
+   Feature is compiled in, nothing imports it. Review whether it's actually
+   needed; if not, the report prints the exact sdkconfig line(s) to add.
+
+## Reading the output
+
+```
+state  used  feature
+------ ----- -------
+on     no    BLE (NimBLE stack)
+        WARN: enabled but no Python code imports it
+        hint: drop sdkconfig.ble from SDKCONFIG_DEFAULTS ...
+```
+
+- `state` — derived from the effective sdkconfig (inherited files + board
+  override). `on` / `off` / `?` (unknown, usually a MicroPython C define the
+  analyser doesn't parse).
+- `used` — whether any firmware file imports one of the feature's gateway
+  modules (e.g. `bluetooth`, `ssl`, `btree`).
+
+`?` rows aren't warnings — the analyser just can't determine state from
+sdkconfig alone. The import check still runs on them.
+
+## Things this tool deliberately doesn't do
+
+- **Doesn't measure actual flash usage.** For that, build the firmware and
+  run `idf.py size` / `idf.py size-components`. The analyser is a static
+  lint; some kconfig switches have huge transitive effects while others do
+  almost nothing. Measure before celebrating.
+- **Doesn't parse C macro conditionals** in `mpconfigport.h`. If a
+  MICROPY_PY_* define has a complex default, the feature shows as `?`.
+  Listed features without sdkconfig keys (WebREPL, btree, binascii, etc.)
+  are import-only checks.
+- **Doesn't know about C user modules.** The `cmodules/` directory is not
+  audited here — use the `add-c-module` skill for that.
+
+## When you add a new feature
+
+If you add a new firmware Python import that pulls in an IDF component
+(e.g. starting to use TLS, or adding BLE for a future accessory), add an
+entry to the `FEATURES` list in `tools/size-review.py`:
+
+```python
+Feature(
+    name="Human readable name",
+    imports=("module_a", "module_b"),     # what to grep for in firmware/
+    off_when=[("CONFIG_FOO", "n")],       # all-must-match means off
+    on_when=[("CONFIG_FOO", "y")],        # any-match means on
+    default_on=True,                       # if ESP-IDF defaults it on
+    how_to_disable="concrete sdkconfig lines",
+    notes="rough size impact",
+),
+```
+
+Keep the list focused — features worth mentioning move ≥ 10 KB. Micro-flags
+add noise without helping.
+
+## Top-three size wins for Bodn (current state)
+
+From running the tool today:
+
+1. **BLE** — 200–300 KB. Remove `sdkconfig.ble` from
+   `SDKCONFIG_DEFAULTS`; `CONFIG_BT_ENABLED=n`.
+2. **TLS** — 100–150 KB. `CONFIG_MBEDTLS_TLS_ENABLED=n` plus the
+   client/server sub-switches.
+3. **PPP** — ~30 KB. `CONFIG_LWIP_PPP_SUPPORT=n` (+ PAP/CHAP).
+
+After trimming, consider re-partitioning `partitions-8MiBplus-ota.csv` to
+give the saved app-partition bytes back to the VFS — that's what actually
+makes OTA staging fit.
+
+See the PR that introduced `tools/size-review.py` for context.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -25,6 +25,21 @@ if [ -n "$EXISTING_PY" ]; then
     fi
 fi
 
+# --- Size-review check: run when firmware .py or board config is staged ---
+# Hard fails when a disabled feature is imported (would ImportError on
+# device). Warnings about enabled-but-unused features don't block commits —
+# use `uv run python tools/size-review.py --strict` to gate on those too.
+if echo "$STAGED" | grep -qE '^(firmware/.+\.py|boards/BODN_S3/(sdkconfig\.board|mpconfigboard\.(cmake|h)))$'; then
+    if ! uv run python tools/size-review.py >/dev/null 2>&1; then
+        echo ""
+        echo "ERROR: size-review found imports that the custom firmware has disabled."
+        echo ""
+        echo "  See:  uv run python tools/size-review.py"
+        echo ""
+        exit 1
+    fi
+fi
+
 # --- Wiring sync check: only when config.py is being committed ---
 if ! echo "$STAGED" | grep -q 'firmware/bodn/config\.py'; then
     exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,11 +174,12 @@ bodn-esp32/
 │  └─ wiring.md             # auto-generated pin diagram and tables
 ├─ tools/
 │  ├─ pinout.py             # generate wiring docs from config.py
-│  ├─ sync.sh               # deploy firmware to device via mpremote
+│  ├─ deploy.sh             # top-level deploy entry point (auto-detects USB/WiFi)
+│  ├─ sync.sh               # USB sync via mpremote (used by deploy.sh --usb)
 │  ├─ wokwi-sync.py         # deploy firmware to Wokwi simulator (raw TCP)
 │  ├─ wokwi-push.py         # push a single file into a running Wokwi sim
-│  ├─ ota-push.py           # push firmware over WiFi via HTTP (no USB needed)
-│  ├─ ftp-sync.py           # push firmware over WiFi via FTP (faster, STA mode only)
+│  ├─ ota-push.py           # WiFi push via HTTP (used by deploy.sh --wifi)
+│  ├─ ftp-sync.py           # legacy WiFi push via FTP (unreliable — prefer ota-push.py)
 │  ├─ build-firmware.sh     # build custom MicroPython firmware with C modules
 │  ├─ generate_tts.py       # generate i18n TTS WAVs from STRINGS dicts
 │  ├─ generate_story_tts.py # generate story narration TTS from story scripts
@@ -245,8 +246,16 @@ bodn-esp32/
 # Install host tools
 uv sync
 
-# Deploy firmware to device
-./tools/sync.sh
+# Deploy firmware to device (auto-detects USB vs WiFi)
+./tools/deploy.sh                         # auto (WiFi via bodn.local if resolvable, else USB)
+./tools/deploy.sh --usb                   # force USB
+./tools/deploy.sh --wifi 192.168.1.143    # force WiFi to a specific IP
+./tools/deploy.sh --mount                 # live-mount firmware/ over USB (no copy; edits are live)
+./tools/deploy.sh --force                 # re-upload all files (WiFi path)
+
+# Underlying tools (deploy.sh picks one):
+./tools/sync.sh                           # USB sync via mpremote
+uv run python tools/ota-push.py HOST       # WiFi push via HTTP
 
 # Deploy firmware to Wokwi simulator (start simulator first)
 uv run python tools/wokwi-sync.py
@@ -282,15 +291,10 @@ make -C micropython/ports/unix                     # build the Unix port binary
 # In Wokwi: requires Wokwi Private Gateway for inbound port forwarding
 # Without gateway, test via REPL: import boot; boot.settings["lockdown"] = True
 
-# OTA firmware push via HTTP (works in AP and STA mode)
+# OTA firmware push via HTTP (works in AP and STA mode — use deploy.sh normally)
 uv run python tools/ota-push.py               # AP mode (192.168.4.1)
 uv run python tools/ota-push.py 192.168.1.42  # specific IP
 uv run python tools/ota-push.py --wokwi        # Wokwi (localhost:9080)
-
-# OTA firmware push via FTP (faster bulk sync — STA/home network only)
-# Device must be in STA mode; credentials set via ftp_user/ftp_pass in settings
-uv run python tools/ftp-sync.py 192.168.1.42       # specific IP
-uv run python tools/ftp-sync.py 192.168.1.42 --force  # re-upload all files
 
 # TTS pipeline (generate spoken audio from i18n strings + story scripts)
 # Install Piper TTS once: pip install piper-tts

--- a/boards/BODN_S3/mpconfigboard.cmake
+++ b/boards/BODN_S3/mpconfigboard.cmake
@@ -4,9 +4,11 @@ set(IDF_TARGET esp32s3)
 # resolves them with file(READ) from the port directory.
 get_filename_component(_PORT_DIR ${CMAKE_CURRENT_LIST_DIR}/../../micropython/ports/esp32 ABSOLUTE)
 
+# Deliberately do NOT include sdkconfig.ble — the firmware never imports
+# `bluetooth`, so pulling in the NimBLE stack (200–300 KB) is pure waste.
+# Run `tools/size-review.py` after changing this list.
 set(SDKCONFIG_DEFAULTS
     ${_PORT_DIR}/boards/sdkconfig.base
-    ${_PORT_DIR}/boards/sdkconfig.ble
     ${_PORT_DIR}/boards/sdkconfig.spiram_sx
     ${_PORT_DIR}/boards/sdkconfig.spiram_oct
     ${CMAKE_CURRENT_LIST_DIR}/sdkconfig.board

--- a/boards/BODN_S3/mpconfigboard.h
+++ b/boards/BODN_S3/mpconfigboard.h
@@ -6,3 +6,10 @@
 
 #define MICROPY_HW_I2C0_SCL                 (9)
 #define MICROPY_HW_I2C0_SDA                 (8)
+
+// --- Size trimming ---
+// Both of these are `#ifndef`-gated in mpconfigport.h so overriding here
+// wins. Paired with the matching IDF-level disables in sdkconfig.board so
+// neither the Python bindings nor the C stack gets compiled.
+#define MICROPY_PY_BLUETOOTH                (0)
+#define MICROPY_PY_ESPNOW                   (0)

--- a/boards/BODN_S3/partitions-bodn-8MiB.csv
+++ b/boards/BODN_S3/partitions-bodn-8MiB.csv
@@ -1,0 +1,20 @@
+# Bodn custom partition table — 8 MiB flash, OTA, maximised VFS.
+#
+# Derived from micropython/ports/esp32/partitions-8MiBplus-ota.csv but with
+# OTA slots shrunk to 2.1 MiB (from 2.4 MiB) and an explicit 3.7 MiB vfs
+# partition. Safe only as long as firmware-bodn.bin stays comfortably under
+# 2.1 MiB — run `ls -l build/firmware-bodn.bin` and `tools/size-review.py`
+# after every trim change to confirm.
+#
+# Changing this file requires a full USB reflash with erase — the partition
+# table location is fixed, and VFS data cannot survive a layout change.
+# See .claude/skills/deploy-firmware/SKILL.md §"Repartitioning" for the
+# safe procedure.
+
+# Name,   Type, SubType, Offset,   Size,     Flags
+nvs,      data, nvs,     0x9000,   0x4000,
+otadata,  data, ota,     0xd000,   0x2000,
+phy_init, data, phy,     0xf000,   0x1000,
+ota_0,    app,  ota_0,   0x10000,  0x210000,
+ota_1,    app,  ota_1,   0x220000, 0x210000,
+vfs,      data, fat,     0x430000, 0x3D0000,

--- a/boards/BODN_S3/sdkconfig.board
+++ b/boards/BODN_S3/sdkconfig.board
@@ -22,6 +22,17 @@ CONFIG_LWIP_PPP_SUPPORT=n
 CONFIG_LWIP_PPP_PAP_SUPPORT=n
 CONFIG_LWIP_PPP_CHAP_SUPPORT=n
 
+# Ethernet. sdkconfig.base enables SPI Ethernet + three chip drivers
+# (W5500, KSZ8851SNL, DM9051) unconditionally. The ESP32-S3 has no
+# internal MAC and the board has no SPI-Ethernet chip, so none of this
+# can ever fire. MicroPython's network.LAN goes with it — mpconfigport.h
+# auto-flips MICROPY_PY_NETWORK_LAN to 0 once these are off.
+CONFIG_ETH_ENABLED=n
+CONFIG_ETH_USE_SPI_ETHERNET=n
+CONFIG_ETH_SPI_ETHERNET_W5500=n
+CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL=n
+CONFIG_ETH_SPI_ETHERNET_DM9051=n
+
 # NOTE: TLS (mbedtls TLS layer) is also unused and would save another
 # ~150 KB, but MicroPython's esp32 port hard-wires MICROPY_PY_SSL to
 # MICROPY_PY_NETWORK with no override, and its ssl module links directly

--- a/boards/BODN_S3/sdkconfig.board
+++ b/boards/BODN_S3/sdkconfig.board
@@ -10,3 +10,20 @@ CONFIG_I2S_ISR_IRAM_SAFE=y
 
 # SPI master ISR in IRAM for reliable DMA callbacks
 CONFIG_SPI_MASTER_ISR_IN_IRAM=y
+
+# --- Size trimming (see tools/size-review.py + .claude/skills/size-review) ---
+# Belt-and-braces with dropping sdkconfig.ble from mpconfigboard.cmake.
+# Firmware never imports `bluetooth` — saves ~200-300 KB in the app partition.
+CONFIG_BT_ENABLED=n
+CONFIG_BT_NIMBLE_ENABLED=n
+
+# PPP (serial IP-over-UART). Unused; firmware talks WiFi only.
+CONFIG_LWIP_PPP_SUPPORT=n
+CONFIG_LWIP_PPP_PAP_SUPPORT=n
+CONFIG_LWIP_PPP_CHAP_SUPPORT=n
+
+# NOTE: TLS (mbedtls TLS layer) is also unused and would save another
+# ~150 KB, but MicroPython's esp32 port hard-wires MICROPY_PY_SSL to
+# MICROPY_PY_NETWORK with no override, and its ssl module links directly
+# against mbedtls TLS functions — disabling CONFIG_MBEDTLS_TLS_CLIENT/SERVER
+# breaks the MicroPython link. Needs a submodule patch; tracked separately.

--- a/firmware/bodn/ftp.py
+++ b/firmware/bodn/ftp.py
@@ -59,11 +59,12 @@ def _list_dir(path):
 
 
 class _FTPSession:
-    def __init__(self, reader, writer, user, password):
+    def __init__(self, reader, writer, user, password, settings=None):
         self._r = reader
         self._w = writer
         self._user = user
         self._pass = password
+        self._settings = settings
         self.authed = False
         self._pending_user = None
         self.cwd = "/"
@@ -72,6 +73,14 @@ class _FTPSession:
         self._data_r = None
         self._data_w = None
         self._data_srv = None
+
+    def _poke_idle(self):
+        """Reset the device's idle timer so a long sync doesn't trip lightsleep."""
+        if self._settings is None:
+            return
+        tracker = self._settings.get("_idle_tracker")
+        if tracker is not None:
+            tracker.poke()
 
     def _real(self, path=""):
         """Map an FTP path (relative to FTP root) to a real filesystem path
@@ -158,6 +167,7 @@ class _FTPSession:
                 text = line.decode().strip()
                 if not text:
                     continue
+                self._poke_idle()
                 parts = text.split(" ", 1)
                 cmd = parts[0].upper()
                 arg = parts[1].strip() if len(parts) > 1 else ""
@@ -338,6 +348,7 @@ class _FTPSession:
         await self._send("125 Transfer starting\r\n")
         # Write to a .tmp file first; rename on success (atomic at file level)
         tmp = real + ".tmp"
+        chunks_since_poke = 0
         try:
             with open(tmp, "wb") as f:
                 while True:
@@ -345,6 +356,11 @@ class _FTPSession:
                     if not chunk:
                         break
                     f.write(chunk)
+                    chunks_since_poke += 1
+                    # Keep the idle timer fresh during long single-file uploads.
+                    if chunks_since_poke >= 32:
+                        self._poke_idle()
+                        chunks_since_poke = 0
                     # Yield to the async loop so TCP can breathe during
                     # long flash writes — without this, large files stall.
                     await asyncio.sleep_ms(0)
@@ -423,7 +439,7 @@ async def start_ftp(settings):
     from bodn.config import FTP_PORT
 
     async def _cb(r, w):
-        session = _FTPSession(r, w, user, password)
+        session = _FTPSession(r, w, user, password, settings=settings)
         await session.run()
 
     try:

--- a/firmware/bodn/ui/admin_qr.py
+++ b/firmware/bodn/ui/admin_qr.py
@@ -23,11 +23,25 @@ class AdminQRScreen(Screen):
         self._manager = manager
         self._dirty = True
 
-        # Build URL from current IP
-        from bodn.wifi import get_ip
+        # Prefer <hostname>.local when we're on a real network (STA). mDNS
+        # is only advertised on the STA interface in MicroPython's esp32
+        # port, so fall back to the raw AP IP when serving the device's
+        # own access point.
+        try:
+            import network
 
-        ip = get_ip()
-        self._url = "http://{}".format(ip)
+            sta = network.WLAN(network.STA_IF)
+            on_sta = sta.active() and sta.isconnected()
+        except Exception:
+            on_sta = False
+
+        if on_sta:
+            hostname = self._settings.get("hostname", "bodn")
+            self._url = "http://{}.local".format(hostname)
+        else:
+            from bodn.wifi import get_ip
+
+            self._url = "http://{}".format(get_ip())
 
         # Generate QR code
         try:

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -181,10 +181,11 @@ async def _drain_body(reader, cl):
         cl -= n
 
 
-async def _handle_upload(reader, writer, headers):
+async def _handle_upload(reader, writer, headers, settings=None):
     """OTA file upload — streams body to staging, checks free space first."""
     remote_path = headers.get("x-path", "")
     cl = int(headers.get("content-length", 0))
+    tracker = settings.get("_idle_tracker") if settings is not None else None
 
     if not remote_path:
         await _drain_body(reader, cl)
@@ -213,6 +214,7 @@ async def _handle_upload(reader, writer, headers):
         written = 0
         with open(tmp, "wb") as f:
             remaining = cl
+            chunks_since_poke = 0
             while remaining > 0:
                 n = min(remaining, 512)
                 chunk = await reader.read(n)
@@ -221,6 +223,11 @@ async def _handle_upload(reader, writer, headers):
                 f.write(chunk)
                 written += len(chunk)
                 remaining -= len(chunk)
+                chunks_since_poke += 1
+                # Keep idle timer fresh during long single-file uploads.
+                if tracker is not None and chunks_since_poke >= 64:
+                    tracker.poke()
+                    chunks_since_poke = 0
         try:
             os.remove(staged)
         except OSError:
@@ -240,6 +247,13 @@ async def _handle_request(reader, writer, session_mgr, settings):
         request_line = await reader.readline()
         if not request_line:
             return
+
+        # Keep the device awake while clients are actively talking to us —
+        # OTA/UI/status requests all count as activity. Without this a
+        # multi-minute sync can trip the idle-timeout lightsleep.
+        tracker = settings.get("_idle_tracker")
+        if tracker is not None:
+            tracker.poke()
 
         parts = request_line.decode().split()
         if len(parts) < 2:
@@ -402,7 +416,7 @@ async def _handle_request(reader, writer, session_mgr, settings):
             machine.reset()
 
         elif method == "POST" and path == "/api/upload":
-            await _handle_upload(reader, writer, headers)
+            await _handle_upload(reader, writer, headers, settings=settings)
 
         elif method == "POST" and path == "/api/ota/commit":
             # Verify integrity (when MANIFEST.json is present), then move

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -232,22 +232,27 @@ async def _handle_upload(reader, writer, headers, settings=None):
             _mkdirs(parent)
         tmp = target + ".new"
         written = 0
+        # 4 KiB chunks: 8× fewer Python loop iterations than 512 B, and
+        # comfortably fits in L1 on the ESP32-S3. Flash writes are
+        # block-level anyway, so larger chunks also reduce FAT overhead.
+        CHUNK = 4096
         with open(tmp, "wb") as f:
             remaining = cl
-            chunks_since_poke = 0
+            bytes_since_poke = 0
             while remaining > 0:
-                n = min(remaining, 512)
+                n = min(remaining, CHUNK)
                 chunk = await reader.read(n)
                 if not chunk:
                     break
                 f.write(chunk)
                 written += len(chunk)
                 remaining -= len(chunk)
-                chunks_since_poke += 1
-                # Keep idle timer fresh during long single-file uploads.
-                if tracker is not None and chunks_since_poke >= 64:
+                bytes_since_poke += len(chunk)
+                # Keep idle timer fresh during long single-file uploads
+                # (~every 32 KB regardless of chunk size).
+                if tracker is not None and bytes_since_poke >= 32768:
                     tracker.poke()
-                    chunks_since_poke = 0
+                    bytes_since_poke = 0
         try:
             os.remove(target)
         except OSError:

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -51,8 +51,16 @@ def _rmtree(path):
 
 
 def _ota_walk(stage_dir):
-    """Yield (staged_path, target_path) pairs from the staging directory."""
-    for name in os.listdir(stage_dir):
+    """Yield (staged_path, target_path) pairs from the staging directory.
+
+    Silently yields nothing if the staging dir doesn't exist (HTTP uploads
+    write live, so /.ota is only populated by the FTP path).
+    """
+    try:
+        entries = os.listdir(stage_dir)
+    except OSError:
+        return
+    for name in entries:
         full = stage_dir + "/" + name
         try:
             os.listdir(full)  # directory
@@ -182,7 +190,16 @@ async def _drain_body(reader, cl):
 
 
 async def _handle_upload(reader, writer, headers, settings=None):
-    """OTA file upload — streams body to staging, checks free space first."""
+    """OTA file upload — streams body directly to the target path.
+
+    We used to stage into /.ota/ and copy to live on commit, but that
+    doubles filesystem usage, which exceeds the VFS partition on the 8 MiB
+    build once firmware grows past ~half the partition. The bulk-atomic
+    FTP path still uses /.ota/ staging because it needs MANIFEST-backed
+    cross-file integrity verification; HTTP uploads are one-file-at-a-time
+    and retry per file, so per-file atomicity (write .new + rename) is
+    sufficient.
+    """
     remote_path = headers.get("x-path", "")
     cl = int(headers.get("content-length", 0))
     tracker = settings.get("_idle_tracker") if settings is not None else None
@@ -192,7 +209,10 @@ async def _handle_upload(reader, writer, headers, settings=None):
         await _send_json(writer, {"error": "need X-Path header"}, 400)
         return
 
-    # Check free space (keep 4 KB reserve for filesystem metadata)
+    # Need room for the new copy + small metadata reserve. The old copy
+    # still on disk is freed by the rename below; if the new file is
+    # larger than the old we have to hold both briefly, which is what
+    # this check ensures.
     try:
         st = os.statvfs("/")
         free = st[0] * st[3]  # f_bsize * f_bavail
@@ -206,11 +226,11 @@ async def _handle_upload(reader, writer, headers, settings=None):
         return
 
     try:
-        staged = OTA_STAGE + remote_path
-        parent = staged.rsplit("/", 1)[0]
-        _mkdirs(parent)
-        # Stream body in 512-byte chunks
-        tmp = staged + ".tmp"
+        target = remote_path  # remote_path starts with "/"
+        parent = target.rsplit("/", 1)[0]
+        if parent and parent != "":
+            _mkdirs(parent)
+        tmp = target + ".new"
         written = 0
         with open(tmp, "wb") as f:
             remaining = cl
@@ -229,13 +249,13 @@ async def _handle_upload(reader, writer, headers, settings=None):
                     tracker.poke()
                     chunks_since_poke = 0
         try:
-            os.remove(staged)
+            os.remove(target)
         except OSError:
             pass
-        os.rename(tmp, staged)
+        os.rename(tmp, target)
         await _send_json(
             writer,
-            {"ok": True, "path": remote_path, "staged": staged, "size": written},
+            {"ok": True, "path": remote_path, "size": written},
         )
     except Exception as e:
         await _send_json(writer, {"error": str(e)}, 500)
@@ -419,30 +439,43 @@ async def _handle_request(reader, writer, session_mgr, settings):
             await _handle_upload(reader, writer, headers, settings=settings)
 
         elif method == "POST" and path == "/api/ota/commit":
-            # Verify integrity (when MANIFEST.json is present), then move
-            # staged files into place and reboot.
+            # Two deploy paths converge here:
+            #   * HTTP (/api/upload) writes directly to the live path and
+            #     never creates a MANIFEST — commit is just "please reboot".
+            #   * FTP populates /.ota/ plus a MANIFEST; commit verifies
+            #     hashes and moves staged files to live.
+            # Presence of MANIFEST.json is the unambiguous signal for the
+            # FTP path. Without this gate, a stale /.ota/ left over from
+            # an aborted HTTP deploy (or a USB hotfix) would silently
+            # downgrade live files on the next commit.
             try:
-                ok, errors = _verify_manifest()
-                if not ok:
-                    await _send_json(
-                        writer,
-                        {"error": "integrity check failed", "details": errors},
-                        400,
-                    )
-                    return
+                try:
+                    os.stat(_OTA_MANIFEST)
+                    have_manifest = True
+                except OSError:
+                    have_manifest = False
                 count = 0
-                for staged, target in _ota_walk(OTA_STAGE):
-                    if staged == _OTA_MANIFEST:
-                        continue  # control file — never deploy to live filesystem
-                    parent = target.rsplit("/", 1)[0]
-                    _mkdirs(parent)
-                    try:
-                        os.remove(target)
-                    except OSError:
-                        pass
-                    os.rename(staged, target)
-                    count += 1
-                _rmtree(OTA_STAGE)
+                if have_manifest:
+                    ok, errors = _verify_manifest()
+                    if not ok:
+                        await _send_json(
+                            writer,
+                            {"error": "integrity check failed", "details": errors},
+                            400,
+                        )
+                        return
+                    for staged, target in _ota_walk(OTA_STAGE):
+                        if staged == _OTA_MANIFEST:
+                            continue  # control file — never deploy to live
+                        parent = target.rsplit("/", 1)[0]
+                        _mkdirs(parent)
+                        try:
+                            os.remove(target)
+                        except OSError:
+                            pass
+                        os.rename(staged, target)
+                        count += 1
+                    _rmtree(OTA_STAGE)
                 # Flush filesystem to flash before hard reset — without this,
                 # FAT metadata for unrelated dirs (e.g. /data/) can be lost.
                 try:

--- a/firmware/bodn/wifi.py
+++ b/firmware/bodn/wifi.py
@@ -48,20 +48,21 @@ def get_ip():
     return "0.0.0.0"
 
 
-def start_mdns(hostname="bodn"):
-    """Register mDNS so the device is reachable at bodn.local."""
-    try:
-        import mdns
+def _set_hostname(hostname="bodn"):
+    """Set the network hostname so mDNS advertises <hostname>.local.
 
-        mdns.start(hostname, hostname)
-        print("mDNS: {}.local".format(hostname))
-    except ImportError:
-        # mdns module not available — try network.hostname instead
-        try:
-            network.hostname(hostname)
-            print("mDNS: hostname set to", hostname)
-        except Exception:
-            print("mDNS: not available")
+    Must be called BEFORE the STA interface comes up: MicroPython's esp32
+    port initialises the ESP-IDF mDNS responder once, on IP_EVENT_STA_GOT_IP,
+    and reads the current hostname at that moment (see
+    ports/esp32/network_wlan.c::network_wlan_ip_event_handler). Setting the
+    hostname afterwards updates the DHCP-client name but leaves the mDNS
+    responder stuck on the default, which is why `<host>.local` silently
+    fails to resolve.
+    """
+    try:
+        network.hostname(hostname)
+    except Exception as e:
+        print("mDNS: could not set hostname:", e)
 
 
 class WiFiController:
@@ -116,11 +117,15 @@ def connect(settings):
 
     hostname = settings.get("hostname", "bodn")
 
+    # Set hostname BEFORE any STA activity so the mDNS responder picks
+    # up the right name at init time (see _set_hostname docstring).
+    _set_hostname(hostname)
+
     # User configured a network — try it
     if mode == "sta" and ssid:
         print("WiFi: connecting to", ssid)
         if connect_sta(ssid, password):
-            start_mdns(hostname)
+            print("mDNS: {}.local".format(hostname))
             return get_ip()
         print("WiFi: failed to connect to", ssid)
 
@@ -131,11 +136,10 @@ def connect(settings):
         # Once the user configures WiFi via the web UI, this path is skipped.
         print("WiFi: trying Wokwi-GUEST...")
         if connect_sta("Wokwi-GUEST", "", timeout=3):
-            start_mdns(hostname)
+            print("mDNS: {}.local".format(hostname))
             return get_ip()
 
-    # Fall back to AP mode
+    # Fall back to AP mode — mDNS responder only runs on the STA interface
+    # in MicroPython's esp32 port, so bodn.local won't resolve here.
     print("WiFi: starting AP mode")
-    ip = start_ap()
-    start_mdns(hostname)
-    return ip
+    return start_ap()

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -1201,6 +1201,15 @@ async def main():
     )
     wifi_ctrl = WiFiController(settings)
 
+    # Create IdleTracker up front and expose it via settings so HTTP and FTP
+    # servers can poke it on activity — prevents lightsleep during an active
+    # sync (otherwise a multi-minute upload trips the idle timeout).
+    idle_tracker = IdleTracker(
+        timeout_s=settings.get("sleep_timeout_s", config.SLEEP_TIMEOUT_S),
+        time_fn=time.time,
+    )
+    settings["_idle_tracker"] = idle_tracker
+
     _server = None
     try:
         _server = await start_server(session_mgr, settings)
@@ -1271,11 +1280,8 @@ async def main():
         if not settings.get("audio_enabled", True):
             audio.volume = 0
 
-    # Power management
-    idle_tracker = IdleTracker(
-        timeout_s=settings.get("sleep_timeout_s", config.SLEEP_TIMEOUT_S),
-        time_fn=time.time,
-    )
+    # Power management (idle_tracker already constructed above so network
+    # servers can see it — just create the hardware-side PowerManager here).
     power_mgr = PowerManager(tft, tft2, mcp, pwm=pwm)
 
     # Startup sound disabled — re-enable when tuned:

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Deploy firmware to Bodn — auto-detects USB vs WiFi.
+#
+# Usage:
+#   ./tools/deploy.sh                   auto (prefers WiFi if mDNS resolves, else USB)
+#   ./tools/deploy.sh --usb             force USB sync via mpremote (tools/sync.sh)
+#   ./tools/deploy.sh --wifi            force WiFi push via HTTP (tools/ota-push.py)
+#   ./tools/deploy.sh --wifi 192.168.x  WiFi to a specific host
+#   ./tools/deploy.sh --mount           live-mount firmware/ over USB (no copy, edits are live)
+#   ./tools/deploy.sh --force           re-upload all files (skip hash cache); forwarded to WiFi path
+#
+# Any bare non-flag argument is treated as the WiFi host shorthand:
+#   ./tools/deploy.sh 192.168.1.143
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MDNS_HOST="${BODN_MDNS:-bodn.local}"
+
+mode=""
+host=""
+force=""
+
+usage() {
+    sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --usb)    mode=usb ;;
+        --wifi)   mode=wifi ;;
+        --mount)  mode=mount ;;
+        --force)  force="--force" ;;
+        -h|--help) usage; exit 0 ;;
+        --*)      echo "unknown flag: $1" >&2; usage >&2; exit 2 ;;
+        *)        host="$1"; [ -z "$mode" ] && mode=wifi ;;
+    esac
+    shift
+done
+
+# ──────────────────────────────────────────────────────────────── discovery
+
+find_usb() {
+    # First match wins. macOS: usbserial-* (CP210x/CH340 UART bridge) or
+    # usbmodem* (native USB-CDC). Linux: /dev/ttyUSB* / /dev/ttyACM*.
+    for pat in /dev/cu.usbserial-* /dev/cu.usbmodem* /dev/ttyUSB* /dev/ttyACM*; do
+        for dev in $pat; do
+            [ -e "$dev" ] && { echo "$dev"; return 0; }
+        done
+    done
+    return 1
+}
+
+resolve_mdns() {
+    # Returns the IPv4 of $MDNS_HOST if resolvable, else nothing.
+    # Uses dscacheutil on macOS (reads the Bonjour cache) or getent on Linux.
+    local ip=""
+    if command -v dscacheutil >/dev/null 2>&1; then
+        ip=$(dscacheutil -q host -a name "$MDNS_HOST" 2>/dev/null \
+             | awk '/^ip_address:/ {print $2; exit}')
+    elif command -v getent >/dev/null 2>&1; then
+        ip=$(getent hosts "$MDNS_HOST" 2>/dev/null | awk '{print $1; exit}')
+    fi
+    [ -n "$ip" ] && echo "$ip"
+}
+
+# ──────────────────────────────────────────────────────────────── mode resolution
+
+if [ -z "$mode" ]; then
+    # Auto. Prefer WiFi if mDNS resolves (delta-upload is fast and works
+    # from anywhere on the LAN). Fall back to USB.
+    if host=$(resolve_mdns) && [ -n "$host" ]; then
+        mode=wifi
+        echo "deploy: auto → wifi (bodn.local → $host)"
+    elif usb=$(find_usb); then
+        mode=usb
+        echo "deploy: auto → usb ($usb)"
+    else
+        echo "deploy: no USB device and $MDNS_HOST did not resolve." >&2
+        echo "        Connect USB, or pass an IP: ./tools/deploy.sh 192.168.x.x" >&2
+        exit 1
+    fi
+fi
+
+# ──────────────────────────────────────────────────────────────── dispatch
+
+case "$mode" in
+    usb)
+        exec "$ROOT/tools/sync.sh"
+        ;;
+    mount)
+        # No copy — device imports files from the host over USB. Edits are
+        # live. Soft-reset (Ctrl-D in the REPL) to restart main.py with
+        # the updated code.
+        cd "$ROOT/firmware"
+        exec uv run mpremote connect auto mount . + repl
+        ;;
+    wifi)
+        if [ -z "$host" ]; then
+            if host=$(resolve_mdns) && [ -n "$host" ]; then
+                :
+            else
+                host="192.168.4.1"   # AP-mode fallback
+                echo "deploy: no host given and $MDNS_HOST did not resolve — trying AP ($host)"
+            fi
+        fi
+        if [ -n "$force" ]; then
+            exec uv run python "$ROOT/tools/ota-push.py" "$force" "$host"
+        else
+            exec uv run python "$ROOT/tools/ota-push.py" "$host"
+        fi
+        ;;
+esac

--- a/tools/ota-push.py
+++ b/tools/ota-push.py
@@ -73,6 +73,8 @@ def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int
     new_hashes = dict(prev_hashes)
     uploaded = 0
     skipped = 0
+    total_bytes = 0
+    batch_start = time.monotonic()
 
     for rel_path in FILES:
         local = FIRMWARE_DIR / rel_path
@@ -102,12 +104,18 @@ def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int
         for attempt in range(3):
             timeout = 10 + attempt * 10  # 10s, 20s, 30s
             req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
+            t0 = time.monotonic()
             try:
                 resp = urllib.request.urlopen(req, timeout=timeout)
                 resp.read()
-                print(f"  {rel_path} ({len(data)} bytes)")
+                dt = time.monotonic() - t0
+                rate = (len(data) / dt / 1024) if dt > 0 else 0
+                print(
+                    f"  {rel_path}  {len(data):>7} B  {dt * 1000:>5.0f} ms  {rate:>5.0f} KB/s"
+                )
                 new_hashes[rel_path] = h
                 uploaded += 1
+                total_bytes += len(data)
                 success = True
                 break
             except urllib.error.HTTPError as e:
@@ -130,10 +138,16 @@ def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int
     # Save hashes for files that did upload (even if some failed)
     save_hashes(new_hashes)
 
-    if skipped and not uploaded:
-        print(f"  All {skipped} files unchanged.")
+    elapsed = time.monotonic() - batch_start
+    if uploaded:
+        avg = (total_bytes / elapsed / 1024) if elapsed > 0 else 0
+        print(
+            f"  {uploaded} uploaded, {skipped} unchanged — "
+            f"{total_bytes / 1024:.0f} KB in {elapsed:.1f}s "
+            f"(avg {avg:.0f} KB/s)"
+        )
     elif skipped:
-        print(f"  {uploaded} uploaded, {skipped} unchanged.")
+        print(f"  All {skipped} files unchanged ({elapsed:.1f}s)")
 
     return ok, uploaded
 

--- a/tools/ota-push.py
+++ b/tools/ota-push.py
@@ -204,6 +204,12 @@ def main() -> None:
     base_url, token, force = _parse_args()
 
     print(f"Pushing firmware to {base_url}...")
+    # Clear any leftover /.ota/ staging from a previously aborted run —
+    # HTTP uploads write live, but old firmware (or the FTP path) may
+    # have left staged copies behind eating VFS. Best-effort: ignore
+    # failures and keep going; the device-side endpoint no-ops when
+    # staging is already empty.
+    ota_abort(base_url, token)
     ok, uploaded = push(base_url, token, force)
     if not ok:
         print("Upload failed — aborting staged files.")

--- a/tools/ota-push.py
+++ b/tools/ota-push.py
@@ -66,7 +66,8 @@ def file_hash(path: Path) -> str:
 FILES = discover_files()
 
 
-def push(base_url: str, token: str = "", force: bool = False) -> bool:
+def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int]:
+    """Upload changed files. Returns (ok, uploaded_count)."""
     ok = True
     prev_hashes = {} if force else load_hashes()
     new_hashes = dict(prev_hashes)
@@ -134,7 +135,7 @@ def push(base_url: str, token: str = "", force: bool = False) -> bool:
     elif skipped:
         print(f"  {uploaded} uploaded, {skipped} unchanged.")
 
-    return ok and uploaded > 0
+    return ok, uploaded
 
 
 def ota_commit(base_url: str, token: str = "") -> bool:
@@ -189,16 +190,17 @@ def main() -> None:
     base_url, token, force = _parse_args()
 
     print(f"Pushing firmware to {base_url}...")
-    result = push(base_url, token, force)
-    if result:
-        print("Committing update...")
-        ota_commit(base_url, token)
-        print("Done — device is rebooting with new firmware.")
-    elif result is False:
+    ok, uploaded = push(base_url, token, force)
+    if not ok:
         print("Upload failed — aborting staged files.")
         ota_abort(base_url, token)
         sys.exit(1)
-    # else: nothing to upload (all unchanged), no reboot needed
+    if uploaded == 0:
+        # Nothing to do — device already in sync.
+        return
+    print("Committing update...")
+    ota_commit(base_url, token)
+    print("Done — device is rebooting with new firmware.")
 
 
 if __name__ == "__main__":

--- a/tools/size-review.py
+++ b/tools/size-review.py
@@ -104,6 +104,23 @@ FEATURES: list[Feature] = [
         notes="Not used by Bodn; pure saving.",
     ),
     Feature(
+        name="Ethernet (SPI-attached PHY drivers)",
+        imports=(),  # network.LAN is the user API; no direct import name
+        off_when=[("CONFIG_ETH_USE_SPI_ETHERNET", "n")],
+        on_when=[("CONFIG_ETH_USE_SPI_ETHERNET", "y")],
+        default_on=True,  # sdkconfig.base enables the SPI-Ethernet drivers
+        how_to_disable=(
+            "add CONFIG_ETH_ENABLED=n + CONFIG_ETH_USE_SPI_ETHERNET=n + "
+            "CONFIG_ETH_SPI_ETHERNET_W5500=n + "
+            "CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL=n + "
+            "CONFIG_ETH_SPI_ETHERNET_DM9051=n to sdkconfig.board"
+        ),
+        notes=(
+            "S3 has no internal MAC and the board has no SPI-Ethernet chip. "
+            "MICROPY_PY_NETWORK_LAN auto-flips to 0 when these are off."
+        ),
+    ),
+    Feature(
         name="ESP-NOW",
         imports=("espnow", "aioespnow"),
         off_when=[("CONFIG_ESP_WIFI_ESPNOW_ENABLED", "n")],

--- a/tools/size-review.py
+++ b/tools/size-review.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Flag mismatches between the custom firmware's enabled features and what
+the Python code actually imports.
+
+Two kinds of mismatch:
+
+  1. **Imported but disabled** — hard failure. A Python file imports a
+     module whose backing feature has been turned off in the custom
+     firmware. The device will raise ImportError on boot.
+
+  2. **Enabled but unused** — warning. The feature takes flash and app
+     partition space but no Python code uses it. Candidate for trimming.
+
+Runs as a pre-commit check. It's a *lint*, not a build system — the only
+authoritative size breakdown comes from `idf.py size-components` after a
+real build. Treat warnings as leads, not rules.
+
+Usage:
+    uv run python tools/size-review.py              # report; exits 1 on hard fails
+    uv run python tools/size-review.py --strict     # warnings become failures too
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BOARD_DIR = ROOT / "boards" / "BODN_S3"
+MPY_PORT_DIR = ROOT / "micropython" / "ports" / "esp32"
+FIRMWARE_DIR = ROOT / "firmware"
+
+
+# --------------------------------------------------------------- Feature table
+#
+# Each entry describes one knob (or small set of related knobs) that can be
+# turned off to shrink the firmware. Keep the list focused on features that
+# actually move the needle — micro-flags (a few KB) aren't worth the noise.
+#
+# "imports"     — top-level Python module names that pull this feature in.
+#                 An import of *any* of these counts as "feature is used".
+# "off_when"    — list of (CONFIG_KEY, value) pairs; if every pair matches
+#                 the effective sdkconfig, the feature is considered disabled.
+# "on_when"     — same, but any match means enabled (checked after off_when).
+# "how_to_*"    — short human-readable hint printed with the report.
+
+
+@dataclass
+class Feature:
+    name: str
+    imports: tuple[str, ...]
+    off_when: list[tuple[str, str]] = field(default_factory=list)
+    on_when: list[tuple[str, str]] = field(default_factory=list)
+    # ESP-IDF kconfig defaults aren't written into any sdkconfig.defaults
+    # file — only explicit overrides are. Set default_on for features that
+    # ESP-IDF ships enabled, so the analyzer treats silence as "on" rather
+    # than "unknown".
+    default_on: bool = False
+    how_to_disable: str = ""
+    how_to_enable: str = ""
+    notes: str = ""
+
+
+FEATURES: list[Feature] = [
+    Feature(
+        name="BLE (NimBLE stack)",
+        imports=("bluetooth", "ubluetooth", "aioble"),
+        off_when=[("CONFIG_BT_ENABLED", "n")],
+        on_when=[("CONFIG_BT_ENABLED", "y")],
+        how_to_disable=(
+            "drop sdkconfig.ble from SDKCONFIG_DEFAULTS in "
+            "boards/BODN_S3/mpconfigboard.cmake; add CONFIG_BT_ENABLED=n "
+            "to sdkconfig.board"
+        ),
+        notes="Biggest single win — typically 200-300 KB in the app partition.",
+    ),
+    Feature(
+        name="TLS (mbedtls TLS layer)",
+        imports=("ssl", "ussl", "tls"),
+        off_when=[("CONFIG_MBEDTLS_TLS_ENABLED", "n")],
+        on_when=[("CONFIG_MBEDTLS_TLS_ENABLED", "y")],
+        default_on=True,  # ESP-IDF default
+        how_to_disable=(
+            "add CONFIG_MBEDTLS_TLS_ENABLED=n + CONFIG_MBEDTLS_TLS_CLIENT=n "
+            "+ CONFIG_MBEDTLS_TLS_SERVER=n to sdkconfig.board"
+        ),
+        notes=(
+            "WPA2/WPA3 keeps lower mbedtls primitives (AES, SHA, bignum) "
+            "regardless — only the TLS/X.509 top layer goes."
+        ),
+    ),
+    Feature(
+        name="PPP (serial IP over UART)",
+        imports=(),  # no direct Python module
+        off_when=[("CONFIG_LWIP_PPP_SUPPORT", "n")],
+        on_when=[("CONFIG_LWIP_PPP_SUPPORT", "y")],
+        how_to_disable=(
+            "add CONFIG_LWIP_PPP_SUPPORT=n + CONFIG_LWIP_PPP_PAP_SUPPORT=n "
+            "+ CONFIG_LWIP_PPP_CHAP_SUPPORT=n to sdkconfig.board"
+        ),
+        notes="Not used by Bodn; pure saving.",
+    ),
+    Feature(
+        name="ESP-NOW",
+        imports=("espnow", "aioespnow"),
+        off_when=[("CONFIG_ESP_WIFI_ESPNOW_ENABLED", "n")],
+        on_when=[("CONFIG_ESP_WIFI_ESPNOW_ENABLED", "y")],
+    ),
+    Feature(
+        name="BTree key-value store",
+        imports=("btree",),
+        # Controlled by MICROPY_PY_BTREE (C define, not sdkconfig). We still
+        # list it so the import check catches accidental use.
+    ),
+    Feature(
+        name="WebREPL",
+        imports=("webrepl", "webrepl_setup"),
+        # Controlled by MICROPY_PY_WEBREPL.
+    ),
+    Feature(
+        name="zlib / deflate",
+        imports=("zlib", "deflate", "uzlib"),
+        # Controlled by MICROPY_PY_DEFLATE.
+    ),
+    Feature(
+        name="cryptolib",
+        imports=("cryptolib", "ucryptolib"),
+        # Controlled by MICROPY_PY_CRYPTOLIB.
+    ),
+    Feature(
+        name="binascii",
+        imports=("binascii", "ubinascii"),
+        # Small; listed mostly for completeness.
+    ),
+]
+
+
+# --------------------------------------------------------------- sdkconfig I/O
+
+
+def parse_sdkconfig(path: Path) -> dict[str, str]:
+    """Return {CONFIG_NAME: value_str} from a single sdkconfig file.
+
+    Also understands the `# CONFIG_FOO is not set` comment form, which
+    ESP-IDF emits for boolean options that are explicitly off.
+    """
+    result: dict[str, str] = {}
+    if not path.is_file():
+        return result
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        # Explicit off via comment form
+        m = re.match(r"#\s*(CONFIG_\w+)\s+is not set\s*$", line)
+        if m:
+            result[m.group(1)] = "n"
+            continue
+        if line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        result[k.strip()] = v.strip().strip('"')
+    return result
+
+
+def sdkconfig_files_from_cmake(cmake: Path) -> list[Path]:
+    """Extract the ordered list of sdkconfig defaults from mpconfigboard.cmake."""
+    if not cmake.is_file():
+        return []
+    text = cmake.read_text()
+    m = re.search(r"set\s*\(\s*SDKCONFIG_DEFAULTS\s+([^)]+)\)", text, re.DOTALL)
+    if not m:
+        return []
+    paths: list[Path] = []
+    for line in m.group(1).splitlines():
+        entry = line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        entry = entry.replace("${_PORT_DIR}", str(MPY_PORT_DIR))
+        entry = entry.replace("${CMAKE_CURRENT_LIST_DIR}", str(cmake.parent))
+        if "$" in entry:
+            # Unsubstituted variable — skip rather than guess.
+            continue
+        paths.append(Path(entry))
+    return paths
+
+
+def effective_sdkconfig() -> tuple[dict[str, str], list[Path]]:
+    """Merge inherited sdkconfig files + the board's override in cmake order."""
+    cmake = BOARD_DIR / "mpconfigboard.cmake"
+    files = sdkconfig_files_from_cmake(cmake)
+    cfg: dict[str, str] = {}
+    for f in files:
+        cfg.update(parse_sdkconfig(f))
+    return cfg, files
+
+
+# --------------------------------------------------------------- Imports scan
+
+
+IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+([\w.]+)", re.MULTILINE)
+
+
+def collect_imports() -> dict[str, set[Path]]:
+    """Return {top_level_module_name: {file_where_imported, ...}}."""
+    result: dict[str, set[Path]] = {}
+    for py in FIRMWARE_DIR.rglob("*.py"):
+        if "__pycache__" in py.parts:
+            continue
+        try:
+            text = py.read_text()
+        except OSError:
+            continue
+        for m in IMPORT_RE.finditer(text):
+            top = m.group(1).split(".", 1)[0]
+            result.setdefault(top, set()).add(py.relative_to(ROOT))
+    return result
+
+
+# --------------------------------------------------------------- Feature state
+
+
+def feature_is_off(f: Feature, cfg: dict[str, str]) -> bool:
+    return bool(f.off_when) and all(cfg.get(k) == v for k, v in f.off_when)
+
+
+def feature_is_on(f: Feature, cfg: dict[str, str]) -> bool:
+    return bool(f.on_when) and any(cfg.get(k) == v for k, v in f.on_when)
+
+
+def feature_state(f: Feature, cfg: dict[str, str]) -> str:
+    """Return 'off', 'on', or 'unknown'.
+
+    Features without any sdkconfig pairs are marked 'unknown' — they're
+    controlled by MICROPY_PY_* C defines which we don't parse. The import
+    check still runs.
+    """
+    if feature_is_off(f, cfg):
+        return "off"
+    if feature_is_on(f, cfg):
+        return "on"
+    if f.default_on:
+        return "on"
+    return "unknown"
+
+
+def feature_is_used(f: Feature, imports: dict[str, set[Path]]) -> list[Path]:
+    hits: set[Path] = set()
+    for name in f.imports:
+        hits.update(imports.get(name, ()))
+    return sorted(hits)
+
+
+# --------------------------------------------------------------- Main
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="warnings (enabled-but-unused) become failures too",
+    )
+    args = ap.parse_args()
+
+    cfg, files = effective_sdkconfig()
+    if not files:
+        print(
+            "size-review: could not resolve SDKCONFIG_DEFAULTS from "
+            "boards/BODN_S3/mpconfigboard.cmake — is the MicroPython "
+            "submodule initialised?",
+            file=sys.stderr,
+        )
+        return 2
+
+    imports = collect_imports()
+    hard_fails = 0
+    warnings = 0
+
+    print("size-review — firmware feature vs import audit")
+    print()
+    print("Inherited sdkconfig files (in order):")
+    for f in files:
+        try:
+            rel = f.relative_to(ROOT)
+        except ValueError:
+            rel = f
+        mark = "✓" if f.is_file() else "✗ missing"
+        print(f"  {mark}  {rel}")
+    print()
+
+    col = {"off": "off   ", "on": "on    ", "unknown": "?     "}
+    print(f"{'state':<6} {'used':<5} feature")
+    print(f"{'-' * 6} {'-' * 5} {'-' * 40}")
+
+    for feat in FEATURES:
+        state = feature_state(feat, cfg)
+        used_in = feature_is_used(feat, imports)
+        used = "yes" if used_in else "no "
+
+        print(f"{col[state]} {used:<5} {feat.name}")
+
+        # Mismatches
+        if state == "off" and used_in:
+            hard_fails += 1
+            print("        FAIL: imported but disabled — will ImportError at runtime")
+            for p in used_in[:5]:
+                print(f"              {p}")
+            if len(used_in) > 5:
+                print(f"              (+{len(used_in) - 5} more)")
+            if feat.how_to_enable:
+                print(f"        fix: {feat.how_to_enable}")
+        elif state == "on" and not used_in:
+            warnings += 1
+            print("        WARN: enabled but no Python code imports it")
+            if feat.how_to_disable:
+                print(f"        hint: {feat.how_to_disable}")
+            if feat.notes:
+                print(f"        note: {feat.notes}")
+        elif state == "unknown" and used_in:
+            # Used, and we can't tell if it's really compiled in — just FYI
+            pass
+
+    print()
+    print(f"Summary: {hard_fails} hard fail(s), {warnings} warning(s)")
+    print()
+    print(
+        "Truth source for actual flash use is `idf.py size-components` after "
+        "a rebuild.\nTreat warnings as leads — some features pull in a lot "
+        "of code transitively\nwhile others are already compiled out by "
+        "default. Measure before committing."
+    )
+
+    if hard_fails:
+        return 1
+    if warnings and args.strict:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Overview

This started as a fix for flaky `sync.sh` and grew into a coherent bundle around "deploying firmware should just work, on the cable or over WiFi, without running out of space or the device falling asleep mid-sync." Each commit is self-contained; they're grouped here by concern.

## What's in it

### 1. Deploy entry point — `tools/deploy.sh`

One auto-detecting wrapper. Prefers WiFi when `bodn.local` resolves; falls back to USB; supports `--mount` for live iteration.

```
./tools/deploy.sh                        # auto
./tools/deploy.sh --usb | --wifi IP
./tools/deploy.sh --mount                # live-mount firmware/ via USB
./tools/deploy.sh --force                # re-upload all files
```

Underlying `sync.sh` (USB via `mpremote`) and `ota-push.py` (HTTP) remain; `ftp-sync.py` kept for now but marked legacy in `CLAUDE.md`.

### 2. mDNS actually works now — `firmware/bodn/wifi.py`

MicroPython's esp32 port initialises the ESP-IDF mDNS responder once, on `IP_EVENT_STA_GOT_IP` (`network_wlan.c:190-199`), reading the hostname at that instant. We were calling `network.hostname("bodn")` *after* `connect_sta()` — too late, so the responder bound to the default hostname and silently ignored `bodn.local` queries. DHCP still worked because DHCP-client name is re-read per lease.

Fix: set hostname before STA activation. Dropped the defunct `import mdns` branch (no such module) in the process.

Follow-on: `firmware/bodn/ui/admin_qr.py` now shows `http://bodn.local` on STA, falls back to raw IP on AP (mDNS responder only runs on STA interface).

### 3. Sync doesn't trip the idle timer — `main.py` + `bodn/web.py` + `bodn/ftp.py`

`IdleTracker` is now constructed before the HTTP/FTP servers and exposed via `settings["_idle_tracker"]`. Any incoming request pokes it; upload loops poke every ~32 KB during long single-file transfers. Previously a multi-minute sync would trip the 5-minute idle timeout and the device would lightsleep while the client was still talking.

Does not address "device was already asleep before you started" — ESP32 can't wake on network in lightsleep. Documented.

### 4. HTTP OTA doesn't blow the VFS partition — `bodn/web.py`

`_handle_upload` used to stage into `/.ota/<path>`, committed by moving to live. That doubles VFS usage and overflows on the 8 MiB build once firmware grows past half the partition — the bug the user hit mid-sync as `Not enough space on device`.

Fixed two things:
- `_handle_upload` writes directly to the live target path (`.new` + rename). Per-file atomicity preserved; cross-file atomicity was never offered by the HTTP path.
- `/api/ota/commit` gates the "move /.ota/ → live" step on `MANIFEST.json` being present. Without this a stale `/.ota/` from an aborted sync would silently downgrade live files on the next commit.
- `_ota_walk` returns cleanly when the staging dir is absent.

`tools/ota-push.py` also fixed — `push()` returning `ok and uploaded > 0` made "all files unchanged" look like "upload failed → abort staged." Now returns `(ok, uploaded_count)` and main() no-ops the commit when nothing uploaded.

### 5. Custom firmware size trim — `boards/BODN_S3/*`

Disabled components the Bodn firmware never references:

- **BLE / NimBLE stack**: drop `sdkconfig.ble` from `SDKCONFIG_DEFAULTS` in `mpconfigboard.cmake`; `CONFIG_BT_ENABLED=n`; `MICROPY_PY_BLUETOOTH=0` in `mpconfigboard.h`.
- **PPP (serial IP over UART)**: `CONFIG_LWIP_PPP_SUPPORT=n` + PAP/CHAP.
- **Ethernet stack (SPI-attached PHY drivers)**: `CONFIG_ETH_ENABLED=n` + the four SPI chip drivers. MicroPython's `network.LAN` auto-disables via its existing conditional in `mpconfigport.h:390`.
- **MICROPY_PY_ESPNOW=0**: belt-and-braces.

Measured impact: `firmware-bodn.bin` dropped from 1.98 MB → 1.82 MB across the trim rounds (-76 KB on the ETH pass alone). All four target libraries confirmed absent from the map file: `libnimble.a`, `libbt.a`, `libbtdm_app.a`, `libesp_eth.a`.

TLS is **not** trimmed here — MicroPython's esp32 port hardwires `MICROPY_PY_SSL` to `MICROPY_PY_NETWORK` with no override path, and its `ssl` module links directly against mbedtls TLS functions. Dropping `CONFIG_MBEDTLS_TLS_*` breaks the MicroPython link. Tracked in `sdkconfig.board` comment as a follow-up (~150 KB).

### 6. `size-review` skill + static analyzer

`tools/size-review.py` cross-references `firmware/**/*.py` imports against the effective sdkconfig (merged from `SDKCONFIG_DEFAULTS` in `mpconfigboard.cmake` + board override). Two kinds of mismatch:

- **Imported but disabled** → exit 1. A Python file imports a module whose backing feature is off; would `ImportError` at boot.
- **Enabled but unused** → warning. Feature compiled in, nothing imports it. Optimisation lead.

Wired into `.githooks/pre-commit` to run when `firmware/**/*.py` or `boards/BODN_S3/*` is staged. Skill doc at `.claude/skills/size-review/SKILL.md` in the `perf-review` style.

Current output: 0 hard fails, 1 warning (the known TLS case).

### 7. `deploy-firmware` skill rewritten — `.claude/skills/deploy-firmware/SKILL.md`

Leads with `deploy.sh` as the normal entry point. Adds a comprehensive §Repartitioning section covering when to bother, the safe reflash procedure, failure modes, and what the erase actually loses vs keeps. `ftp-sync.py` demoted to legacy mention.

A reference CSV at `boards/BODN_S3/partitions-bodn-8MiB.csv` (2.06 MiB OTA slots + 3.81 MiB VFS) is committed but NOT activated — the switch is deliberate opt-in and needs a full erase + reflash.

## Explicitly not in this PR

- **TLS trim (~150 KB)** — requires a MicroPython submodule patch for the `MICROPY_PY_SSL` wiring. Noted inline in `sdkconfig.board`.
- **Repartitioning reflash** — CSV committed for reference, `CONFIG_PARTITION_TABLE_CUSTOM_FILENAME` left pointing at upstream. Do it via the procedure in the skill when you're ready.
- **`bodn/ftp.py` retirement** — HTTP is the recommended path; FTP path still works, just poked by the idle-tracker fix. Removing it is a separate cleanup PR once HTTP has bedded in.

## Test plan

- [x] Host tests pass — `uv run pytest` (857 passed)
- [x] Ruff clean on changed files
- [x] CI green on HEAD (`eb73d0c`)
- [x] `tools/size-review.py` — 0 hard fails, 1 known warning (TLS)
- [x] Rebuilt custom firmware; map confirms NimBLE/BT/ETH absent
- [ ] On device: `dscacheutil -q host -a name bodn.local` returns the device IP after boot
- [ ] On device: `./tools/deploy.sh` (no args) auto-picks WiFi and completes a delta sync cleanly
- [ ] On device: `./tools/deploy.sh --force` completes a full 99-file re-upload without hitting space errors and without the device lightsleeping mid-sync
- [ ] On device: admin QR code shows `http://bodn.local` in STA mode, raw IP in AP mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)