### PR TITLE
fix: secondary display orientation/colour + demo and sequencer bugs

### DIFF
--- a/firmware/bodn/config.py
+++ b/firmware/bodn/config.py
@@ -48,13 +48,13 @@ TFT2_LANDSCAPE = False  # set True when display is mounted sideways
 if TFT2_LANDSCAPE:
     TFT2_WIDTH = 160
     TFT2_HEIGHT = 128
-    TFT2_MADCTL = 0x68  # MV + MX + BGR (90° CW — adjust MX/MY to match mounting)
+    TFT2_MADCTL = 0x60  # MV + MX (90° CW, RGB — panel uses RGB subpixels)
     TFT2_COL_OFFSET = 0
     TFT2_ROW_OFFSET = 0
 else:
     TFT2_WIDTH = 128
     TFT2_HEIGHT = 160
-    TFT2_MADCTL = 0x08  # BGR only (may need MX depending on module)
+    TFT2_MADCTL = 0xC0  # MY + MX (180° for upside-down mount, RGB subpixels)
     TFT2_COL_OFFSET = 0
     TFT2_ROW_OFFSET = 0
 

--- a/firmware/bodn/ui/demo.py
+++ b/firmware/bodn/ui/demo.py
@@ -38,6 +38,10 @@ _D_BUTTONS = const(8)
 _D_ARCADE = const(16)
 _D_ALL = const(31)  # 1|2|4|8|16
 
+# Arcade colour override: held = solid full-brightness, release fades over
+# this many frames (~20 ms each, so 18 ≈ 600 ms) back to the pattern.
+_ARC_FADE_FRAMES = const(18)
+
 # Colour palette per pattern index — module-level to avoid per-frame allocation
 _COLOUR_RGB = [
     (255, 0, 0),
@@ -167,16 +171,22 @@ class DemoScreen(Screen):
                 self._neo_dirty = True
                 break
 
-        # Arcade button tap → flash that button's color on all LEDs
+        # Arcade buttons drive a colour override on all NeoPixels:
+        #   • while held → solid at full brightness
+        #   • on release → fade back to the running pattern over _ARC_FADE_FRAMES
+        # A quick tap still looks like a flash: the press sets full brightness
+        # for at least one frame, then the release kicks off the fade.
         n_arc = len(inp.arc_held)
+        held_idx = -1
         for i in range(n_arc):
-            if inp.arc_just_pressed[i]:
-                self._arc_flash = i
-                self._arc_flash_ttl = 9  # ~300 ms at 30 fps
+            if inp.arc_held[i]:
+                held_idx = i
                 break
 
-        # Decay arcade flash (LED-only, no screen section)
-        if self._arc_flash_ttl > 0:
+        if held_idx >= 0:
+            self._arc_flash = held_idx
+            self._arc_flash_ttl = _ARC_FADE_FRAMES
+        elif self._arc_flash_ttl > 0:
             self._arc_flash_ttl -= 1
             if self._arc_flash_ttl == 0:
                 self._arc_flash = -1
@@ -255,15 +265,19 @@ class DemoScreen(Screen):
         if self._neo_dirty:
             self._neo_dirty = False
             self._apply_neo_pattern()
-        # Arcade flash override via C engine
+        # Arcade flash override via C engine: held = full, released = fade
         if self._arc_flash >= 0 and self._arc_flash < len(_ARC_RGB):
             cr, cg, cb = _ARC_RGB[self._arc_flash]
-            fade = self._arc_flash_ttl * self._brightness.value // 9
+            bri = self._brightness.value
+            if held_idx >= 0:
+                scale = bri
+            else:
+                scale = self._arc_flash_ttl * bri // _ARC_FADE_FRAMES
             neo.set_override(
                 neo.OVERRIDE_SOLID,
-                (cr * fade) >> 8,
-                (cg * fade) >> 8,
-                (cb * fade) >> 8,
+                (cr * scale) >> 8,
+                (cg * scale) >> 8,
+                (cb * scale) >> 8,
             )
 
     def _apply_neo_pattern(self):

--- a/firmware/bodn/ui/demo.py
+++ b/firmware/bodn/ui/demo.py
@@ -180,6 +180,8 @@ class DemoScreen(Screen):
             self._arc_flash_ttl -= 1
             if self._arc_flash_ttl == 0:
                 self._arc_flash = -1
+                # Release the solid-colour override so zone patterns render again
+                neo.clear_override()
 
         # Encoder A button → cycle pattern
         if inp.enc_btn_pressed[ENC_A]:

--- a/firmware/bodn/ui/sequencer.py
+++ b/firmware/bodn/ui/sequencer.py
@@ -62,7 +62,6 @@ class SequencerScreen(Screen):
 
     def __init__(
         self,
-        np,
         overlay,
         audio=None,
         arcade=None,
@@ -71,7 +70,6 @@ class SequencerScreen(Screen):
         on_exit=None,
         drum_bufs=None,
     ):
-        self._np = np
         self._overlay = overlay
         self._audio = audio
         self._arcade = arcade


### PR DESCRIPTION
Small batch of post-assembly fixes I hit while using the device.

## Summary
- **Secondary ST7735**: panel was mounted upside down and showing bluish colours — rotate 180° and switch to RGB subpixel order via MADCTL (`0x08` → `0xC0`).
- **Demo mode, stuck colour**: arcade-flash override was never released when its TTL decayed, so NeoPixels got stuck on a solid colour and mini-button pattern changes had no visible effect until re-entering the mode.
- **Demo mode, UX polish**: arcade buttons now drive a full-brightness solid override while held, fading back to the running pattern over ~600 ms on release. Quick taps still produce a clear flash.
- **Sequencer crash on entry**: `SequencerScreen.__init__` had a leftover unused `np` parameter in position 1; factory passed only `overlay`, which got bound to `np`, and entry crashed with "missing positional argument #2". Dropped the dead parameter.

## Test plan
- [ ] Secondary display renders right-way-up on boot logo and catface; cat is amber/orange (not bluish)
- [ ] Demo mode: tap an arcade button → brief flash fades back to pattern; hold an arcade button → solid colour stays until released
- [ ] Demo mode: after arcade interaction, mini buttons still switch patterns (Rainbow, Chase, etc.)
- [ ] Enter Sequencer mode from home carousel without crash; metronome, BPM encoder, and drum arcade triggers all work
- [ ] If secondary is shifted by a couple pixels along one edge, bump `TFT2_COL_OFFSET` / `TFT2_ROW_OFFSET`

🤖 Generated with [Claude Code](https://claude.com/claude-code)