### PR TITLE
feat: show cooldown countdown + resume-now button (#167)

### DIFF
--- a/firmware/bodn/session.py
+++ b/firmware/bodn/session.py
@@ -85,6 +85,26 @@ class SessionManager:
         return max(0, limit - elapsed)
 
     @property
+    def cooldown_remaining_s(self):
+        """Seconds until the device returns to IDLE from a break state.
+
+        Covers WINDDOWN (30 s grace) + SLEEPING + COOLDOWN (break_min).
+        Returns 0 for all other states. Always 0 when sessions are disabled.
+        """
+        if not self.settings.get("sessions_enabled", True):
+            return 0
+        break_s = self.settings.get("break_min", 0) * 60
+        now = self._get_time()
+        if self.state == WINDDOWN:
+            winddown_left = max(0, 30 - (now - self._sleep_start))
+            return winddown_left + break_s
+        if self.state == SLEEPING:
+            return break_s
+        if self.state == COOLDOWN:
+            return max(0, break_s - (now - self._sleep_start))
+        return 0
+
+    @property
     def sessions_today(self):
         return self._sessions_today
 
@@ -238,3 +258,17 @@ class SessionManager:
             self._record_session("force_sleep")
         self.state = SLEEPING
         self._sleep_start = self._get_time()
+
+    def resume_now(self):
+        """Skip the remainder of a break and return to IDLE immediately.
+
+        Has no effect outside WINDDOWN / SLEEPING / COOLDOWN. If the current
+        state is WINDDOWN the session record is emitted as if the break had
+        run to completion, so the sessions_today count stays consistent.
+        """
+        if self.state == WINDDOWN:
+            self._record_session("normal")
+        if self.state in (WINDDOWN, SLEEPING, COOLDOWN):
+            self.state = IDLE
+            return True
+        return False

--- a/firmware/bodn/ui/ambient.py
+++ b/firmware/bodn/ui/ambient.py
@@ -1,7 +1,7 @@
 # bodn/ui/ambient.py — screens for the secondary (ambient) display
 
 import time
-from bodn.session import PLAYING, WARN_5, WARN_2, IDLE
+from bodn.session import PLAYING, WARN_5, WARN_2, IDLE, WINDDOWN, SLEEPING, COOLDOWN
 from bodn.ui.screen import Screen
 from bodn.ui.widgets import draw_centered, draw_progress_bar, draw_battery_icon
 from bodn.ui.secondary import CONTENT_SIZE
@@ -59,6 +59,7 @@ class StatusStrip(Screen):
         self._last_min = -1
         self._prev_state = None
         self._prev_remaining_min = -1
+        self._prev_cooldown_s = -1
         self._prev_bat_pct = -1
         self._prev_charging = None
         self._prev_temp_status = "ok"
@@ -68,6 +69,7 @@ class StatusStrip(Screen):
         self._last_min = -1
         self._prev_state = None
         self._prev_remaining_min = -1
+        self._prev_cooldown_s = -1
         self._prev_bat_pct = -1
         self._prev_charging = None
         self._prev_temp_status = "ok"
@@ -92,6 +94,14 @@ class StatusStrip(Screen):
             if remaining_min != self._prev_remaining_min:
                 self._prev_remaining_min = remaining_min
                 changed = True
+
+        if state in (WINDDOWN, SLEEPING, COOLDOWN):
+            cd_s = self._session_mgr.cooldown_remaining_s
+            if cd_s != self._prev_cooldown_s:
+                self._prev_cooldown_s = cd_s
+                changed = True
+        else:
+            self._prev_cooldown_s = -1
 
         # Battery (cached — at most one ADC read per call, refresh every 30 s)
         bat_pct, charging = battery.read()
@@ -166,6 +176,15 @@ class StatusStrip(Screen):
             label = _t("plays", remaining)
             x_right = w - len(label) * 8 - 2
             tft.text(label, x_right, 2, color)
+
+        elif state in (WINDDOWN, SLEEPING, COOLDOWN):
+            cd_s = self._session_mgr.cooldown_remaining_s
+            if cd_s > 0:
+                mm = cd_s // 60
+                ss = cd_s % 60
+                label = "{}:{:02d}".format(mm, ss)
+                x_right = w - len(label) * 8 - 2
+                tft.text(label, x_right, 2, theme.MAGENTA)
 
         # Row 2: safety alerts > battery icon (priority order)
         temp_st = temperature.status()
@@ -279,6 +298,18 @@ class StatusStrip(Screen):
                 label = label[:max_chars]
             lx = (w - len(label) * 8) // 2
             tft.text(label, max(0, lx), y_session, color)
+
+        elif state in (WINDDOWN, SLEEPING, COOLDOWN):
+            cd_s = self._session_mgr.cooldown_remaining_s
+            if cd_s > 0:
+                mm = cd_s // 60
+                ss = cd_s % 60
+                label = "{}:{:02d}".format(mm, ss)
+                max_chars = w // 8
+                if len(label) > max_chars:
+                    label = "{}m".format(mm)
+                lx = (w - len(label) * 8) // 2
+                tft.text(label, max(0, lx), y_session, theme.MAGENTA)
 
         # Bottom: safety alerts > battery icon (priority order)
         temp_st = temperature.status()

--- a/firmware/bodn/ui/overlay.py
+++ b/firmware/bodn/ui/overlay.py
@@ -31,6 +31,7 @@ class SessionOverlay(Screen):
         self._prev_state = None
         self._prev_temp_status = "ok"
         self._prev_bat_status = "ok"
+        self._prev_countdown_s = -1
         self._dirty = True
         self._full_clear = True
 
@@ -91,6 +92,15 @@ class SessionOverlay(Screen):
         # Blinking states need periodic redraws
         if state == WINDDOWN and frame % 20 == 0:
             self._dirty = True
+
+        # Countdown needs per-second redraw during break states
+        if state in (WINDDOWN, SLEEPING, COOLDOWN):
+            countdown_s = self.session_mgr.cooldown_remaining_s
+            if countdown_s != self._prev_countdown_s:
+                self._prev_countdown_s = countdown_s
+                self._dirty = True
+        else:
+            self._prev_countdown_s = -1
         # Overtemp / low-battery blink for attention
         if temp_status in ("warn", "critical") and frame % 15 == 0:
             self._dirty = True
@@ -156,11 +166,13 @@ class SessionOverlay(Screen):
             tft.fill_rect(40, 70, 80, 10, theme.BLACK)
             if (frame // 20) % 2 == 0:
                 tft.text(t("overlay_zzz"), 40, 70, theme.AMBER)
+            self._draw_countdown(tft, theme)
 
         elif state in (SLEEPING, COOLDOWN):
             tft.text(t("overlay_zzz_short"), 52, 60, theme.BLUE)
             tft.text(t("overlay_see_you"), 36, 80, theme.WHITE)
             tft.text(t("overlay_soon"), 44, 96, theme.WHITE)
+            self._draw_countdown(tft, theme)
 
         elif state == LOCKDOWN:
             tft.text(t("overlay_goodnight"), 24, 70, theme.MAGENTA)
@@ -176,6 +188,21 @@ class SessionOverlay(Screen):
             lx = (tft.width - len(label) * 8) // 2
             tft.fill_rect(0, 0, tft.width, 12, theme.AMBER)
             tft.text(label, max(0, lx), 2, theme.BLACK)
+
+    def _draw_countdown(self, tft, theme):
+        """Draw an M:SS countdown showing time until the device wakes."""
+        secs = self.session_mgr.cooldown_remaining_s
+        if secs <= 0:
+            return
+        m = secs // 60
+        s = secs % 60
+        label = "{}:{:02d}".format(m, s)
+        # scale=2 → 16 px glyph width
+        w = len(label) * 16
+        x = (tft.width - w) // 2
+        y = 130
+        tft.fill_rect(0, y, tft.width, 18, theme.BLACK)
+        tft.text(label, max(0, x), y, theme.CYAN, scale=2)
 
     def static_led_override(self, state, leds, brightness):
         """Override LEDs with static colors based on session state.

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -570,6 +570,8 @@ async def _handle_request(reader, writer, request_line, session_mgr, settings):
             data = {
                 "state": session_mgr.state,
                 "time_remaining_s": session_mgr.time_remaining_s,
+                "cooldown_remaining_s": session_mgr.cooldown_remaining_s,
+                "break_s": settings["break_min"] * 60,
                 "sessions_today": session_mgr.sessions_today,
                 "sessions_remaining": session_mgr.sessions_remaining,
                 "max_session_s": settings["max_session_min"] * 60,
@@ -621,6 +623,10 @@ async def _handle_request(reader, writer, request_line, session_mgr, settings):
             settings["lockdown"] = not settings.get("lockdown", False)
             storage.save_settings(settings)
             await _send_json(writer, {"ok": True, "lockdown": settings["lockdown"]})
+
+        elif method == "POST" and path == "/api/resume":
+            ok = session_mgr.resume_now()
+            await _send_json(writer, {"ok": ok, "state": session_mgr.state})
 
         elif method == "GET" and path == "/api/history":
             sessions = storage.load_sessions()

--- a/firmware/bodn/web_ui.py
+++ b/firmware/bodn/web_ui.py
@@ -117,7 +117,7 @@ th{color:#aaa}
 <span id="state-badge" class="badge idle">IDLE</span>
 </div>
 <div class="stat"><label>Sessions today</label><span id="s-count" class="val">0</span> / <span id="s-max" class="val">5</span></div>
-<div class="stat"><label>Time remaining</label><div class="progress"><div id="time-bar" class="bar" style="width:0%"></div></div><div id="time-text" style="text-align:center;font-size:0.85em;margin-top:4px">--</div></div>
+<div class="stat"><label id="time-label">Time remaining</label><div class="progress"><div id="time-bar" class="bar" style="width:0%"></div></div><div id="time-text" style="text-align:center;font-size:0.85em;margin-top:4px">--</div></div>
 <div class="toggle"><input type="checkbox" id="sessions-enabled" checked onchange="toggleSessions()"><label>Session limits enabled</label></div>
 <div class="stats-grid">
 <div id="bat-card" class="stat-card" style="display:none">
@@ -130,6 +130,7 @@ th{color:#aaa}
 </div>
 </div>
 <div id="safety-alert" style="display:none;margin:8px 0;padding:10px;border-radius:8px;font-size:0.85em;font-weight:bold"></div>
+<button class="btn btn-primary" id="resume-btn" onclick="resumeNow()" style="display:none;margin-bottom:8px">Resume now</button>
 <button class="btn btn-danger" id="lockdown-btn" onclick="toggleLockdown()">Lockdown</button>
 </div>
 
@@ -239,10 +240,22 @@ var b=document.getElementById('state-badge');
 b.textContent=d.state;b.className='badge '+badgeClass(d.state);
 document.getElementById('s-count').textContent=d.sessions_today;
 document.getElementById('s-max').textContent=d.sessions_remaining+d.sessions_today;
+var tLbl=document.getElementById('time-label'),tBar=document.getElementById('time-bar'),tText=document.getElementById('time-text');
+var inBreak=(d.state==='WINDDOWN'||d.state==='SLEEPING'||d.state==='COOLDOWN');
+if(inBreak&&d.cooldown_remaining_s>0){
+var totS=(d.break_s||0)+30;
+var cpct=totS>0?Math.round(d.cooldown_remaining_s*100/totS):0;
+tLbl.textContent='Break remaining';
+tBar.style.width=cpct+'%';tBar.style.background='#8e44ad';
+tText.textContent=fmtTime(d.cooldown_remaining_s);
+}else{
 var pct=0,maxS=d.max_session_s||1200;
 if(d.time_remaining_s>0)pct=Math.round(d.time_remaining_s*100/maxS);
-document.getElementById('time-bar').style.width=pct+'%';
-document.getElementById('time-text').textContent=d.time_remaining_s>0?fmtTime(d.time_remaining_s):'--';
+tLbl.textContent='Time remaining';
+tBar.style.width=pct+'%';tBar.style.background='';
+tText.textContent=d.time_remaining_s>0?fmtTime(d.time_remaining_s):'--';
+}
+var rb=document.getElementById('resume-btn');if(rb)rb.style.display=inBreak?'':'none';
 document.getElementById('lockdown-btn').textContent=d.state==='LOCKDOWN'?'Unlock':'Lockdown';
 var tc=document.getElementById('temp-card'),tv=document.getElementById('temp-val');
 var bc=document.getElementById('bat-card'),bv=document.getElementById('bat-val'),bl=document.getElementById('bat-lbl');
@@ -353,6 +366,10 @@ setTimeout(function(){msg.className='msg'},2000);
 }
 async function toggleLockdown(){
 await fetch('/api/lockdown',{method:'POST'});
+refresh();
+}
+async function resumeNow(){
+await fetch('/api/resume',{method:'POST'});
 refresh();
 }
 async function loadHistory(){

--- a/tests/test_ota_push.py
+++ b/tests/test_ota_push.py
@@ -189,11 +189,13 @@ def _start_real_server(port: int):
         "ui_pin": "",
         "ota_token": "",
         "max_session_min": 10,
+        "break_min": 15,
     }
 
     class FakeSession:
         state = "idle"
         time_remaining_s = 0
+        cooldown_remaining_s = 0
         sessions_today = 0
         sessions_remaining = 0
         mode = None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -200,6 +200,89 @@ class TestForceSleep:
         assert mgr.sessions_today == 1
 
 
+class TestCooldownRemaining:
+    def test_zero_when_idle(self):
+        mgr, _, _ = make_session()
+        assert mgr.cooldown_remaining_s == 0
+
+    def test_zero_while_playing(self):
+        mgr, _, _ = make_session()
+        mgr.try_wake()
+        assert mgr.cooldown_remaining_s == 0
+
+    def test_counts_down_during_cooldown(self):
+        mgr, now, _ = make_session({"max_session_min": 1, "break_min": 2})
+        mgr.try_wake()
+        now[0] = 60
+        mgr.tick()  # WINDDOWN
+        now[0] = 90
+        mgr.tick()  # SLEEPING
+        mgr.tick()  # COOLDOWN
+        assert mgr.state == COOLDOWN
+        assert mgr.cooldown_remaining_s == 120  # 2 min break
+        now[0] = 150
+        assert mgr.cooldown_remaining_s == 60
+        now[0] = 210
+        assert mgr.cooldown_remaining_s == 0
+
+    def test_includes_winddown_grace(self):
+        mgr, now, _ = make_session({"max_session_min": 1, "break_min": 2})
+        mgr.try_wake()
+        now[0] = 60
+        mgr.tick()  # WINDDOWN (sleep_start = 60)
+        assert mgr.state == WINDDOWN
+        # 30s winddown + 120s break = 150s until IDLE
+        assert mgr.cooldown_remaining_s == 150
+        now[0] = 75
+        assert mgr.cooldown_remaining_s == 135  # 15s winddown left + 120
+
+    def test_zero_when_sessions_disabled(self):
+        mgr, _, _ = make_session({"sessions_enabled": False})
+        assert mgr.cooldown_remaining_s == 0
+
+
+class TestResumeNow:
+    def test_resume_from_cooldown(self):
+        mgr, now, _ = make_session({"max_session_min": 1, "break_min": 5})
+        mgr.try_wake()
+        now[0] = 60
+        mgr.tick()  # WINDDOWN
+        now[0] = 90
+        mgr.tick()  # SLEEPING
+        mgr.tick()  # COOLDOWN
+        assert mgr.state == COOLDOWN
+        assert mgr.resume_now() is True
+        assert mgr.state == IDLE
+        assert mgr.try_wake()
+
+    def test_resume_from_winddown_records_session(self):
+        records = []
+        mgr, now, _ = make_session(
+            {"max_session_min": 1, "break_min": 5},
+            on_session_end=lambda r: records.append(r),
+        )
+        mgr.try_wake()
+        now[0] = 60
+        mgr.tick()  # WINDDOWN
+        assert mgr.state == WINDDOWN
+        assert mgr.resume_now() is True
+        assert mgr.state == IDLE
+        assert len(records) == 1
+        assert records[0]["end_reason"] == "normal"
+        assert mgr.sessions_today == 1
+
+    def test_resume_is_noop_while_playing(self):
+        mgr, _, _ = make_session()
+        mgr.try_wake()
+        assert mgr.resume_now() is False
+        assert mgr.state == PLAYING
+
+    def test_resume_is_noop_while_idle(self):
+        mgr, _, _ = make_session()
+        assert mgr.resume_now() is False
+        assert mgr.state == IDLE
+
+
 class TestModeLimits:
     def test_default_mode_is_free_play(self):
         mgr, _, _ = make_session()


### PR DESCRIPTION
## Summary
- Adds a visible break timer so a waiting child (or parent) can see how long until the device wakes. Closes #167.
- Surfaces the same countdown in three places: primary overlay (M:SS), secondary StatusStrip (mm:ss, portrait + landscape), and the parental web UI (Break remaining bar).
- Adds a **Resume now** button in the web UI dashboard that skips the remainder of the break and returns the device to IDLE.

## Changes
- `session.py`: new `cooldown_remaining_s` property covering WINDDOWN grace + SLEEPING + COOLDOWN, and `resume_now()` that returns to IDLE (records the session if resumed from WINDDOWN so `sessions_today` stays consistent).
- `web.py`: `/api/status` exposes `cooldown_remaining_s` and `break_s`; `POST /api/resume` skips the break.
- `web_ui.py`: dashboard swaps "Time remaining" -> "Break remaining" with a purple bar during break states; "Resume now" button appears only in those states.
- `ui/overlay.py`: renders M:SS countdown under the "Vi ses snart!" banner.
- `ui/ambient.py` `StatusStrip`: renders compact mm:ss in both layouts.
- Tests: new `TestCooldownRemaining` and `TestResumeNow`; `real_server` fixture updated for new fields. 881 tests passing.

## Test plan
- [x] `uv run pytest` — all 881 tests pass
- [x] `uv run ruff check` — clean
- [x] `uv run black --check` — clean
- [ ] Flash to device, start a 1 min session with a 2 min break, verify countdown ticks on both displays and in web UI
- [ ] Hit "Resume now" in the web UI during COOLDOWN -> device returns to IDLE and a new session can be started

🤖 Generated with [Claude Code](https://claude.com/claude-code)