### PR TITLE
perf: run ESP32-S3 at 240 MHz instead of 160 MHz

### DIFF
--- a/boards/BODN_S3/mpconfigboard.cmake
+++ b/boards/BODN_S3/mpconfigboard.cmake
@@ -11,5 +11,6 @@ set(SDKCONFIG_DEFAULTS
     ${_PORT_DIR}/boards/sdkconfig.base
     ${_PORT_DIR}/boards/sdkconfig.spiram_sx
     ${_PORT_DIR}/boards/sdkconfig.spiram_oct
+    ${_PORT_DIR}/boards/sdkconfig.240mhz
     ${CMAKE_CURRENT_LIST_DIR}/sdkconfig.board
 )


### PR DESCRIPTION
## Summary
- The custom \`BODN_S3\` board definition pulled in \`sdkconfig.spiram_oct\` but skipped its companion \`sdkconfig.240mhz\` — the pair that the stock \`ESP32_GENERIC_S3\` \`SPIRAM_OCT\` variant includes together.
- Without \`CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y\`, ESP-IDF defaults the S3 to 160 MHz, so the device has been running at 2/3 of its rated speed since we switched to the custom board definition.
- One-line fix: add \`sdkconfig.240mhz\` to \`SDKCONFIG_DEFAULTS\` in \`boards/BODN_S3/mpconfigboard.cmake\`.

## Test plan
- [x] Rebuild firmware (\`./tools/build-firmware.sh\`) and flash
- [x] Verify \`machine.freq()\` returns \`240000000\` and diag screen shows \`CPU: 240 MHz\`
- [ ] Watch battery/enclosure temps on first long session — thermal task already sheds load at ≥50 °C and deep-sleeps at ≥60 °C, but the higher clock will draw more current

🤖 Generated with [Claude Code](https://claude.com/claude-code)