### PR TITLE
fix: story mode TTS — use AudioEngine public API

### DIFF
--- a/firmware/bodn/ui/story.py
+++ b/firmware/bodn/ui/story.py
@@ -292,7 +292,7 @@ class StoryScreen(Screen):
         self._tts_has_choices = eng.narrate_choices and eng.choice_count > 0
         # Try to play scene TTS
         tts_found = False
-        if self._audio and self._audio._voices:
+        if self._audio:
             scene_path = self._resolve_story_tts(eng.node_id)
             if scene_path:
                 self._audio.play(scene_path, channel="ui")
@@ -315,13 +315,9 @@ class StoryScreen(Screen):
             return
 
         if self._tts_playing:
-            # Check if UI voice is still active
-            if self._audio and self._audio._voices:
-                from bodn.audio import V_UI
-
-                ui_voice = self._audio._voices[V_UI]
-                if ui_voice.source is not None:
-                    return  # still playing
+            # Check if UI channel is still active
+            if self._audio and self._audio.channel_active("ui"):
+                return  # still playing
             # TTS phase finished
             if self._tts_phase == 0:
                 # Scene done — try choices


### PR DESCRIPTION
## Summary
- Story mode played no narration and jumped straight to the choices screen. Root cause: `StoryScreen` was written against the old Python `AudioEngine` that exposed a `_voices` list with per-voice `.source`; the native `_audiomix` C mixer replaced that with a pool API (`channel_active(pool)`), so the `self._audio._voices` gate was always falsy and `_start_narration` never queued the scene WAV — the length-based timer fallback then raced to the choices.
- Drop the `_voices` gate in `_start_narration` and swap the `_voices[V_UI].source` check in `_check_tts_done` for `channel_active("ui")`, matching the pattern in `bodn/tts.py`.
- Swept the firmware for other private `AudioEngine` access — story.py was the only broken call site. Sequencer, Space, Tone Lab, and `tts.py` already use the public API.

## Test plan
- [x] `uv run pytest` — 882 passed
- [ ] Flash to device, open Story Mode, confirm scene narration plays and choices narration follows (where `narrate_choices` is set)
- [ ] Confirm hand-recorded overrides still take precedence over generated TTS
- [ ] Confirm timer fallback still works for nodes without WAVs

🤖 Generated with [Claude Code](https://claude.com/claude-code)