### PR TITLE
perf + UX: OTA sync 10-15 min → ~2 min, with takeover status screen

### DIFF
--- a/firmware/bodn/lang/en.py
+++ b/firmware/bodn/lang/en.py
@@ -127,6 +127,10 @@ STRINGS = {
     "overlay_see_you": "See you",
     "overlay_soon": "soon!",
     "overlay_goodnight": "Goodnight!",
+    # OTA status screen (shown while a WiFi firmware sync is active)
+    "ota_updating": "Updating...",
+    "ota_please_wait": "Please wait...",
+    "ota_rebooting": "Rebooting!",
     # Demo
     "demo_buttons": "Buttons",
     "demo_arcade": "Drums",

--- a/firmware/bodn/lang/sv.py
+++ b/firmware/bodn/lang/sv.py
@@ -127,6 +127,10 @@ STRINGS = {
     "overlay_see_you": "Vi ses",
     "overlay_soon": "snart!",
     "overlay_goodnight": "Godnatt!",
+    # OTA status screen (shown while a WiFi firmware sync is active)
+    "ota_updating": "Uppdaterar...",
+    "ota_please_wait": "Vänta lite...",
+    "ota_rebooting": "Startar om!",
     # Demo
     "demo_buttons": "Knappar",
     "demo_arcade": "Trummor",

--- a/firmware/bodn/ui/ota.py
+++ b/firmware/bodn/ui/ota.py
@@ -1,0 +1,111 @@
+# bodn/ui/ota.py — OTA firmware sync status screen
+#
+# Rendered directly by primary_task while bodn.web.ota_active(settings)
+# is True. The normal UI render loop is skipped during OTA to free the
+# Python VM for the upload handler (see bodn.web._mark_ota_active and
+# the primary/secondary render loops in main.py); this module provides
+# a minimal "Updating..." takeover so the device isn't visually frozen
+# from the child's perspective.
+
+from bodn.i18n import t
+from bodn.ui import widgets
+
+
+def _fmt_path(path, max_chars):
+    """Truncate a path to fit `max_chars`, keeping the tail (filename).
+
+    /bodn/ui/nfc_provision.py  →  ...fc_provision.py
+    """
+    if not path:
+        return ""
+    if len(path) <= max_chars:
+        return path
+    return "..." + path[-(max_chars - 3) :]
+
+
+def render(tft, theme, settings, frame):
+    """Paint the full OTA status screen.
+
+    Called at ~4 fps from primary_task (enough to show progress moving
+    without meaningfully competing with the upload handler for CPU).
+    """
+    w = tft.width
+    h = tft.height
+
+    # Full black background every frame — simpler than dirty tracking,
+    # and we only redraw ~4× per second anyway.
+    tft.fill(theme.BLACK)
+
+    # Big banner near the top
+    banner = t("ota_updating")
+    banner_y = h // 4 - 12
+    widgets.draw_centered(tft, banner, banner_y, theme.CYAN, w, scale=2)
+
+    # "Please wait" subtext
+    wait = t("ota_please_wait")
+    widgets.draw_centered(tft, wait, banner_y + 28, theme.MUTED, w, scale=1)
+
+    # Current file being written (truncated to fit at scale=1)
+    path = settings.get("_ota_current_path", "") or ""
+    if path:
+        path_chars = max(1, w // 8)  # 8px per char at scale=1
+        shown = _fmt_path(path, path_chars)
+        widgets.draw_centered(tft, shown, h // 2, theme.WHITE, w, scale=1)
+
+    # Counter: "N / TOTAL" files
+    files_done = settings.get("_ota_files_done", 0)
+    total_files = settings.get("_ota_total_files", 0)
+    if total_files > 0:
+        label = "{} / {}".format(files_done, total_files)
+        widgets.draw_centered(tft, label, h // 2 + 20, theme.AMBER, w, scale=2)
+
+    # Progress bar
+    bar_h = 16
+    bar_w = int(w * 0.75)
+    bar_x = (w - bar_w) // 2
+    bar_y = (h * 3) // 4
+    total_bytes = settings.get("_ota_total_bytes", 0)
+    bytes_done = settings.get("_ota_bytes_done", 0)
+    if total_bytes > 0:
+        widgets.draw_progress_bar(
+            tft,
+            bar_x,
+            bar_y,
+            bar_w,
+            bar_h,
+            bytes_done,
+            total_bytes,
+            fg=theme.CYAN,
+            bg=theme.DIM,
+            border=theme.MUTED,
+        )
+        kb_done = bytes_done // 1024
+        kb_total = total_bytes // 1024
+        kb_label = "{} / {} KB".format(kb_done, kb_total)
+        widgets.draw_centered(tft, kb_label, bar_y + bar_h + 6, theme.MUTED, w, scale=1)
+    else:
+        # Indeterminate: no totals yet. Animate a sliding chunk to show
+        # the device is alive.
+        chunk_w = bar_w // 4
+        # Ping-pong across the bar once every ~20 frames (at 4 fps, ~5 s).
+        phase = frame % 40
+        pos = phase if phase < 20 else 40 - phase
+        chunk_x = bar_x + (bar_w - chunk_w) * pos // 20
+        tft.rect(bar_x, bar_y, bar_w, bar_h, theme.MUTED)
+        tft.fill_rect(bar_x + 1, bar_y + 1, bar_w - 2, bar_h - 2, theme.DIM)
+        tft.fill_rect(chunk_x, bar_y + 1, chunk_w, bar_h - 2, theme.CYAN)
+
+
+def render_secondary(tft, theme, settings):
+    """Paint a minimal 'Updating' panel on the 128×128 secondary display.
+
+    Low frequency (once when entering OTA mode, then on each
+    render-tick from secondary_task). Kept dead simple — no animation,
+    no progress bar — so a single fill + two text calls per cycle.
+    """
+    tft.fill(theme.BLACK)
+    banner = t("ota_updating")
+    y = tft.height // 2 - 12
+    widgets.draw_centered(tft, banner, y, theme.CYAN, tft.width, scale=1)
+    wait = t("ota_please_wait")
+    widgets.draw_centered(tft, wait, y + 14, theme.MUTED, tft.width, scale=1)

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -119,19 +119,28 @@ async def _send(writer, status, content_type, body, extra_headers=None):
     Honours `writer._keep_alive` (set by the connection loop) to pick the
     response protocol (HTTP/1.1 vs 1.0) and Connection header. Always sends
     an explicit Content-Length so the client can reuse the socket.
+
+    Batches headers + body into a single write(): under keep-alive there's
+    no terminating close() to flush a half-filled segment, so splitting the
+    response across multiple write() calls lets Nagle + delayed-ACK pair up
+    and add ~hundreds of ms per request on MicroPython. One write() →
+    one segment → fast.
     """
     keep_alive = getattr(writer, "_keep_alive", False)
     body_bytes = body if isinstance(body, bytes) else body.encode("utf-8")
     proto = "HTTP/1.1" if keep_alive else "HTTP/1.0"
-    writer.write("{} {} OK\r\n".format(proto, status).encode())
-    writer.write("Content-Type: {}\r\n".format(content_type).encode())
-    writer.write("Content-Length: {}\r\n".format(len(body_bytes)).encode())
+    conn = "keep-alive" if keep_alive else "close"
+    parts = [
+        "{} {} OK\r\n".format(proto, status).encode(),
+        "Content-Type: {}\r\n".format(content_type).encode(),
+        "Content-Length: {}\r\n".format(len(body_bytes)).encode(),
+    ]
     if extra_headers:
         for h in extra_headers:
-            writer.write("{}\r\n".format(h).encode())
-    conn = "keep-alive" if keep_alive else "close"
-    writer.write("Connection: {}\r\n\r\n".format(conn).encode())
-    writer.write(body_bytes)
+            parts.append("{}\r\n".format(h).encode())
+    parts.append("Connection: {}\r\n\r\n".format(conn).encode())
+    parts.append(body_bytes)
+    writer.write(b"".join(parts))
     await writer.drain()
 
 
@@ -701,10 +710,36 @@ async def _connection_loop(reader, writer, session_mgr, settings):
             pass
 
 
+def _disable_nagle(writer):
+    """Turn off Nagle's algorithm on the accepted TCP socket.
+
+    Without TCP_NODELAY, small writes (response headers, small JSON
+    bodies) get stuck waiting for the ACK of the previous segment, which
+    on MicroPython's lwIP can pause ~200ms per request. Under keep-alive
+    this overhead stacks across every file in an OTA sync.
+    """
+    sock = None
+    try:
+        sock = writer.get_extra_info("socket")
+    except Exception:
+        pass
+    if sock is None:
+        sock = getattr(writer, "s", None)  # MicroPython uasyncio
+    if sock is None:
+        return
+    try:
+        import socket as _sock
+
+        sock.setsockopt(_sock.IPPROTO_TCP, _sock.TCP_NODELAY, 1)
+    except Exception:
+        pass  # platform/build doesn't expose TCP_NODELAY — no-op
+
+
 async def start_server(session_mgr, settings, port=80):
     """Start the async web server. Returns the server object."""
 
     async def handler(reader, writer):
+        _disable_nagle(writer)
         try:
             await _connection_loop(reader, writer, session_mgr, settings)
         except Exception as e:

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -55,6 +55,48 @@ def ota_active(settings):
     return True
 
 
+# MicroPython's FAT statvfs walks the FAT to count free clusters —
+# ~1.1-1.3 s per call on the 6 MiB VFS partition. Calling it per
+# /api/upload turned a 97-file --force into ~125 s of pure statvfs
+# overhead. Cache the answer, decrement by bytes we write ourselves,
+# and only re-stat when the estimate drifts stale (a fresh write might
+# exceed it) or a generous time budget elapses.
+_FREE_CACHE = {"bytes": None, "written_since": 0, "refreshed_ms": 0}
+_FREE_REFRESH_BYTES = 500_000
+_FREE_REFRESH_MS = 60_000
+
+
+def _estimated_free(force=False):
+    import time
+
+    now = time.ticks_ms()
+    stale = (
+        _FREE_CACHE["bytes"] is None
+        or force
+        or _FREE_CACHE["written_since"] >= _FREE_REFRESH_BYTES
+        or time.ticks_diff(now, _FREE_CACHE["refreshed_ms"]) >= _FREE_REFRESH_MS
+    )
+    if stale:
+        try:
+            st = os.statvfs("/")
+            _FREE_CACHE["bytes"] = st[0] * st[3]
+        except Exception:
+            _FREE_CACHE["bytes"] = 0
+        _FREE_CACHE["written_since"] = 0
+        _FREE_CACHE["refreshed_ms"] = now
+    return _FREE_CACHE["bytes"]
+
+
+def _record_free_delta(bytes_written):
+    """Decrement the cached estimate. Approximate — the FAT may charge
+    a cluster-rounded amount, but over-writes get caught the next time
+    we re-stat (either by the byte or time budget).
+    """
+    if _FREE_CACHE["bytes"] is not None:
+        _FREE_CACHE["bytes"] -= bytes_written
+    _FREE_CACHE["written_since"] += bytes_written
+
+
 def _mkdirs(path):
     """Recursively create parent directories (MicroPython os.mkdir is single-level)."""
     parts = path.strip("/").split("/")
@@ -303,14 +345,14 @@ async def _handle_upload(reader, writer, headers, settings=None):
     # Need room for the new copy + small metadata reserve. The old copy
     # still on disk is freed by the rename below; if the new file is
     # larger than the old we have to hold both briefly, which is what
-    # this check ensures.
+    # this check ensures. Uses the cached estimate — see _estimated_free.
     t_stat0 = ticks()
-    try:
-        st = os.statvfs("/")
-        free = st[0] * st[3]  # f_bsize * f_bavail
-    except Exception:
-        free = 0
+    free = _estimated_free()
     t_stat = diff(ticks(), t_stat0)
+    if free > 0 and cl > free - 4096:
+        # Cache may be stale — force one authoritative re-stat before
+        # refusing the upload.
+        free = _estimated_free(force=True)
     if free > 0 and cl > free - 4096:
         await _drain_body(reader, cl)
         await _send_json(
@@ -370,6 +412,11 @@ async def _handle_upload(reader, writer, headers, settings=None):
         t_rn0 = ticks()
         os.rename(tmp, target)
         t_rn = diff(ticks(), t_rn0)
+        # os.remove freed the old target's clusters; we net-consumed
+        # (written - old_size) but don't know old_size cheaply. Record
+        # the conservative worst case: the full write. Any drift is
+        # reconciled by the byte/time budget in _estimated_free.
+        _record_free_delta(written)
         t_resp0 = ticks()
         await _send_json(
             writer,

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -114,17 +114,40 @@ def _verify_manifest():
 
 
 async def _send(writer, status, content_type, body, extra_headers=None):
-    """Send an HTTP response."""
+    """Send an HTTP response.
+
+    Honours `writer._keep_alive` (set by the connection loop) to pick the
+    response protocol (HTTP/1.1 vs 1.0) and Connection header. Always sends
+    an explicit Content-Length so the client can reuse the socket.
+    """
+    keep_alive = getattr(writer, "_keep_alive", False)
     body_bytes = body if isinstance(body, bytes) else body.encode("utf-8")
-    writer.write("HTTP/1.0 {} OK\r\n".format(status).encode())
+    proto = "HTTP/1.1" if keep_alive else "HTTP/1.0"
+    writer.write("{} {} OK\r\n".format(proto, status).encode())
     writer.write("Content-Type: {}\r\n".format(content_type).encode())
     writer.write("Content-Length: {}\r\n".format(len(body_bytes)).encode())
     if extra_headers:
         for h in extra_headers:
             writer.write("{}\r\n".format(h).encode())
-    writer.write(b"Connection: close\r\n\r\n")
+    conn = "keep-alive" if keep_alive else "close"
+    writer.write("Connection: {}\r\n\r\n".format(conn).encode())
     writer.write(body_bytes)
     await writer.drain()
+
+
+def _wants_keep_alive(request_line, headers):
+    """Decide whether to keep the connection open after this request.
+
+    HTTP/1.1 defaults to keep-alive (RFC 7230); HTTP/1.0 defaults to close
+    unless the client opted in with `Connection: keep-alive`. An explicit
+    `Connection: close` always wins.
+    """
+    conn = headers.get("connection", "").lower()
+    if "close" in conn:
+        return False
+    if "keep-alive" in conn:
+        return True
+    return b"HTTP/1.1" in request_line
 
 
 async def _send_json(writer, data, status=200):
@@ -185,8 +208,26 @@ async def _drain_body(reader, cl):
     """Read and discard cl bytes from reader."""
     while cl > 0:
         n = min(cl, 512)
-        await reader.read(n)
-        cl -= n
+        chunk = await reader.read(n)
+        if not chunk:
+            break
+        cl -= len(chunk)
+
+
+async def _read_exact(reader, n):
+    """Read exactly n bytes (loops until full or EOF). Required for
+    keep-alive: a single read() may return short, leaving body bytes in
+    the socket that would then be parsed as the next request line.
+    """
+    if n <= 0:
+        return b""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = await reader.read(n - len(buf))
+        if not chunk:
+            break
+        buf.extend(chunk)
+    return bytes(buf)
 
 
 async def _handle_upload(reader, writer, headers, settings=None):
@@ -236,6 +277,7 @@ async def _handle_upload(reader, writer, headers, settings=None):
         # comfortably fits in L1 on the ESP32-S3. Flash writes are
         # block-level anyway, so larger chunks also reduce FAT overhead.
         CHUNK = 4096
+        short_read = False
         with open(tmp, "wb") as f:
             remaining = cl
             bytes_since_poke = 0
@@ -243,6 +285,7 @@ async def _handle_upload(reader, writer, headers, settings=None):
                 n = min(remaining, CHUNK)
                 chunk = await reader.read(n)
                 if not chunk:
+                    short_read = True
                     break
                 f.write(chunk)
                 written += len(chunk)
@@ -253,6 +296,11 @@ async def _handle_upload(reader, writer, headers, settings=None):
                 if tracker is not None and bytes_since_poke >= 32768:
                     tracker.poke()
                     bytes_since_poke = 0
+        if short_read:
+            # Socket framing is now ambiguous — force the client to
+            # reconnect rather than misread leftover bytes as the next
+            # request line.
+            writer._keep_alive = False
         try:
             os.remove(target)
         except OSError:
@@ -263,16 +311,22 @@ async def _handle_upload(reader, writer, headers, settings=None):
             {"ok": True, "path": remote_path, "size": written},
         )
     except Exception as e:
+        # Mid-write failure leaves an unknown number of bytes in the
+        # socket; safest to drop the connection.
+        writer._keep_alive = False
         await _send_json(writer, {"error": str(e)}, 500)
 
 
-async def _handle_request(reader, writer, session_mgr, settings):
-    """Parse HTTP request and route to handler."""
-    try:
-        request_line = await reader.readline()
-        if not request_line:
-            return
+async def _handle_request(reader, writer, request_line, session_mgr, settings):
+    """Parse HTTP request and route to handler.
 
+    `request_line` has already been read by the connection loop. Returns
+    True if the connection should be kept alive for another request.
+    """
+    # Default: don't keep alive — error paths fall through here and we
+    # can't safely reuse the socket if the request body wasn't drained.
+    writer._keep_alive = False
+    try:
         # Keep the device awake while clients are actively talking to us —
         # OTA/UI/status requests all count as activity. Without this a
         # multi-minute sync can trip the idle-timeout lightsleep.
@@ -282,13 +336,17 @@ async def _handle_request(reader, writer, session_mgr, settings):
 
         parts = request_line.decode().split()
         if len(parts) < 2:
-            return
+            return False
 
         method = parts[0]
         path = parts[1]
 
         # Read headers
         headers = await _read_headers(reader)
+        # Decide keep-alive intent now that we have headers; individual
+        # endpoints can downgrade to close (e.g. before reboot, or when
+        # they bail without draining the body).
+        writer._keep_alive = _wants_keep_alive(request_line, headers)
 
         # Parse body for POST (upload route streams directly to flash)
         body = None
@@ -297,7 +355,7 @@ async def _handle_request(reader, writer, session_mgr, settings):
         elif method == "POST":
             cl = int(headers.get("content-length", 0))
             if cl > 0:
-                raw = await reader.read(cl)
+                raw = await _read_exact(reader, cl)
                 body = json.loads(raw)
 
         # --- Auth: PIN login endpoint (always accessible) ---
@@ -314,7 +372,7 @@ async def _handle_request(reader, writer, session_mgr, settings):
                 )
             else:
                 await _send_unauthorized(writer, "Wrong PIN")
-            return
+            return writer._keep_alive
 
         # --- Auth: OTA endpoints require bearer token ---
         ota_paths = (
@@ -326,8 +384,12 @@ async def _handle_request(reader, writer, session_mgr, settings):
         )
         if path in ota_paths:
             if not _check_ota_token(headers, settings):
+                # /api/upload bodies are large and we haven't read them
+                # yet — force the client to reconnect rather than draining
+                # a rejected upload through the socket.
+                writer._keep_alive = False
                 await _send_unauthorized(writer, "Invalid OTA token")
-                return
+                return False
 
         # --- Auth: all other API/UI endpoints require PIN ---
         if path != "/api/login":
@@ -336,7 +398,7 @@ async def _handle_request(reader, writer, session_mgr, settings):
                 from bodn.web_ui import LOGIN_HTML
 
                 await _send(writer, 200, "text/html", LOGIN_HTML)
-                return
+                return writer._keep_alive
 
         # Route
         if method == "GET" and path == "/":
@@ -429,6 +491,7 @@ async def _handle_request(reader, writer, session_mgr, settings):
                     if k in body:
                         settings[k] = body[k]
                 storage.save_settings(settings)
+            writer._keep_alive = False  # we're about to reset
             await _send_json(writer, {"ok": True})
             # Reboot after response is sent
             await asyncio.sleep_ms(500)
@@ -487,6 +550,7 @@ async def _handle_request(reader, writer, session_mgr, settings):
                     os.sync()
                 except Exception:
                     pass  # os.sync() not available on all builds
+                writer._keep_alive = False  # we're about to reset
                 await _send_json(writer, {"ok": True, "committed": count})
                 try:
                     import machine
@@ -503,6 +567,7 @@ async def _handle_request(reader, writer, session_mgr, settings):
             await _send_json(writer, {"ok": True})
 
         elif method == "POST" and path == "/api/reboot":
+            writer._keep_alive = False  # we're about to reset
             await _send_json(writer, {"ok": True, "rebooting": True})
             try:
                 os.sync()
@@ -589,10 +654,45 @@ async def _handle_request(reader, writer, session_mgr, settings):
             await _send(writer, 404, "text/plain", "Not found")
 
     except Exception as e:
+        # Internal error: socket may be in an unknown state — close.
+        writer._keep_alive = False
         try:
             await _send(writer, 500, "text/plain", str(e))
         except Exception:
             pass
+
+    return writer._keep_alive
+
+
+# Idle timeout for an open keep-alive connection. The full --force OTA
+# push has gaps of a few hundred ms between requests; 5 s is plenty of
+# headroom while still freeing the socket promptly when the client is
+# done.
+_KEEP_ALIVE_IDLE_S = 5
+
+
+async def _connection_loop(reader, writer, session_mgr, settings):
+    """Serve sequential requests on one TCP connection until the client
+    closes, the keep-alive timeout fires, or a handler downgrades to
+    Connection: close.
+    """
+    try:
+        while True:
+            try:
+                request_line = await asyncio.wait_for(
+                    reader.readline(), _KEEP_ALIVE_IDLE_S
+                )
+            except Exception:
+                # asyncio.TimeoutError on idle, or a transport error —
+                # either way we're done with this connection.
+                break
+            if not request_line:
+                break  # client closed cleanly between requests
+            keep_alive = await _handle_request(
+                reader, writer, request_line, session_mgr, settings
+            )
+            if not keep_alive:
+                break
     finally:
         try:
             writer.close()
@@ -606,7 +706,7 @@ async def start_server(session_mgr, settings, port=80):
 
     async def handler(reader, writer):
         try:
-            await _handle_request(reader, writer, session_mgr, settings)
+            await _connection_loop(reader, writer, session_mgr, settings)
         except Exception as e:
             print("Web handler error:", e)
 

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -32,14 +32,27 @@ _OTA_QUIET_MS = 10_000
 def _mark_ota_active(settings):
     """Extend the 'OTA in progress' window.
 
-    primary_task / secondary_task poll `ota_active(settings)` and skip
-    rendering while the flag is set, freeing the Python VM so the
-    upload handler's many `await` points return promptly instead of
-    round-tripping through a frame render each time.
+    primary_task / secondary_task poll `ota_active(settings)` and
+    render the OTA status screen at low fps while the flag is set,
+    freeing the Python VM so the upload handler's many `await` points
+    return promptly instead of round-tripping through a full frame of
+    the game screen each time.
     """
     import time
 
     settings["_ota_deadline_ms"] = time.ticks_add(time.ticks_ms(), _OTA_QUIET_MS)
+
+
+def _reset_ota_progress(settings):
+    """Clear per-sync counters. Called from /api/ota/begin and
+    /api/ota/abort so the status screen doesn't show stale numbers
+    from a previous sync.
+    """
+    settings["_ota_current_path"] = ""
+    settings["_ota_files_done"] = 0
+    settings["_ota_bytes_done"] = 0
+    settings["_ota_total_files"] = 0
+    settings["_ota_total_bytes"] = 0
 
 
 def ota_active(settings):
@@ -337,6 +350,11 @@ async def _handle_upload(reader, writer, headers, settings=None):
     cl = int(headers.get("content-length", 0))
     tracker = settings.get("_idle_tracker") if settings is not None else None
 
+    # Publish the current file path so the OTA status screen can show
+    # it while we process this upload.
+    if settings is not None and remote_path:
+        settings["_ota_current_path"] = remote_path
+
     if not remote_path:
         await _drain_body(reader, cl)
         await _send_json(writer, {"error": "need X-Path header"}, 400)
@@ -422,6 +440,10 @@ async def _handle_upload(reader, writer, headers, settings=None):
             # request line.
             writer._keep_alive = False
         _record_free_delta(written)
+        # Bump per-sync counters for the status screen.
+        if settings is not None:
+            settings["_ota_files_done"] = settings.get("_ota_files_done", 0) + 1
+            settings["_ota_bytes_done"] = settings.get("_ota_bytes_done", 0) + written
         t_resp0 = ticks()
         await _send_json(
             writer,
@@ -515,6 +537,7 @@ async def _handle_request(reader, writer, request_line, session_mgr, settings):
             "/api/upload",
             "/api/reboot",
             "/api/files",
+            "/api/ota/begin",
             "/api/ota/commit",
             "/api/ota/abort",
         )
@@ -700,9 +723,26 @@ async def _handle_request(reader, writer, request_line, session_mgr, settings):
             except Exception as e:
                 await _send_json(writer, {"error": str(e)}, 500)
 
+        elif method == "POST" and path == "/api/ota/begin":
+            # Called by ota-push.py once per sync, before the first
+            # /api/upload, with {"files": N, "bytes": M}. Used by the
+            # OTA status screen to render a real progress bar instead
+            # of an indeterminate pulse. Body is optional — if it's
+            # missing we just fall through to the indeterminate state.
+            _reset_ota_progress(settings)
+            if body:
+                try:
+                    settings["_ota_total_files"] = int(body.get("files", 0) or 0)
+                    settings["_ota_total_bytes"] = int(body.get("bytes", 0) or 0)
+                except (TypeError, ValueError):
+                    pass  # malformed — keep the zeroed counters
+            await _send_json(writer, {"ok": True})
+
         elif method == "POST" and path == "/api/ota/abort":
-            # Discard staged files.
+            # Discard staged files and clear any progress state — a
+            # follow-up sync starts from a clean slate.
             _rmtree(OTA_STAGE)
+            _reset_ota_progress(settings)
             await _send_json(writer, {"ok": True})
 
         elif method == "POST" and path == "/api/reboot":

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -365,17 +365,29 @@ async def _handle_upload(reader, writer, headers, settings=None):
         parent = target.rsplit("/", 1)[0]
         if parent and parent != "":
             _mkdirs(parent)
-        tmp = target + ".new"
         written = 0
         # 4 KiB chunks: 8× fewer Python loop iterations than 512 B, and
         # comfortably fits in L1 on the ESP32-S3. Flash writes are
         # block-level anyway, so larger chunks also reduce FAT overhead.
         CHUNK = 4096
         short_read = False
+        # Write directly to target — not via a `.new` + remove + rename
+        # dance. On MicroPython FAT, each os.rename costs ~150-1000 ms
+        # (rises linearly within a directory until it hits a cluster
+        # boundary), and every rename is preceded by an os.remove that
+        # also scans the directory. Over a 97-file --force that totalled
+        # ~60 s of pure FAT metadata work. Writing in place sacrifices
+        # atomicity (power loss mid-write corrupts the target instead
+        # of keeping the old version), which is an acceptable trade-off
+        # for HTTP OTA: the client retries on error, and on any write
+        # exception we delete the target so the next boot fails
+        # cleanly on a missing file rather than importing a truncated
+        # one. FTP OTA still uses the `/.ota/` manifest-verified path
+        # when cross-file atomicity matters.
         t_open0 = ticks()
         t_read = 0
         t_write = 0
-        with open(tmp, "wb") as f:
+        with open(target, "wb") as f:
             t_open = diff(ticks(), t_open0)
             remaining = cl
             bytes_since_poke = 0
@@ -399,23 +411,16 @@ async def _handle_upload(reader, writer, headers, settings=None):
                     tracker.poke()
                     bytes_since_poke = 0
         if short_read:
-            # Socket framing is now ambiguous — force the client to
+            # The file is now truncated on flash. Delete it — better a
+            # missing import than a half-written one.
+            try:
+                os.remove(target)
+            except OSError:
+                pass
+            # Socket framing is also ambiguous — force the client to
             # reconnect rather than misread leftover bytes as the next
             # request line.
             writer._keep_alive = False
-        t_rm0 = ticks()
-        try:
-            os.remove(target)
-        except OSError:
-            pass
-        t_rm = diff(ticks(), t_rm0)
-        t_rn0 = ticks()
-        os.rename(tmp, target)
-        t_rn = diff(ticks(), t_rn0)
-        # os.remove freed the old target's clusters; we net-consumed
-        # (written - old_size) but don't know old_size cheaply. Record
-        # the conservative worst case: the full write. Any drift is
-        # reconciled by the byte/time budget in _estimated_free.
         _record_free_delta(written)
         t_resp0 = ticks()
         await _send_json(
@@ -425,22 +430,25 @@ async def _handle_upload(reader, writer, headers, settings=None):
         t_resp = diff(ticks(), t_resp0)
         if debug:
             print(
-                "OTA {} {}B  stat={} open={} read={} write={} rm={} rn={} resp={} total={}".format(
+                "OTA {} {}B  stat={} open={} read={} write={} resp={} total={}".format(
                     remote_path,
                     written,
                     t_stat,
                     t_open,
                     t_read,
                     t_write,
-                    t_rm,
-                    t_rn,
                     t_resp,
                     diff(ticks(), t_start),
                 )
             )
     except Exception as e:
         # Mid-write failure leaves an unknown number of bytes in the
-        # socket; safest to drop the connection.
+        # socket AND possibly a partial file. Delete the partial and
+        # drop the connection.
+        try:
+            os.remove(target)
+        except (OSError, NameError):
+            pass
         writer._keep_alive = False
         await _send_json(writer, {"error": str(e)}, 500)
 

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -23,6 +23,37 @@ from bodn import storage
 OTA_STAGE = "/.ota"
 _OTA_MANIFEST = OTA_STAGE + "/MANIFEST.json"
 
+# Deadline in ticks_ms; once past it, ota_active() returns False and the
+# main render tasks go back to normal. Refreshed on every /api/upload
+# and /api/ota/* call, so an interrupted deploy recovers on its own.
+_OTA_QUIET_MS = 10_000
+
+
+def _mark_ota_active(settings):
+    """Extend the 'OTA in progress' window.
+
+    primary_task / secondary_task poll `ota_active(settings)` and skip
+    rendering while the flag is set, freeing the Python VM so the
+    upload handler's many `await` points return promptly instead of
+    round-tripping through a frame render each time.
+    """
+    import time
+
+    settings["_ota_deadline_ms"] = time.ticks_add(time.ticks_ms(), _OTA_QUIET_MS)
+
+
+def ota_active(settings):
+    """Query whether we're currently mid-OTA and render loops should step aside."""
+    deadline = settings.get("_ota_deadline_ms")
+    if deadline is None:
+        return False
+    import time
+
+    if time.ticks_diff(deadline, time.ticks_ms()) <= 0:
+        settings["_ota_deadline_ms"] = None
+        return False
+    return True
+
 
 def _mkdirs(path):
     """Recursively create parent directories (MicroPython os.mkdir is single-level)."""
@@ -249,7 +280,17 @@ async def _handle_upload(reader, writer, headers, settings=None):
     cross-file integrity verification; HTTP uploads are one-file-at-a-time
     and retry per file, so per-file atomicity (write .new + rename) is
     sufficient.
+
+    When `settings["debug_ota"]` is truthy, prints a per-phase timing
+    breakdown to serial so a slow floor can be diagnosed without guessing.
     """
+    import time
+
+    debug = bool(settings and settings.get("debug_ota"))
+    ticks = time.ticks_ms
+    diff = time.ticks_diff
+    t_start = ticks()
+
     remote_path = headers.get("x-path", "")
     cl = int(headers.get("content-length", 0))
     tracker = settings.get("_idle_tracker") if settings is not None else None
@@ -263,11 +304,13 @@ async def _handle_upload(reader, writer, headers, settings=None):
     # still on disk is freed by the rename below; if the new file is
     # larger than the old we have to hold both briefly, which is what
     # this check ensures.
+    t_stat0 = ticks()
     try:
         st = os.statvfs("/")
         free = st[0] * st[3]  # f_bsize * f_bavail
     except Exception:
         free = 0
+    t_stat = diff(ticks(), t_stat0)
     if free > 0 and cl > free - 4096:
         await _drain_body(reader, cl)
         await _send_json(
@@ -287,16 +330,24 @@ async def _handle_upload(reader, writer, headers, settings=None):
         # block-level anyway, so larger chunks also reduce FAT overhead.
         CHUNK = 4096
         short_read = False
+        t_open0 = ticks()
+        t_read = 0
+        t_write = 0
         with open(tmp, "wb") as f:
+            t_open = diff(ticks(), t_open0)
             remaining = cl
             bytes_since_poke = 0
             while remaining > 0:
                 n = min(remaining, CHUNK)
+                tr0 = ticks()
                 chunk = await reader.read(n)
+                t_read += diff(ticks(), tr0)
                 if not chunk:
                     short_read = True
                     break
+                tw0 = ticks()
                 f.write(chunk)
+                t_write += diff(ticks(), tw0)
                 written += len(chunk)
                 remaining -= len(chunk)
                 bytes_since_poke += len(chunk)
@@ -310,15 +361,36 @@ async def _handle_upload(reader, writer, headers, settings=None):
             # reconnect rather than misread leftover bytes as the next
             # request line.
             writer._keep_alive = False
+        t_rm0 = ticks()
         try:
             os.remove(target)
         except OSError:
             pass
+        t_rm = diff(ticks(), t_rm0)
+        t_rn0 = ticks()
         os.rename(tmp, target)
+        t_rn = diff(ticks(), t_rn0)
+        t_resp0 = ticks()
         await _send_json(
             writer,
             {"ok": True, "path": remote_path, "size": written},
         )
+        t_resp = diff(ticks(), t_resp0)
+        if debug:
+            print(
+                "OTA {} {}B  stat={} open={} read={} write={} rm={} rn={} resp={} total={}".format(
+                    remote_path,
+                    written,
+                    t_stat,
+                    t_open,
+                    t_read,
+                    t_write,
+                    t_rm,
+                    t_rn,
+                    t_resp,
+                    diff(ticks(), t_start),
+                )
+            )
     except Exception as e:
         # Mid-write failure leaves an unknown number of bytes in the
         # socket; safest to drop the connection.
@@ -399,6 +471,9 @@ async def _handle_request(reader, writer, request_line, session_mgr, settings):
                 writer._keep_alive = False
                 await _send_unauthorized(writer, "Invalid OTA token")
                 return False
+            # Mark OTA active *after* auth succeeds — an attacker probing
+            # with no token shouldn't be able to freeze the UI.
+            _mark_ota_active(settings)
 
         # --- Auth: all other API/UI endpoints require PIN ---
         if path != "/api/login":

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -16,7 +16,7 @@ from bodn.mcp23017 import MCP23017
 from bodn.pca9685 import PCA9685
 from bodn.arcade import ArcadeButtons
 from bodn.session import SessionManager
-from bodn.web import start_server
+from bodn.web import start_server, ota_active
 from bodn.ftp import start_ftp
 from bodn.wifi import WiFiController
 from bodn import storage
@@ -751,6 +751,18 @@ async def primary_task(
     _PERF_INTERVAL = const(60)  # print every 60 frames
 
     while True:
+        # ── OTA quiet mode ───────────────────────────────────
+        # While a WiFi OTA is in progress, every ~20 ms we'd otherwise
+        # spend a few ms on update()+render() — long enough that the
+        # upload handler's await points end up round-tripping through
+        # a frame render on each chunk. Skipping both here frees the
+        # Python VM so the web task's awaits return promptly.
+        # The deadline auto-expires ~10 s after the last OTA request,
+        # so an interrupted deploy recovers without human intervention.
+        if ota_active(settings):
+            await asyncio.sleep_ms(50)
+            continue
+
         t0 = ticks_ms()
 
         # ── Input + game logic (always runs) ──────────────────
@@ -876,7 +888,7 @@ async def primary_task(
         await asyncio.sleep_ms(2)
 
 
-async def secondary_task(secondary):
+async def secondary_task(secondary, settings):
     """Secondary display tick.
 
     DMA mode: 50 ms (20 fps) — SPI no longer blocks Python.
@@ -887,6 +899,10 @@ async def secondary_task(secondary):
     _interval = 50 if _dma else 200
     errors = 0
     while True:
+        if ota_active(settings):
+            # See OTA quiet mode comment in primary_task — same rationale.
+            await asyncio.sleep_ms(_interval)
+            continue
         try:
             secondary.tick()
         except KeyboardInterrupt:
@@ -1301,7 +1317,7 @@ async def main():
             idle_tracker,
             power_mgr,
         ),
-        secondary_task(secondary),
+        secondary_task(secondary, settings),
         housekeeping_task(session_mgr, settings, audio=audio, pwm=pwm),
     ]
     if audio:

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -750,18 +750,46 @@ async def primary_task(
     _perf_t0 = ticks_ms()
     _PERF_INTERVAL = const(60)  # print every 60 frames
 
+    prev_ota = False
+    ota_frame = 0
+    next_ota_render_ms = 0
+    _OTA_RENDER_INTERVAL_MS = 250  # ~4 fps — enough for a moving progress bar
     while True:
         # ── OTA quiet mode ───────────────────────────────────
         # While a WiFi OTA is in progress, every ~20 ms we'd otherwise
         # spend a few ms on update()+render() — long enough that the
         # upload handler's await points end up round-tripping through
-        # a frame render on each chunk. Skipping both here frees the
-        # Python VM so the web task's awaits return promptly.
-        # The deadline auto-expires ~10 s after the last OTA request,
-        # so an interrupted deploy recovers without human intervention.
+        # a frame render on each chunk. Skipping the normal pipeline
+        # here frees the Python VM so the web task's awaits return
+        # promptly. We still paint the dedicated OTA status screen at
+        # ~4 fps so the kid sees something purposeful happening rather
+        # than a frozen game. The deadline auto-expires ~10 s after
+        # the last OTA request, so an interrupted deploy recovers
+        # without human intervention.
         if ota_active(settings):
+            prev_ota = True
+            now = ticks_ms()
+            if ticks_diff(now, next_ota_render_ms) >= 0:
+                from bodn.ui import ota as ota_ui
+
+                try:
+                    ota_ui.render(manager.tft, manager.theme, settings, ota_frame)
+                    manager.tft.show()
+                except Exception as e:
+                    import sys
+
+                    sys.print_exception(e)
+                next_ota_render_ms = ticks_ms() + _OTA_RENDER_INTERVAL_MS
+                ota_frame += 1
             await asyncio.sleep_ms(50)
             continue
+
+        # Transitioning out of OTA — the OTA screen is still on the
+        # framebuffer; force the active screen to repaint from scratch
+        # on the next frame.
+        if prev_ota:
+            prev_ota = False
+            manager.invalidate()
 
         t0 = ticks_ms()
 
@@ -898,11 +926,27 @@ async def secondary_task(secondary, settings):
     _dma = getattr(secondary.tft, "_native", False)
     _interval = 50 if _dma else 200
     errors = 0
+    prev_ota = False
     while True:
         if ota_active(settings):
-            # See OTA quiet mode comment in primary_task — same rationale.
+            # Paint "Uppdaterar..." once on entry; no per-tick work
+            # while OTA is running (progress/polish lives on the
+            # primary display). Secondary re-renders after OTA ends
+            # via the transition-out path below.
+            if not prev_ota:
+                prev_ota = True
+                try:
+                    from bodn.ui import ota as ota_ui
+
+                    ota_ui.render_secondary(secondary.tft, secondary.theme, settings)
+                    secondary.tft.show()
+                except Exception as e:
+                    print("secondary OTA paint error:", e)
             await asyncio.sleep_ms(_interval)
             continue
+        if prev_ota:
+            prev_ota = False
+            secondary.invalidate()
         try:
             secondary.tick()
         except KeyboardInterrupt:

--- a/tests/test_ota_push.py
+++ b/tests/test_ota_push.py
@@ -1,0 +1,309 @@
+"""Test the OTA push client's connection-reuse behaviour.
+
+Loads tools/ota-push.py by path (the hyphen in the filename makes a
+plain `import` awkward) and stubs out http.client.HTTPConnection so we
+can count how many TCP connections it actually opens for N requests.
+
+Regression target: before HTTP keep-alive, every file opened a fresh
+TCP connection — N files = N connections + N handshakes (~2 s of floor
+each on the ESP32). After: one connection should serve them all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OTA_PUSH_PATH = REPO_ROOT / "tools" / "ota-push.py"
+
+
+def _load_ota_push():
+    spec = importlib.util.spec_from_file_location("ota_push", OTA_PUSH_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["ota_push"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ota_push = _load_ota_push()
+
+
+class FakeResponse:
+    """Minimal stand-in for http.client.HTTPResponse."""
+
+    def __init__(
+        self, status: int = 200, body: bytes = b'{"ok":true}', will_close: bool = False
+    ):
+        self.status = status
+        self._body = body
+        self.will_close = will_close
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class FakeConnection:
+    """Counts how many requests were sent on this connection."""
+
+    instances: list["FakeConnection"] = []
+
+    def __init__(self, host, port=80, timeout=None):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.requests: list[tuple[str, str, bytes, dict]] = []
+        self.closed = False
+        self.sock = None  # ota-push.py touches this when adjusting timeouts
+        self._will_close_next = False
+        FakeConnection.instances.append(self)
+
+    def request(self, method, url, body=None, headers=None):
+        self.requests.append((method, url, body or b"", dict(headers or {})))
+
+    def getresponse(self):
+        return FakeResponse(will_close=self._will_close_next)
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_connections():
+    FakeConnection.instances.clear()
+    yield
+    FakeConnection.instances.clear()
+
+
+def test_keep_alive_reuses_one_connection_for_many_requests(monkeypatch):
+    monkeypatch.setattr(ota_push.http.client, "HTTPConnection", FakeConnection)
+    client = ota_push.KeepAliveClient("http://device.local")
+
+    for i in range(50):
+        status, _ = client.request(
+            "POST", "/api/upload", b"data", {"X-Path": f"/f{i}.py"}
+        )
+        assert status == 200
+
+    assert len(FakeConnection.instances) == 1
+    assert client.connect_count == 1
+    assert len(FakeConnection.instances[0].requests) == 50
+
+
+def test_keep_alive_advertised_in_headers(monkeypatch):
+    monkeypatch.setattr(ota_push.http.client, "HTTPConnection", FakeConnection)
+    client = ota_push.KeepAliveClient("http://device.local")
+    client.request("POST", "/api/upload", b"x", {"X-Path": "/a.py"})
+
+    sent_headers = FakeConnection.instances[0].requests[0][3]
+    assert sent_headers.get("Connection") == "keep-alive"
+    # Caller-supplied header survives.
+    assert sent_headers.get("X-Path") == "/a.py"
+    # Content-Length is set even when caller omits it.
+    assert sent_headers.get("Content-Length") == "1"
+
+
+def test_reconnect_on_server_close(monkeypatch):
+    """If the server closes the socket between requests we should
+    transparently open a new one and the caller never sees an error."""
+
+    class FlakyConnection(FakeConnection):
+        def getresponse(self):
+            # First call: act normal but mark socket as torn down so
+            # the next request() raises (the real http.client raises
+            # RemoteDisconnected when the peer closed before the next
+            # request was sent).
+            if len(self.requests) == 1 and not getattr(self, "_primed", False):
+                self._primed = True
+                return FakeResponse()
+            raise ConnectionResetError("server closed idle socket")
+
+    monkeypatch.setattr(ota_push.http.client, "HTTPConnection", FlakyConnection)
+    client = ota_push.KeepAliveClient("http://device.local")
+
+    # First request: succeeds on the original connection.
+    status, _ = client.request("POST", "/api/upload", b"a", {"X-Path": "/a"})
+    assert status == 200
+    # Second request: first connection raises on getresponse, so we
+    # reconnect and retry. The reconnect itself succeeds.
+    status, _ = client.request("POST", "/api/upload", b"b", {"X-Path": "/b"})
+    assert status == 200
+
+    # We opened at least 2 connections in total (original + at least
+    # one reconnect after the simulated server close).
+    assert client.connect_count >= 2
+
+
+def test_close_drops_cached_connection(monkeypatch):
+    monkeypatch.setattr(ota_push.http.client, "HTTPConnection", FakeConnection)
+    client = ota_push.KeepAliveClient("http://device.local")
+    client.request("POST", "/api/upload", b"x", {"X-Path": "/a"})
+    first = FakeConnection.instances[-1]
+    client.close()
+    assert first.closed is True
+
+    client.request("POST", "/api/upload", b"x", {"X-Path": "/b"})
+    # A second connection was opened after close().
+    assert client.connect_count == 2
+    assert len(FakeConnection.instances) == 2
+
+
+def test_will_close_response_drops_socket(monkeypatch):
+    """If the server replies Connection: close (via response.will_close)
+    we should drop the cached socket so the next request reconnects."""
+
+    class CloseAfterFirst(FakeConnection):
+        def getresponse(self):
+            return FakeResponse(will_close=True)
+
+    monkeypatch.setattr(ota_push.http.client, "HTTPConnection", CloseAfterFirst)
+    client = ota_push.KeepAliveClient("http://device.local")
+    client.request("POST", "/api/upload", b"x", {"X-Path": "/a"})
+    client.request("POST", "/api/upload", b"x", {"X-Path": "/b"})
+
+    assert client.connect_count == 2
+
+
+# ─────────────────────────────────────────────────────────────────────
+# End-to-end: real bodn.web server + real http.client over a local
+# socket. Catches server-side keep-alive bugs (framing, idle timeout,
+# header parsing) that pure mock tests can't see.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _start_real_server(port: int):
+    """Boot bodn.web on 127.0.0.1:port in a background thread.
+
+    Returns (thread, settings, stop_callable). The thread runs its own
+    asyncio loop so the test can use blocking http.client calls.
+    """
+    import asyncio
+    import threading
+    import bodn.web as web
+
+    settings = {
+        "ui_pin": "",
+        "ota_token": "",
+        "max_session_min": 10,
+    }
+
+    class FakeSession:
+        state = "idle"
+        time_remaining_s = 0
+        sessions_today = 0
+        sessions_remaining = 0
+        mode = None
+
+    loop_holder = {}
+
+    def run():
+        loop = asyncio.new_event_loop()
+        loop_holder["loop"] = loop
+        asyncio.set_event_loop(loop)
+        server = loop.run_until_complete(
+            web.start_server(FakeSession(), settings, port=port)
+        )
+        loop_holder["server"] = server
+        try:
+            loop.run_forever()
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    # Wait for server to be ready.
+    import socket
+    import time
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                break
+        except OSError:
+            time.sleep(0.02)
+    else:
+        raise RuntimeError("server did not start")
+
+    def stop():
+        loop = loop_holder.get("loop")
+        if loop is None:
+            return
+        loop.call_soon_threadsafe(loop.stop)
+        t.join(timeout=2)
+
+    return settings, stop
+
+
+@pytest.fixture
+def real_server():
+    """Boot bodn.web on a free port; tear it down after the test."""
+    import socket as _s
+
+    with _s.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+    settings, stop = _start_real_server(port)
+    try:
+        yield port, settings
+    finally:
+        stop()
+
+
+def test_server_serves_many_requests_on_one_connection(real_server, tmp_path):
+    """Send 100 sequential GET /api/status on one TCP connection."""
+    port, _settings = real_server
+    client = ota_push.KeepAliveClient(f"http://127.0.0.1:{port}", timeout=5)
+    try:
+        for _ in range(100):
+            status, body = client.request("GET", "/api/status", b"", {})
+            assert status == 200
+            assert b"state" in body
+        assert client.connect_count == 1
+    finally:
+        client.close()
+
+
+def test_server_idle_timeout_closes_connection(real_server):
+    """After the server-side idle timeout the socket is closed; next
+    request must transparently reconnect."""
+    import time
+
+    # Patch the idle timeout down to keep the test fast.
+    import bodn.web as web
+
+    original = web._KEEP_ALIVE_IDLE_S
+    web._KEEP_ALIVE_IDLE_S = 0.3
+    try:
+        port, _ = real_server
+        client = ota_push.KeepAliveClient(f"http://127.0.0.1:{port}", timeout=5)
+        try:
+            status, _ = client.request("GET", "/api/status", b"", {})
+            assert status == 200
+            time.sleep(0.6)  # let the server-side idle timeout fire
+            status, _ = client.request("GET", "/api/status", b"", {})
+            assert status == 200
+            assert client.connect_count >= 2
+        finally:
+            client.close()
+    finally:
+        web._KEEP_ALIVE_IDLE_S = original
+
+
+def test_server_honours_connection_close(real_server):
+    """When the client sends Connection: close the server must not keep
+    the socket open."""
+    import http.client
+
+    port, _ = real_server
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.request("GET", "/api/status", headers={"Connection": "close"})
+    resp = conn.getresponse()
+    resp.read()
+    assert resp.status == 200
+    assert resp.will_close, "server should echo Connection: close"
+    conn.close()

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -2,14 +2,19 @@
 # Deploy firmware to Bodn — auto-detects USB vs WiFi.
 #
 # Usage:
-#   ./tools/deploy.sh                   auto (prefers WiFi if mDNS resolves, else USB)
-#   ./tools/deploy.sh --usb             force USB sync via mpremote (tools/sync.sh)
-#   ./tools/deploy.sh --wifi            force WiFi push via HTTP (tools/ota-push.py)
-#   ./tools/deploy.sh --wifi 192.168.x  WiFi to a specific host
-#   ./tools/deploy.sh --mount           live-mount firmware/ over USB (no copy, edits are live)
-#   ./tools/deploy.sh --force           re-upload all files (skip hash cache); forwarded to WiFi path
+#   ./tools/deploy.sh                          auto (prefers WiFi if mDNS resolves, else USB)
+#   ./tools/deploy.sh --usb                    force USB sync via mpremote (tools/sync.sh)
+#   ./tools/deploy.sh --usb PATH [PATH ...]    USB-deploy just these files (no full rsync)
+#   ./tools/deploy.sh --wifi                   force WiFi push via HTTP (tools/ota-push.py)
+#   ./tools/deploy.sh --wifi 192.168.x         WiFi to a specific host
+#   ./tools/deploy.sh --mount                  live-mount firmware/ over USB (no copy, edits are live)
+#   ./tools/deploy.sh --force                  re-upload all files (skip hash cache); forwarded to WiFi path
 #
-# Any bare non-flag argument is treated as the WiFi host shorthand:
+# PATH arguments accept either firmware-relative (bodn/web.py) or
+# repo-relative (firmware/bodn/web.py) paths. The device-side target
+# mirrors the firmware-relative form.
+#
+# Any bare non-flag argument without --usb is treated as the WiFi host:
 #   ./tools/deploy.sh 192.168.1.143
 set -euo pipefail
 
@@ -19,9 +24,10 @@ MDNS_HOST="${BODN_MDNS:-bodn.local}"
 mode=""
 host=""
 force=""
+files=()
 
 usage() {
-    sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,17p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 while [ $# -gt 0 ]; do
@@ -32,7 +38,19 @@ while [ $# -gt 0 ]; do
         --force)  force="--force" ;;
         -h|--help) usage; exit 0 ;;
         --*)      echo "unknown flag: $1" >&2; usage >&2; exit 2 ;;
-        *)        host="$1"; [ -z "$mode" ] && mode=wifi ;;
+        *)
+            # --usb collects positionals as file paths; without an
+            # explicit mode (or with --wifi) the first bare arg is the
+            # host and anything else is an error.
+            if [ "$mode" = "usb" ]; then
+                files+=("$1")
+            elif [ -z "$host" ]; then
+                host="$1"
+                [ -z "$mode" ] && mode=wifi
+            else
+                echo "unexpected argument: $1" >&2; usage >&2; exit 2
+            fi
+            ;;
     esac
     shift
 done
@@ -85,6 +103,9 @@ fi
 
 case "$mode" in
     usb)
+        if [ ${#files[@]} -gt 0 ]; then
+            exec "$ROOT/tools/sync.sh" "${files[@]}"
+        fi
         exec "$ROOT/tools/sync.sh"
         ;;
     mount)

--- a/tools/ota-push.py
+++ b/tools/ota-push.py
@@ -16,11 +16,12 @@ Usage:
 """
 
 import hashlib
+import http.client
 import json
+import socket
 import sys
 import time
-import urllib.error
-import urllib.request
+import urllib.parse
 from pathlib import Path
 
 FIRMWARE_DIR = Path(__file__).resolve().parent.parent / "firmware"
@@ -66,7 +67,106 @@ def file_hash(path: Path) -> str:
 FILES = discover_files()
 
 
-def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int]:
+class KeepAliveClient:
+    """Reuse one TCP connection across many HTTP requests.
+
+    The previous urlopen() path opened a fresh TCP/HTTP handshake per
+    file, which dominated per-file time on the device. http.client lets
+    us send Connection: keep-alive and reuse the socket so the second
+    request lands on an already-established connection.
+
+    Reconnects on transport errors / unexpected EOF so a transient
+    glitch (or a server-side close after the idle timeout) doesn't fail
+    the whole sync — the caller's per-file retry loop then re-sends the
+    request body.
+    """
+
+    def __init__(self, base_url: str, timeout: float = 10.0):
+        parsed = urllib.parse.urlsplit(base_url)
+        if parsed.scheme not in ("http", ""):
+            raise ValueError(f"only http:// supported, got {base_url!r}")
+        self.host = parsed.hostname or ""
+        self.port = parsed.port or 80
+        self.timeout = timeout
+        self._conn: http.client.HTTPConnection | None = None
+        # For tests: count how many times we opened a TCP connection.
+        self.connect_count = 0
+
+    def _connect(self) -> http.client.HTTPConnection:
+        if self._conn is None:
+            self._conn = http.client.HTTPConnection(
+                self.host, self.port, timeout=self.timeout
+            )
+            self.connect_count += 1
+        return self._conn
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
+            self._conn = None
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes,
+        headers: dict[str, str],
+        timeout: float | None = None,
+    ) -> tuple[int, bytes]:
+        """Send one request, returning (status, body_bytes).
+
+        Caller handles non-2xx responses; transport errors raise.
+        """
+        # Always advertise keep-alive — server falls back to close if it
+        # doesn't support it, and we'll reconnect for the next request.
+        hdrs = dict(headers)
+        hdrs.setdefault("Connection", "keep-alive")
+        hdrs.setdefault("Content-Length", str(len(body)))
+
+        # One reconnect attempt: the server may have closed the socket
+        # after its idle timeout. http.client raises BadStatusLine /
+        # RemoteDisconnected in that case.
+        for is_retry in (False, True):
+            conn = self._connect()
+            if timeout is not None:
+                conn.timeout = timeout
+                if conn.sock is not None:
+                    conn.sock.settimeout(timeout)
+            try:
+                conn.request(method, path, body=body, headers=hdrs)
+                resp = conn.getresponse()
+                data = resp.read()
+                # If the server signalled close, drop our cached conn so
+                # the next request opens a fresh one.
+                if resp.will_close:
+                    self.close()
+                return resp.status, data
+            except (
+                http.client.BadStatusLine,
+                http.client.RemoteDisconnected,
+                ConnectionResetError,
+                BrokenPipeError,
+                socket.timeout,
+            ):
+                # Stale socket — reconnect once and retry the same body.
+                self.close()
+                if is_retry:
+                    raise
+            except Exception:
+                self.close()
+                raise
+        raise RuntimeError("unreachable")
+
+
+def push(
+    base_url: str,
+    token: str = "",
+    force: bool = False,
+    client: KeepAliveClient | None = None,
+) -> tuple[bool, int]:
     """Upload changed files. Returns (ok, uploaded_count)."""
     ok = True
     prev_hashes = {} if force else load_hashes()
@@ -75,6 +175,9 @@ def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int
     skipped = 0
     total_bytes = 0
     batch_start = time.monotonic()
+    own_client = client is None
+    if client is None:
+        client = KeepAliveClient(base_url)
 
     for rel_path in FILES:
         local = FIRMWARE_DIR / rel_path
@@ -92,7 +195,6 @@ def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int
             skipped += 1
             continue
         remote = "/" + rel_path
-        url = base_url.rstrip("/") + "/api/upload"
         hdrs = {
             "X-Path": remote,
             "Content-Type": "application/octet-stream",
@@ -102,12 +204,21 @@ def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int
 
         success = False
         for attempt in range(3):
-            timeout = 10 + attempt * 10  # 10s, 20s, 30s
-            req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
+            req_timeout = 10 + attempt * 10  # 10s, 20s, 30s
             t0 = time.monotonic()
             try:
-                resp = urllib.request.urlopen(req, timeout=timeout)
-                resp.read()
+                status, _ = client.request(
+                    "POST", "/api/upload", data, hdrs, timeout=req_timeout
+                )
+                if status == 401:
+                    print(f"  ERROR {rel_path}: Unauthorized (set --token)")
+                    break  # no point retrying auth errors
+                if status == 507:
+                    print(f"  ERROR {rel_path}: not enough space on device")
+                    break  # no point retrying
+                if status >= 400:
+                    print(f"  ERROR {rel_path}: HTTP {status}")
+                    continue
                 dt = time.monotonic() - t0
                 rate = (len(data) / dt / 1024) if dt > 0 else 0
                 print(
@@ -118,15 +229,6 @@ def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int
                 total_bytes += len(data)
                 success = True
                 break
-            except urllib.error.HTTPError as e:
-                if e.code == 401:
-                    print(f"  ERROR {rel_path}: Unauthorized (set --token)")
-                    break  # no point retrying auth errors
-                elif e.code == 507:
-                    print(f"  ERROR {rel_path}: not enough space on device")
-                    break  # no point retrying
-                else:
-                    print(f"  ERROR {rel_path}: HTTP {e.code}")
             except Exception as e:
                 label = "retrying..." if attempt < 2 else "giving up."
                 print(f"  {rel_path}: {e}, {label}")
@@ -137,6 +239,8 @@ def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int
 
     # Save hashes for files that did upload (even if some failed)
     save_hashes(new_hashes)
+    if own_client:
+        client.close()
 
     elapsed = time.monotonic() - batch_start
     if uploaded:
@@ -154,30 +258,31 @@ def push(base_url: str, token: str = "", force: bool = False) -> tuple[bool, int
 
 def ota_commit(base_url: str, token: str = "") -> bool:
     """Move staged files into place and reboot."""
-    url = base_url.rstrip("/") + "/api/ota/commit"
     hdrs = {"Content-Type": "application/json"}
     if token:
         hdrs["Authorization"] = f"Bearer {token}"
-    req = urllib.request.Request(url, data=b"{}", headers=hdrs, method="POST")
+    client = KeepAliveClient(base_url, timeout=30)
     try:
-        resp = urllib.request.urlopen(req, timeout=30)
-        resp.read()
-        return True
+        client.request("POST", "/api/ota/commit", b"{}", hdrs)
     except Exception:
-        return True  # device reboots mid-response, connection drops
+        pass  # device reboots mid-response, connection drops
+    finally:
+        client.close()
+    return True
 
 
 def ota_abort(base_url: str, token: str = "") -> None:
     """Discard staged files."""
-    url = base_url.rstrip("/") + "/api/ota/abort"
     hdrs = {"Content-Type": "application/json"}
     if token:
         hdrs["Authorization"] = f"Bearer {token}"
-    req = urllib.request.Request(url, data=b"{}", headers=hdrs, method="POST")
+    client = KeepAliveClient(base_url, timeout=5)
     try:
-        urllib.request.urlopen(req, timeout=5)
+        client.request("POST", "/api/ota/abort", b"{}", hdrs)
     except Exception:
         pass
+    finally:
+        client.close()
 
 
 def _parse_args():

--- a/tools/ota-push.py
+++ b/tools/ota-push.py
@@ -204,7 +204,13 @@ def push(
 
         success = False
         for attempt in range(3):
-            req_timeout = 10 + attempt * 10  # 10s, 20s, 30s
+            # Start at 30s: the device's asyncio scheduler yields on every
+            # await, and a busy main loop (UI frame, NeoPixel tick) can push
+            # a single file's processing to >10s. A 10s first-attempt would
+            # then fire socket.timeout, drop the keep-alive connection, and
+            # pay a full reconnect — more costly than just waiting out the
+            # spike on the socket we already have.
+            req_timeout = 30 + attempt * 15  # 30s, 45s, 60s
             t0 = time.monotonic()
             try:
                 status, _ = client.request(

--- a/tools/ota-push.py
+++ b/tools/ota-push.py
@@ -179,6 +179,27 @@ def push(
     if client is None:
         client = KeepAliveClient(base_url)
 
+    # Pre-scan: count files + bytes we're about to upload. The device's
+    # OTA status screen uses these to render a real progress bar instead
+    # of an indeterminate spinner. We'd have to hash every file to
+    # skip-check anyway, so this costs nothing extra.
+    plan_files = 0
+    plan_bytes = 0
+    for rel_path in FILES:
+        local = FIRMWARE_DIR / rel_path
+        if not local.exists():
+            continue
+        h = file_hash(local)
+        if not force and prev_hashes.get(rel_path) == h:
+            continue
+        size = local.stat().st_size
+        if size == 0:
+            continue
+        plan_files += 1
+        plan_bytes += size
+    if plan_files > 0:
+        _ota_begin(client, plan_files, plan_bytes, token)
+
     for rel_path in FILES:
         local = FIRMWARE_DIR / rel_path
         if not local.exists():
@@ -263,6 +284,24 @@ def push(
     print(f"  (opened {client.connect_count} TCP connection(s))")
 
     return ok, uploaded
+
+
+def _ota_begin(
+    client: KeepAliveClient, files: int, byte_total: int, token: str
+) -> None:
+    """Tell the device how many files + bytes we're about to upload so
+    it can render a progress bar on the OTA status screen. Best-effort:
+    if the endpoint doesn't exist (old firmware) or the request fails,
+    the device falls back to an indeterminate spinner.
+    """
+    hdrs = {"Content-Type": "application/json"}
+    if token:
+        hdrs["Authorization"] = f"Bearer {token}"
+    body = json.dumps({"files": files, "bytes": byte_total}).encode("utf-8")
+    try:
+        client.request("POST", "/api/ota/begin", body, hdrs)
+    except Exception:
+        pass
 
 
 def ota_commit(base_url: str, token: str = "") -> bool:

--- a/tools/ota-push.py
+++ b/tools/ota-push.py
@@ -252,6 +252,9 @@ def push(
         )
     elif skipped:
         print(f"  All {skipped} files unchanged ({elapsed:.1f}s)")
+    # Sanity check: confirms HTTP keep-alive actually reused the socket
+    # instead of opening a fresh TCP connection per file.
+    print(f"  (opened {client.connect_count} TCP connection(s))")
 
     return ok, uploaded
 

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # Sync firmware to the ESP32 device via mpremote.
 # Usage: ./tools/sync.sh [--clean] [--minimal]
+#        ./tools/sync.sh PATH [PATH ...]
 #   --clean    Wipe device filesystem before syncing
 #   --minimal  Flash only boot.py, main.py, st7735.py, sdcard.py, and bodn/
 #              (skip firmware/sounds/). Useful when the device is hanging
 #              badly — press RST on the devkit, then run this immediately.
+#   PATH…      Copy only the given files and reset. Accepts repo-relative
+#              (firmware/bodn/web.py) or firmware-relative (bodn/web.py)
+#              paths. The device path mirrors the firmware-relative form.
+#              Fast path for iterating on one or two files.
 #
 # Reliability notes
 # -----------------
@@ -22,6 +27,27 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 MPREMOTE="uv run mpremote connect auto"
+
+# Targeted single/multi-file sync. Everything that isn't a flag is a
+# path; resolve each to a (local_path, device_path) pair and issue a
+# single mpremote invocation (one raw-REPL entry keeps it fast).
+if [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; then
+    cd "$ROOT/firmware"
+    cmd=()
+    for arg in "$@"; do
+        # Strip leading firmware/ so the caller can paste repo-relative paths.
+        rel="${arg#firmware/}"
+        rel="${rel#./}"
+        if [ ! -f "$rel" ]; then
+            echo "sync.sh: not a file: $arg (looked for $ROOT/firmware/$rel)" >&2
+            exit 2
+        fi
+        cmd+=( fs cp "$rel" ":$rel" + )
+    done
+    echo "Deploying ${#} file(s) via USB..."
+    $MPREMOTE "${cmd[@]}" reset
+    exit 0
+fi
 
 if [ "${1:-}" = "--minimal" ]; then
     echo "Deploying core files (boot.py, main.py, st7735.py, sdcard.py, bodn/)..."


### PR DESCRIPTION
## Summary

Drive `./tools/deploy.sh --wifi --force` from 10-15 min to ~2 min 15 s on a real device (97 files, 980 KB) — roughly **5-7× faster** — and give the child a clear "Uppdaterar..." screen while it runs instead of a frozen game.

Started as HTTP keep-alive; when that didn't produce the expected win, profiled the device and peeled back layers.

## Measured per-file breakdown (device side)

| Phase | Role | Fix | After |
|---|---|---|---|
| TCP handshake | fresh connect per file | keep-alive + reconnect-on-error | 1 TCP connection for whole sync |
| `stat` | `os.statvfs('/')` — FAT free-cluster scan | cache the estimate, decrement by bytes written, re-stat on a byte/time budget | ~1200 ms → ~30 ms (floor) |
| `rm` + `rn` | `os.remove(target) + os.rename(tmp, target)` — two FAT dir scans each growing with dir size | write directly to target; on error delete the partial so the next boot fails loudly on missing instead of importing a truncated file | removed entirely |
| Nagle | response split across 5+ `writer.write()` calls | batch into one `write()`; `TCP_NODELAY` on accepted sockets | removed |
| UI contention | `primary_task` / `secondary_task` rendering between `await`s | `ota_active()` flag: upload handler extends a 10 s deadline; render tasks step aside and paint the OTA status screen at ~4 fps instead | main loop stops competing for VM time |

## OTA status screen

While a sync is running, both displays switch to a dedicated takeover:

- **Primary (240×320):** cyan "Uppdaterar..." banner, the current file path, a `N / TOTAL` files counter, and a real progress bar driven by bytes written.
- **Secondary (128×160):** minimal "Uppdaterar..." panel, painted once on entry.
- **Auto-recovery:** after 10 s of no OTA traffic the flag clears and the previous game repaints (`ScreenManager.invalidate()`) — so a crashed or Ctrl-C'd deploy doesn't leave the device stuck on the OTA screen.

New `POST /api/ota/begin` takes `{"files": N, "bytes": M}`; the client pre-scans the changeset and sends it before the first `/api/upload` so the progress bar is real instead of indeterminate. Old clients (without `begin`) get a ping-pong pulse fallback.

i18n keys: `ota_updating`, `ota_please_wait`, `ota_rebooting` (sv + en).

## Commits

1. `perf: HTTP keep-alive for OTA push` — connection reuse, HTTP/1.1, idle loop + timeout
2. `perf: TCP_NODELAY + single-write response to kill Nagle stall`
3. `feat: single-file USB deploy via ./tools/deploy.sh --usb PATH` — dev-loop QoL for iterating on `web.py`
4. `perf: raise OTA per-request timeout floor from 10s to 30s` — slow device spikes were tripping reconnects
5. `perf(ota): quiet main render tasks + per-phase upload timing` — debug instrumentation gated on `settings["debug_ota"]`
6. `perf(ota): cache os.statvfs across uploads — ~125 s saved per full sync`
7. `perf(ota): write uploads straight to target — drop ~60 s of FAT rename cost`
8. `feat(ota): takeover status screen during WiFi firmware sync`

## Acceptance criteria

- [x] Server handles ≥100 sequential `POST /api/upload` on one TCP connection
- [x] Server closes connection after configurable idle timeout (default 5 s)
- [x] Server falls back to single-request mode on `Connection: close`
- [x] Client reuses one connection for all files in `push()`
- [x] Client reconnects on server-side close / timeout / error
- [x] `ota-push.py --force` full firmware ≤ 2 min (came in at 2 min 15 s)
- [x] Existing tests pass (865); new test for connection reuse at the client layer (8 in `tests/test_ota_push.py`)
- [x] Client uses `http.client.HTTPConnection` (stdlib, no new deps)
- [x] Device UI shows it's updating (takeover screen with progress bar)

## Trade-offs

- **Atomicity**: HTTP OTA now writes directly to the live target, so power loss mid-write corrupts that file (old version is gone). The FTP OTA path — which has `MANIFEST.json`-backed cross-file verification — is unchanged for users who need strict atomicity. Write errors / short reads on the HTTP path delete the partial so boot fails cleanly on a missing file.
- **Cached statvfs**: the free-space answer can lag reality by up to 500 KB or 60 s. On a "not enough space" decision we force one authoritative re-stat before returning 507, so the refusal is never based on stale data.
- **OTA screen paints full framebuffer**: 250 ms cadence; tiny compared to the upload cost and a non-issue on DMA SPI.

## Test plan

- [x] `uv run pytest` — all 865 pass
- [x] `uv run ruff check firmware/ tools/ tests/` (changed files clean)
- [x] `uv run ruff format firmware/ tests/` (clean)
- [x] Real-device benchmark: `./tools/deploy.sh --wifi --force` — 135.7 s / 97 files / 1 TCP connection
- [x] Real-device UX: OTA screen appears on both displays during sync, progress bar advances, game resumes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)