### PR TITLE
fix: render Visible modes + Per-mode limits in web UI (#168)

### DIFF
--- a/firmware/bodn/storage.py
+++ b/firmware/bodn/storage.py
@@ -75,8 +75,13 @@ def load_settings():
 
 
 def save_settings(settings):
-    """Save settings dict to flash."""
-    _atomic_write(SETTINGS_PATH, settings)
+    """Save settings dict to flash.
+
+    Keys starting with ``_`` are runtime-only (hardware handles, mode list,
+    idle tracker, …) and never persisted.
+    """
+    persistable = {k: v for k, v in settings.items() if not k.startswith("_")}
+    _atomic_write(SETTINGS_PATH, persistable)
 
 
 def load_sessions():

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -603,7 +603,10 @@ async def _handle_request(reader, writer, request_line, session_mgr, settings):
             await _send_json(writer, data)
 
         elif method == "GET" and path == "/api/settings":
-            await _send_json(writer, settings)
+            # Strip runtime-only keys (non-serializable objects like _pwm,
+            # _idle_tracker, plus internal lists like _all_modes).
+            public = {k: v for k, v in settings.items() if not k.startswith("_")}
+            await _send_json(writer, public)
 
         elif method == "POST" and path == "/api/settings":
             if body:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -50,6 +50,25 @@ class TestSettings:
         settings = load_settings()
         assert settings == DEFAULT_SETTINGS
 
+    def test_underscore_keys_are_not_persisted(self):
+        """Runtime-only keys (e.g. _idle_tracker, _pwm, _all_modes) must
+        not reach flash — they often hold non-serializable objects."""
+
+        class _Opaque:
+            pass
+
+        settings = dict(DEFAULT_SETTINGS)
+        settings["_idle_tracker"] = _Opaque()
+        settings["_pwm"] = _Opaque()
+        settings["_all_modes"] = ["demo", "simon"]
+        settings["max_session_min"] = 17
+        save_settings(settings)
+        loaded = load_settings()
+        assert "_idle_tracker" not in loaded
+        assert "_pwm" not in loaded
+        assert "_all_modes" not in loaded
+        assert loaded["max_session_min"] == 17
+
 
 class TestSessions:
     def test_empty_when_no_file(self):


### PR DESCRIPTION
## Summary

- `GET /api/settings` was serializing the whole `settings` dict including non-JSON-serializable runtime objects (`_idle_tracker`, `_pwm`, `_all_modes`). The exception killed the response, the JS outer `catch` at `web_ui.py:332` swallowed it, and the `/api/modes` fetch never ran — so **Visible modes** and **Per-mode limits** rendered empty. The other form fields looked populated because the HTML has hardcoded defaults (`value="20"` etc.).
- `storage.save_settings` had the same latent bug: `POST /api/settings` does `settings.update(body)` then `save_settings`, which would try to persist the runtime objects to flash too.
- Fix: filter underscore-prefixed keys in both the API response and the flash writer.

Fixes #168.

## Test plan

- [x] `uv run pytest` (882 passed, includes new `test_underscore_keys_are_not_persisted`)
- [x] `uv run ruff check` + `uv run black --check` clean on changed files
- [ ] On device: open web UI Settings → confirm **Visible modes** shows one checkbox per mode (demo, mystery, simon, …) and **Per-mode limits** shows one row per mode
- [ ] Toggle a mode + save → reload → confirm state persists and `/data/settings.json` on flash does NOT contain `_all_modes`, `_idle_tracker`, `_pwm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)