### PR TITLE
feat: configurable NeoPixel max-brightness cap

### DIFF
--- a/firmware/bodn/config.py
+++ b/firmware/bodn/config.py
@@ -100,6 +100,14 @@ LED_LID_RING = (16, 92)  # 144 LED/m strip around lid perimeter
 NEOPIXEL_BRIGHTNESS = const(64)  # 0-255, sticks — low for battery + kid eyes
 NEOPIXEL_LID_BRIGHTNESS = const(32)  # 0-255, lid ring — lower for ambient glow
 
+# Hard cap on NeoPixel brightness (0-255).  All calls through bodn.neo clamp
+# pattern brightness and scale per-pixel RGB to this ceiling.  Keeps peak
+# current from the 5 V buck-boost within safe limits (108 LEDs × 60 mA/LED at
+# full white ≈ 6.5 A — well above the converter and battery C-rate) and
+# prevents thermal issues on the LED strip.  Raise carefully while watching
+# battery temp and brown-out resets.
+NEOPIXEL_MAX_BRIGHTNESS = const(128)
+
 # DevKit-Lipo on-board power monitoring (board-reserved — do not reassign)
 BAT_SENS_PIN = const(6)  # BAT_SENS: LiPo voltage via voltage divider → ADC
 PWR_SENS_PIN = const(5)  # PWR_SENS: high-Z on battery, low when USB present

--- a/firmware/bodn/neo.py
+++ b/firmware/bodn/neo.py
@@ -15,6 +15,28 @@ except ImportError:
     _neopixel = None
 
 
+def _cap(brightness):
+    """Clamp a pattern brightness to config.NEOPIXEL_MAX_BRIGHTNESS."""
+    m = config.NEOPIXEL_MAX_BRIGHTNESS
+    return brightness if brightness <= m else m
+
+
+def _scale_rgb(r, g, b):
+    """Scale per-pixel RGB to honour NEOPIXEL_MAX_BRIGHTNESS."""
+    m = config.NEOPIXEL_MAX_BRIGHTNESS
+    if m >= 255:
+        return r, g, b
+    return (r * m) // 255, (g * m) // 255, (b * m) // 255
+
+
+def _scale_bytes(data):
+    """Scale an r,g,b,r,g,b,... buffer by NEOPIXEL_MAX_BRIGHTNESS."""
+    m = config.NEOPIXEL_MAX_BRIGHTNESS
+    if m >= 255:
+        return data
+    return bytes((b * m) // 255 for b in data)
+
+
 class NeoEngine:
     """Convenience wrapper around _neopixel C module."""
 
@@ -81,7 +103,7 @@ class NeoEngine:
                 brightness = config.NEOPIXEL_LID_BRIGHTNESS
             else:
                 brightness = config.NEOPIXEL_BRIGHTNESS
-        kw = {"speed": speed, "brightness": brightness, "hue_offset": hue_offset}
+        kw = {"speed": speed, "brightness": _cap(brightness), "hue_offset": hue_offset}
         if colour is not None:
             kw["colour"] = colour
         _neopixel.zone_pattern(zone, pattern, **kw)
@@ -92,7 +114,7 @@ class NeoEngine:
 
     def zone_brightness(self, zone, brightness):
         if self._active:
-            _neopixel.zone_brightness(zone, brightness)
+            _neopixel.zone_brightness(zone, _cap(brightness))
 
     def all_off(self):
         """Turn off all zones."""
@@ -116,12 +138,13 @@ class NeoEngine:
 
     def set_pixel(self, index, r, g, b):
         if self._active:
+            r, g, b = _scale_rgb(r, g, b)
             _neopixel.set_pixel(index, r, g, b)
 
     def set_pixels(self, start, data):
         """Bulk set pixels from bytes(r,g,b,r,g,b,...)."""
         if self._active:
-            _neopixel.set_pixels(start, data)
+            _neopixel.set_pixels(start, _scale_bytes(data))
 
     def clear_pixel(self, index):
         if self._active:
@@ -139,6 +162,7 @@ class NeoEngine:
 
     def set_override(self, mode, r=0, g=0, b=0):
         if self._active:
+            r, g, b = _scale_rgb(r, g, b)
             _neopixel.set_override(mode, r=r, g=g, b=b)
 
     def clear_override(self):


### PR DESCRIPTION
## Summary
- Adds `NEOPIXEL_MAX_BRIGHTNESS` (default **128**) in `firmware/bodn/config.py` — single easily-tunable ceiling for all NeoPixel output
- Enforces it centrally in `firmware/bodn/neo.py`: clamps pattern brightness in `zone_pattern` / `zone_brightness`, scales per-pixel RGB in `set_pixel` / `set_pixels` / `set_override`
- Zero-cost fast path (`m >= 255`) so raising the cap to no-limit has no runtime overhead

## Why
108 LEDs at full white ≈ 6.5 A — well above the 5 V buck-boost and LiPo C-rate. Prior brown-outs/crashes and LED-strip heating were consistent with peak-current surges. A single central cap prevents any screen from driving the chain past safe current, regardless of what value game rules or the per-screen `BrightnessControl` knob computes.

## Test plan
- [x] `uv run pytest` — 865 passed
- [x] `uv run ruff check firmware/bodn/neo.py firmware/bodn/config.py` — clean
- [ ] Flash to device, exercise a high-brightness screen (Demo / Space / Garden) — confirm no brown-out, LED strip stays cool
- [ ] Set `NEOPIXEL_MAX_BRIGHTNESS = const(255)` locally and confirm behaviour is unchanged from pre-patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)