### PR TITLE
fix: eliminate Tone Lab pops on freq / wave / effect changes + add gated-output switch

### DIFF
--- a/cmodules/audiomix/audiomix.c
+++ b/cmodules/audiomix/audiomix.c
@@ -126,6 +126,8 @@ static mp_obj_t audiomix_voice_tone(size_t n_args, const mp_obj_t *args) {
     v->tone_samples_left = (audiomix_state->sample_rate * dur_ms) / 1000;
     v->tone_phase = 0;
     v->tone_wave = wave;
+    v->tone_wave_pending = wave;
+    v->tone_wave_xfade_left = 0;
     v->tone_sustain = 0;
     v->env_total_samples = 0;
     v->loop = 0;
@@ -144,6 +146,7 @@ static mp_obj_t audiomix_voice_tone(size_t n_args, const mp_obj_t *args) {
     v->mod_stutter_rate_cHz = 0;
     v->mod_stutter_duty_q15 = 0;
     v->mod_stutter_phase = 0;
+    v->mod_stutter_gate_q15 = 32767;
     audiomix_state->seq_counter++;
     v->start_seq = audiomix_state->seq_counter;
     v->source_type = SRC_TONE;
@@ -726,12 +729,15 @@ static mp_obj_t audiomix_voice_tone_sustained(size_t n_args, const mp_obj_t *arg
     v->tone_samples_left = 0;          // unused when tone_sustain = 1
     v->tone_phase = 0;
     v->tone_wave = wave;
+    v->tone_wave_pending = wave;
+    v->tone_wave_xfade_left = 0;
     v->tone_sustain = 1;
     v->env_total_samples = 0;
     v->loop = 0;
     v->fade_in = 1;                    // avoid click on first chunk
     v->fade_out = 0;
     v->stop_req = 0;
+    v->mod_stutter_gate_q15 = 32767;
     audiomix_state->seq_counter++;
     v->start_seq = audiomix_state->seq_counter;
     v->source_type = SRC_TONE;
@@ -740,6 +746,22 @@ static mp_obj_t audiomix_voice_tone_sustained(size_t n_args, const mp_obj_t *arg
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiomix_voice_tone_sustained_obj, 3, 3,
                                             audiomix_voice_tone_sustained);
+
+// _audiomix.voice_set_wave(idx, wave) — phase-preserving waveform change.
+// Only meaningful for a currently playing SRC_TONE voice.  Kicks off a short
+// (~3ms) linear crossfade between the old and new oscillators so the sample
+// shape transitions smoothly without a click.
+static mp_obj_t audiomix_voice_set_wave(mp_obj_t idx_obj, mp_obj_t wave_obj) {
+    audiomix_voice_t *v = resolve_voice(mp_obj_get_int(idx_obj));
+    uint8_t wave = (uint8_t)mp_obj_get_int(wave_obj);
+    if (wave == v->tone_wave && v->tone_wave_xfade_left == 0) {
+        return mp_const_none;  // no-op
+    }
+    v->tone_wave_pending = wave;
+    v->tone_wave_xfade_left = AUDIOMIX_WAVE_XFADE_SAMPLES;
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(audiomix_voice_set_wave_obj, audiomix_voice_set_wave);
 
 // _audiomix.voice_set_freq(idx, freq) — phase-preserving pitch change.
 // Only meaningful for a currently playing SRC_TONE voice.
@@ -839,6 +861,7 @@ static mp_obj_t audiomix_voice_clear_mods(mp_obj_t idx_obj) {
     v->mod_stutter_rate_cHz = 0;
     v->mod_stutter_duty_q15 = 0;
     v->mod_stutter_phase = 0;
+    v->mod_stutter_gate_q15 = 32767;
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(audiomix_voice_clear_mods_obj, audiomix_voice_clear_mods);
@@ -900,6 +923,7 @@ static const mp_rom_map_elem_t audiomix_module_globals_table[] = {
     // Sustained tones + modulation layer (reusable across modes)
     { MP_ROM_QSTR(MP_QSTR_voice_tone_sustained), MP_ROM_PTR(&audiomix_voice_tone_sustained_obj) },
     { MP_ROM_QSTR(MP_QSTR_voice_set_freq),       MP_ROM_PTR(&audiomix_voice_set_freq_obj) },
+    { MP_ROM_QSTR(MP_QSTR_voice_set_wave),       MP_ROM_PTR(&audiomix_voice_set_wave_obj) },
     { MP_ROM_QSTR(MP_QSTR_voice_set_pitch_lfo),  MP_ROM_PTR(&audiomix_voice_set_pitch_lfo_obj) },
     { MP_ROM_QSTR(MP_QSTR_voice_set_amp_lfo),    MP_ROM_PTR(&audiomix_voice_set_amp_lfo_obj) },
     { MP_ROM_QSTR(MP_QSTR_voice_set_bend),       MP_ROM_PTR(&audiomix_voice_set_bend_obj) },

--- a/cmodules/audiomix/audiomix.h
+++ b/cmodules/audiomix/audiomix.h
@@ -36,6 +36,15 @@
 // Fade length in samples
 #define AUDIOMIX_FADE_SAMPLES   16  // 1ms @ 16kHz
 
+// Waveform crossfade length (samples) for phase-preserving tone_wave swaps.
+// 48 ≈ 3ms at 16kHz — short enough to feel "instant", long enough to mask
+// the sample-value jump between differently-shaped oscillators.
+#define AUDIOMIX_WAVE_XFADE_SAMPLES   48
+
+// Stutter-gate edge ramp in samples (linear slew on the binary on/off gate).
+// 24 ≈ 1.5ms @ 16kHz — removes the click without audibly softening the gate.
+#define AUDIOMIX_STUTTER_RAMP_SAMPLES 24
+
 // ---------------------------------------------------------------------------
 // Ring buffer (lock-free SPSC)
 // ---------------------------------------------------------------------------
@@ -83,9 +92,15 @@ typedef struct {
     // SRC_TONE fields
     uint32_t tone_freq;
     uint32_t tone_samples_left;
-    uint32_t tone_phase;
-    uint8_t  tone_wave;
+    uint32_t tone_phase;                // Q16 cycle phase (0..65535 = one cycle)
+    uint8_t  tone_wave;                 // currently rendering waveform
     uint8_t  tone_sustain;              // 1 = play indefinitely until stop_req
+
+    // Waveform crossfade: when Python asks for a wave change via
+    // voice_set_wave(), we keep playing tone_wave while linearly mixing in
+    // tone_wave_pending over AUDIOMIX_WAVE_XFADE_SAMPLES samples.  0 = idle.
+    uint8_t  tone_wave_pending;
+    uint16_t tone_wave_xfade_left;
 
     // --- Reusable modulation layer (any SRC_TONE voice) ---
     // All fields zero = effect disabled.  Modes enable a subset and all
@@ -110,6 +125,7 @@ typedef struct {
     uint16_t mod_stutter_rate_cHz;      // 0 = off
     uint16_t mod_stutter_duty_q15;      // 0..32767 = off-fraction of cycle
     uint32_t mod_stutter_phase;
+    uint16_t mod_stutter_gate_q15;      // smoothed 0/32767 gate (slew-limited)
 
     // Envelope state (for clock-driven tone tracks — replaces fade_in for tones)
     uint32_t env_attack_samples;        // attack ramp length (0 = instant)

--- a/cmodules/audiomix/mixer.c
+++ b/cmodules/audiomix/mixer.c
@@ -105,6 +105,12 @@ static void apply_amp_modulation(int16_t *buf, uint32_t n,
     uint32_t stut_phase = v->mod_stutter_phase;
     uint32_t amp_depth = v->mod_lfo_amp_depth_q15;  // 0..32767
     uint32_t stut_duty = v->mod_stutter_duty_q15;    // 0..32767
+    // Slew-limited stutter gate: the raw 0/32767 target is low-passed so the
+    // gate edges aren't sharp clicks.  Per-sample step gives a linear ramp
+    // across AUDIOMIX_STUTTER_RAMP_SAMPLES samples.
+    uint32_t stut_gate = v->mod_stutter_gate_q15;
+    const int32_t stut_step = 32767 / AUDIOMIX_STUTTER_RAMP_SAMPLES;
+    int stut_active = (stut_inc && stut_duty) ? 1 : 0;
 
     for (uint32_t i = 0; i < n; i++) {
         // Amp LFO: gain in Q15, centred on unity minus half depth so it wobbles
@@ -117,12 +123,21 @@ static void apply_amp_modulation(int16_t *buf, uint32_t n,
             gain_q15 = 32767 - (uint32_t)dip;
             amp_phase += amp_inc;
         }
-        // Stutter: if we're in the "off" fraction of the cycle, zero the sample.
-        if (stut_inc && stut_duty) {
-            if ((stut_phase & 0xFFFF) < stut_duty) {
-                gain_q15 = 0;
-            }
+        // Stutter: slew-limit a binary on/off target toward the current sample.
+        if (stut_active) {
+            uint32_t target = ((stut_phase & 0xFFFF) < stut_duty) ? 0 : 32767;
+            int32_t delta = (int32_t)target - (int32_t)stut_gate;
+            if (delta >  stut_step) delta =  stut_step;
+            if (delta < -stut_step) delta = -stut_step;
+            stut_gate = (uint32_t)((int32_t)stut_gate + delta);
+            gain_q15 = (gain_q15 * stut_gate) >> 15;
             stut_phase += stut_inc;
+        } else if (stut_gate != 32767) {
+            // Effect just turned off — coast the gate back up to unity.
+            int32_t delta = 32767 - (int32_t)stut_gate;
+            if (delta >  stut_step) delta =  stut_step;
+            stut_gate = (uint32_t)((int32_t)stut_gate + delta);
+            gain_q15 = (gain_q15 * stut_gate) >> 15;
         }
         int32_t val = buf[i];
         val = (val * (int32_t)gain_q15) >> 15;
@@ -130,6 +145,35 @@ static void apply_amp_modulation(int16_t *buf, uint32_t n,
     }
     v->mod_lfo_amp_phase = amp_phase;
     v->mod_stutter_phase = stut_phase;
+    v->mod_stutter_gate_q15 = (uint16_t)stut_gate;
+}
+
+// Compute Q16 phase increment from a frequency in Hz.  Rounded to nearest.
+static inline uint32_t phase_inc_q16(uint32_t freq_hz, uint32_t sample_rate) {
+    if (freq_hz == 0 || sample_rate == 0) return 0;
+    return (uint32_t)(((uint64_t)freq_hz * 65536 + sample_rate / 2)
+                      / sample_rate);
+}
+
+// Generate one chunk of a single waveform into `out` and return the new Q16
+// phase.  Noise has no phase so we pass through unchanged.
+static uint32_t render_wave_chunk(int16_t *out, uint32_t n, uint8_t wave,
+                                   uint32_t inc_q16, uint32_t phase_q16,
+                                   uint32_t freq_hz, uint32_t sample_rate) {
+    switch (wave) {
+    case AUDIOMIX_WAVE_SQUARE:
+        return tonegen_square(out, n, inc_q16, phase_q16);
+    case AUDIOMIX_WAVE_SINE:
+        return tonegen_sine(out, n, inc_q16, phase_q16);
+    case AUDIOMIX_WAVE_SAWTOOTH:
+        return tonegen_sawtooth(out, n, inc_q16, phase_q16);
+    case AUDIOMIX_WAVE_NOISE:
+        tonegen_noise(out, n, freq_hz, sample_rate);
+        return phase_q16;
+    default:
+        memset(out, 0, n * sizeof(int16_t));
+        return phase_q16;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -235,25 +279,46 @@ static uint32_t voice_read(audiomix_state_t *state, audiomix_voice_t *v,
             eff_freq = (uint32_t)(((uint64_t)v->tone_freq * mult) >> 16);
             if (eff_freq == 0) eff_freq = 1;
         }
-        uint32_t period = state->sample_rate / eff_freq;
-        if (period < 1) period = 1;
+        uint32_t inc = phase_inc_q16(eff_freq, state->sample_rate);
 
-        switch (v->tone_wave) {
-        case AUDIOMIX_WAVE_SQUARE:
-            v->tone_phase = tonegen_square(voice_buf, n, period, v->tone_phase);
-            break;
-        case AUDIOMIX_WAVE_SINE:
-            v->tone_phase = tonegen_sine(voice_buf, n, period, v->tone_phase);
-            break;
-        case AUDIOMIX_WAVE_SAWTOOTH:
-            v->tone_phase = tonegen_sawtooth(voice_buf, n, period, v->tone_phase);
-            break;
-        case AUDIOMIX_WAVE_NOISE:
-            tonegen_noise(voice_buf, n, eff_freq, state->sample_rate);
-            break;
-        default:
-            memset(voice_buf, 0, n * 2);
-            break;
+        // Waveform crossfade: if Python requested a wave change, render the
+        // new wave for the whole chunk, then blend the old wave over the first
+        // xfade_left samples.  Phase is shared so both oscillators step in
+        // lockstep — no double-pitch artefacts — and samples past the fade
+        // continue with the new wave cleanly.
+        if (v->tone_wave_xfade_left > 0
+                && v->tone_wave_pending != v->tone_wave) {
+            uint32_t xfade_n = v->tone_wave_xfade_left;
+            if (xfade_n > n) xfade_n = n;
+
+            uint32_t new_phase = render_wave_chunk(
+                voice_buf, n, v->tone_wave_pending, inc, v->tone_phase,
+                eff_freq, state->sample_rate);
+
+            int16_t scratch[AUDIOMIX_WAVE_XFADE_SAMPLES];
+            render_wave_chunk(scratch, xfade_n, v->tone_wave,
+                              inc, v->tone_phase,
+                              eff_freq, state->sample_rate);
+
+            const uint32_t total = AUDIOMIX_WAVE_XFADE_SAMPLES;
+            uint32_t done = total - v->tone_wave_xfade_left;
+            for (uint32_t i = 0; i < xfade_n; i++) {
+                uint32_t t = ((done + i) << 15) / (total > 0 ? total : 1);
+                if (t > 32767) t = 32767;
+                int32_t a = (int32_t)scratch[i]   * (int32_t)(32767 - t);
+                int32_t b = (int32_t)voice_buf[i] * (int32_t)t;
+                voice_buf[i] = (int16_t)((a + b) >> 15);
+            }
+
+            v->tone_phase = new_phase;
+            v->tone_wave_xfade_left -= xfade_n;
+            if (v->tone_wave_xfade_left == 0) {
+                v->tone_wave = v->tone_wave_pending;
+            }
+        } else {
+            v->tone_phase = render_wave_chunk(
+                voice_buf, n, v->tone_wave, inc, v->tone_phase,
+                eff_freq, state->sample_rate);
         }
 
         // Apply envelope or legacy fade
@@ -306,25 +371,10 @@ static uint32_t voice_read(audiomix_state_t *state, audiomix_voice_t *v,
             if (want > v->seq_samples_left) want = v->seq_samples_left;
 
             if (v->tone_freq > 0) {
-                uint32_t period = state->sample_rate / v->tone_freq;
-                if (period < 1) period = 1;
-                switch (v->tone_wave) {
-                case AUDIOMIX_WAVE_SQUARE:
-                    v->seq_phase = tonegen_square(voice_buf + n, want,
-                                                   period, v->seq_phase);
-                    break;
-                case AUDIOMIX_WAVE_SINE:
-                    v->seq_phase = tonegen_sine(voice_buf + n, want,
-                                                 period, v->seq_phase);
-                    break;
-                case AUDIOMIX_WAVE_SAWTOOTH:
-                    v->seq_phase = tonegen_sawtooth(voice_buf + n, want,
-                                                     period, v->seq_phase);
-                    break;
-                default:
-                    memset(voice_buf + n, 0, want * 2);
-                    break;
-                }
+                uint32_t inc = phase_inc_q16(v->tone_freq, state->sample_rate);
+                v->seq_phase = render_wave_chunk(
+                    voice_buf + n, want, v->tone_wave, inc, v->seq_phase,
+                    v->tone_freq, state->sample_rate);
             } else {
                 // freq == 0 means silence (rest)
                 memset(voice_buf + n, 0, want * 2);
@@ -444,11 +494,14 @@ static void mix_task(void *arg) {
                             v->tone_samples_left = dur_samples;
                             v->tone_phase = 0;
                             v->tone_wave = clk->melody_wave;
+                            v->tone_wave_pending = clk->melody_wave;
+                            v->tone_wave_xfade_left = 0;
                             v->loop = 0;
                             v->fade_in = 1;
                             v->fade_out = 0;
                             v->stop_req = 0;
                             v->env_total_samples = 0;  // legacy path
+                            v->mod_stutter_gate_q15 = 32767;
                             v->source_type = SRC_TONE;
                         }
                     }
@@ -479,6 +532,8 @@ static void mix_task(void *arg) {
                     v->tone_samples_left = dur_samples;
                     v->tone_phase = 0;
                     v->tone_wave = ts->wave;
+                    v->tone_wave_pending = ts->wave;
+                    v->tone_wave_xfade_left = 0;
                     v->loop = 0;
                     v->fade_in = 0;   // envelope handles attack
                     v->fade_out = 0;
@@ -490,6 +545,7 @@ static void mix_task(void *arg) {
                     v->env_total_samples = dur_samples;
                     v->env_pos = 0;
                     v->env_velocity = ts->velocity;
+                    v->mod_stutter_gate_q15 = 32767;
 
                     v->source_type = SRC_TONE;
                 }
@@ -632,6 +688,7 @@ const char *mixer_init(const mixer_config_t *cfg, audiomix_state_t **state_out) 
         audiomix_voice_t *v = &state->voices[i];
         v->source_type = SRC_NONE;
         v->gain = AUDIOMIX_GAIN_DEFAULT;
+        v->mod_stutter_gate_q15 = 32767;
         ringbuf_init(&v->ringbuf, AUDIOMIX_RINGBUF_SIZE);
     }
 

--- a/cmodules/audiomix/tonegen.c
+++ b/cmodules/audiomix/tonegen.c
@@ -46,35 +46,43 @@ int16_t tonegen_lfo_sine(uint32_t phase_q16) {
     return sine_lut[(phase_q16 >> 8) & 0xFF];
 }
 
+// Phase is a 16-bit cycle counter (0..65535 = one full cycle).  Each sample
+// advances by inc_q16; the accumulator wraps naturally in 32-bit math and is
+// masked to 16 bits on return.  Because the wrap point doesn't depend on the
+// frequency, freq changes mid-stream are phase-continuous → no click.
+
 uint32_t tonegen_square(int16_t *out, uint32_t n_samples,
-                        uint32_t period, uint32_t phase) {
-    if (period < 1) period = 1;
-    uint32_t half = period / 2;
+                        uint32_t inc_q16, uint32_t phase_q16) {
+    uint32_t phase = phase_q16 & 0xFFFF;
+    uint32_t inc = inc_q16 & 0xFFFF;
     for (uint32_t i = 0; i < n_samples; i++) {
-        uint32_t p = (i + phase) % period;
-        out[i] = (p < half) ? 32767 : -32767;
+        out[i] = (phase < 0x8000) ? 32767 : -32767;
+        phase = (phase + inc) & 0xFFFF;
     }
-    return phase + n_samples;
+    return phase;
 }
 
 uint32_t tonegen_sine(int16_t *out, uint32_t n_samples,
-                      uint32_t period, uint32_t phase) {
-    if (period < 1) period = 1;
+                      uint32_t inc_q16, uint32_t phase_q16) {
+    uint32_t phase = phase_q16 & 0xFFFF;
+    uint32_t inc = inc_q16 & 0xFFFF;
     for (uint32_t i = 0; i < n_samples; i++) {
-        uint32_t idx = ((i + phase) * 256 / period) % 256;
-        out[i] = sine_lut[idx];
+        out[i] = sine_lut[phase >> 8];
+        phase = (phase + inc) & 0xFFFF;
     }
-    return phase + n_samples;
+    return phase;
 }
 
 uint32_t tonegen_sawtooth(int16_t *out, uint32_t n_samples,
-                          uint32_t period, uint32_t phase) {
-    if (period < 1) period = 1;
+                          uint32_t inc_q16, uint32_t phase_q16) {
+    uint32_t phase = phase_q16 & 0xFFFF;
+    uint32_t inc = inc_q16 & 0xFFFF;
     for (uint32_t i = 0; i < n_samples; i++) {
-        uint32_t p = (i + phase) % period;
-        out[i] = (int16_t)((p * 65534 / period) - 32767);
+        // phase 0x0000 → -32768 (min), 0x8000 → 0, 0xFFFF → +32767.
+        out[i] = (int16_t)((int32_t)phase - 0x8000);
+        phase = (phase + inc) & 0xFFFF;
     }
-    return phase + n_samples;
+    return phase;
 }
 
 void tonegen_noise(int16_t *out, uint32_t n_samples,

--- a/cmodules/audiomix/tonegen.h
+++ b/cmodules/audiomix/tonegen.h
@@ -5,20 +5,22 @@
 
 #include <stdint.h>
 
-// Generate square wave samples into `out`.
-// Returns the new phase offset for seamless chaining.
+// Square/sine/sawtooth take a Q16 phase accumulator: 65536 = one full cycle.
+// Callers compute inc_q16 = round(freq_hz * 65536 / sample_rate).  Phase is
+// continuous across chunks and across frequency changes — only the rate of
+// advance changes, so pitch sweeps are click-free.  Returns the new phase
+// (wrapped into 0..65535).
+
 uint32_t tonegen_square(int16_t *out, uint32_t n_samples,
-                        uint32_t period, uint32_t phase);
+                        uint32_t inc_q16, uint32_t phase_q16);
 
-// Generate sine wave samples using a 256-entry LUT.
 uint32_t tonegen_sine(int16_t *out, uint32_t n_samples,
-                      uint32_t period, uint32_t phase);
+                      uint32_t inc_q16, uint32_t phase_q16);
 
-// Generate sawtooth wave samples.
 uint32_t tonegen_sawtooth(int16_t *out, uint32_t n_samples,
-                          uint32_t period, uint32_t phase);
+                          uint32_t inc_q16, uint32_t phase_q16);
 
-// Generate noise with exponential decay.
+// Noise has no notion of phase — it's an exponentially-decaying LFSR burst.
 // decay_rate controls how fast the noise fades (~4000 = sharp click).
 void tonegen_noise(int16_t *out, uint32_t n_samples,
                    uint32_t decay_rate, uint32_t sample_rate);

--- a/firmware/bodn/audio.py
+++ b/firmware/bodn/audio.py
@@ -506,6 +506,15 @@ class AudioEngine:
         """Phase-preserving pitch change for a sustained tone."""
         _audiomix.voice_set_freq(voice, freq_hz)
 
+    def set_wave(self, voice, wave):
+        """Phase-preserving waveform change for a sustained tone.
+
+        Triggers a short (~3ms) linear crossfade between the old and new
+        oscillators so the sample shape transitions smoothly without a click.
+        """
+        wave_id = _WAVE_MAP.get(wave, 1)
+        _audiomix.voice_set_wave(voice, wave_id)
+
     def set_vibrato(self, voice, rate_hz=5.0, depth_cents=30):
         """Pitch LFO.  rate_hz=0 disables.  depth_cents is ±."""
         _audiomix.voice_set_pitch_lfo(voice, int(rate_hz * 100), int(depth_cents))

--- a/firmware/bodn/ui/tone_explorer.py
+++ b/firmware/bodn/ui/tone_explorer.py
@@ -34,6 +34,7 @@ _ENC_TIMBRE = const(1)  # config.ENC_A
 
 # Switch indices in inp.sw — see main.input_scan_task for the MCP layout.
 _SW_AUDIO_OUT = const(0)  # MCP1 GPB0 — True = speaker on, False = silent
+_SW_GATE_MODE = const(1)  # MCP1 GPB1 — True = arcade-gated, False = continuous
 _SW_VIZ_LEFT = const(2)  # MCP2 SW_LEFT — True = scope on primary
 _SW_OCT_RIGHT = const(3)  # MCP2 SW_RIGHT — True = high octave
 
@@ -170,6 +171,14 @@ class ToneExplorerScreen(Screen):
         self._saved_audio_enabled = True
         self._last_audio_sw = None
 
+        # Gate-mode state (sw[1]): when True, the voice only sounds while an
+        # arcade button is held.  _voice_active tracks whether the mixer is
+        # currently producing sound on self._voice — we fade in on first press
+        # and fade out on release so transitions stay click-free.
+        self._voice_active = False
+        self._gate_mode = False
+        self._gate_any_arcade_held = False
+
     # ---- lifecycle ------------------------------------------------------
 
     def enter(self, manager):
@@ -199,7 +208,11 @@ class ToneExplorerScreen(Screen):
         # Scope is only meaningful when the native audio engine is present.
         self._have_scope = hasattr(self._audio, "scope_peek") if self._audio else False
 
-        # Start the sustained voice.  Initial pitch is the engine's default.
+        # Allocate a voice slot from the "music" pool.  Whether it starts
+        # sounding depends on the gate-mode switch — we (re)start it from
+        # _sync_audio() once we know the current sw[1] state.
+        self._voice_active = False
+        self._gate_mode = False
         if self._audio:
             try:
                 self._voice = self._audio.tone_sustained(
@@ -207,7 +220,7 @@ class ToneExplorerScreen(Screen):
                     wave=_wave_name(self._engine.waveform_id),
                     channel="music",
                 )
-                # Zero gain until the first interaction — avoids a startup chirp.
+                self._voice_active = True
                 self._audio.set_freq(self._voice, self._engine.base_freq_hz)
             except Exception as e:
                 print("tone_explorer: failed to start voice:", e)
@@ -267,6 +280,13 @@ class ToneExplorerScreen(Screen):
             eng.on_viz_toggle(inp.sw[_SW_VIZ_LEFT])
         if len(inp.sw) > _SW_AUDIO_OUT:
             self._apply_audio_switch(inp.sw[_SW_AUDIO_OUT])
+        self._gate_mode = (
+            inp.sw[_SW_GATE_MODE] if len(inp.sw) > _SW_GATE_MODE else False
+        )
+        self._gate_any_arcade_held = any(
+            inp.arc_held[i]
+            for i in range(min(NOTES_PER_OCTAVE, len(inp.arc_held)))
+        )
 
         # Encoders — each detent = one pentatonic / timbre step.  Clamping
         # lives in the engine so the screen doesn't need to know the bounds.
@@ -343,20 +363,51 @@ class ToneExplorerScreen(Screen):
             return
         eng = self._engine
         eff_freq = eng.effective_freq_hz()
-        if eff_freq != self._last_eff_freq:
-            self._audio.set_freq(self._voice, eff_freq)
-            self._last_eff_freq = eff_freq
 
-        # Re-trigger the voice when waveform changes (different generator path).
-        if eng.waveform_id != self._last_waveform:
-            self._audio.tone_sustained(
+        # Gate mode: voice only sounds while an arcade button is held.  We
+        # fade the voice out on release (voice_stop) and re-trigger it on the
+        # next press — tone_sustained's fade-in keeps that click-free.
+        if self._gate_mode:
+            should_sound = self._gate_any_arcade_held
+        else:
+            should_sound = True
+
+        if should_sound and not self._voice_active:
+            self._voice = self._audio.tone_sustained(
                 eff_freq,
                 wave=_wave_name(eng.waveform_id),
                 channel="music",
                 voice=self._voice,
             )
+            self._voice_active = True
+            self._last_eff_freq = eff_freq
             self._last_waveform = eng.waveform_id
-            self._last_mask = -1  # force re-apply of mods after retrigger
+            self._last_mask = -1  # reapply effects after retrigger
+        elif not should_sound and self._voice_active:
+            # voice_stop() triggers a graceful fade-out in the mixer before
+            # the voice is released.  No need to touch effect state — the
+            # next tone_sustained() reapplies everything.
+            self._audio.stop(voice=self._voice)
+            self._voice_active = False
+            # Drop the harmony too so it doesn't linger past the gate close.
+            if self._harmony_voice is not None:
+                self._audio.stop(voice=self._harmony_voice)
+                self._harmony_voice = None
+
+        if not self._voice_active:
+            # Keep derived state in sync so the next gate-open starts cleanly.
+            self._last_eff_freq = eff_freq
+            self._last_waveform = eng.waveform_id
+            return
+
+        if eff_freq != self._last_eff_freq:
+            self._audio.set_freq(self._voice, eff_freq)
+            self._last_eff_freq = eff_freq
+
+        # Waveform change: phase-preserving crossfade (no voice retrigger).
+        if eng.waveform_id != self._last_waveform:
+            self._audio.set_wave(self._voice, _wave_name(eng.waveform_id))
+            self._last_waveform = eng.waveform_id
 
         if eng.effects_mask != self._last_mask:
             self._apply_effects()

--- a/firmware/bodn/ui/tone_explorer.py
+++ b/firmware/bodn/ui/tone_explorer.py
@@ -284,8 +284,7 @@ class ToneExplorerScreen(Screen):
             inp.sw[_SW_GATE_MODE] if len(inp.sw) > _SW_GATE_MODE else False
         )
         self._gate_any_arcade_held = any(
-            inp.arc_held[i]
-            for i in range(min(NOTES_PER_OCTAVE, len(inp.arc_held)))
+            inp.arc_held[i] for i in range(min(NOTES_PER_OCTAVE, len(inp.arc_held)))
         )
 
         # Encoders — each detent = one pentatonic / timbre step.  Clamping

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -444,6 +444,10 @@ class _FakeAudiomix:
         if idx in self._voices:
             self._voices[idx]["freq"] = freq
 
+    def voice_set_wave(self, idx, wave_id):
+        if idx in self._voices:
+            self._voices[idx]["wave"] = wave_id
+
     def voice_set_gain(self, idx, gain):
         if idx in self._voices:
             self._voices[idx]["gain"] = gain
@@ -545,6 +549,7 @@ for _attr in (
     "voice_sequence",
     "voice_tone_sustained",
     "voice_set_freq",
+    "voice_set_wave",
     "voice_set_gain",
     "voice_set_pitch_lfo",
     "voice_set_amp_lfo",


### PR DESCRIPTION
Pitch sweeps, timbre steps, and stutter bursts all produced audible clicks
because the mixer changed oscillator state mid-cycle.

- `tonegen` square/sine/sawtooth now run on a 16-bit cycle-phase accumulator
  instead of sample counters.  Frequency changes are phase-continuous, so
  turning the pitch encoder no longer pops.
- New `_audiomix.voice_set_wave()` / `audio.set_wave()` triggers a ~3 ms
  linear crossfade between the old and new oscillators instead of resetting
  the phase via `tone_sustained(voice=...)`.
- Stutter gate edges are now slew-limited over ~1.5 ms instead of being a
  hard 0/1 flip, removing the click when the effect is held.

Tone Lab also gets a gated-output mode on sw[1]: when the switch is on, the
voice only sounds while an arcade button is held; flipping it back to
continuous resumes free play.  Transitions reuse the existing fade-in and
fade-out paths so gating stays click-free.

https://claude.ai/code/session_01Q5SBu3Ric9ksmgruFVqdG1