### PR TITLE
fix: soundboard — clear each slot when its own sound ends

### DIFF
--- a/firmware/bodn/audio.py
+++ b/firmware/bodn/audio.py
@@ -353,6 +353,10 @@ class AudioEngine:
                 return True
         return False
 
+    def voice_active(self, idx):
+        """True if the given voice index is currently playing."""
+        return bool(_audiomix.voice_active(idx))
+
     @property
     def sfx_active(self):
         """Number of SFX pool voices currently playing."""
@@ -428,7 +432,7 @@ class AudioEngine:
     # -----------------------------------------------------------------------
 
     def play(self, path, loop=False, channel="sfx", voice=None):
-        """Play a WAV file."""
+        """Play a WAV file.  Returns the voice index used."""
         idx = self._resolve_voice(voice, channel)
         self._stop_streaming(idx)
         try:
@@ -441,9 +445,10 @@ class AudioEngine:
         except Exception as e:
             print("audio.play error:", e)
             _audiomix.voice_stop(idx)
+        return idx
 
     def play_buffer(self, data, loop=False, channel="sfx", voice=None):
-        """Play pre-loaded PCM data (bytearray)."""
+        """Play pre-loaded PCM data (bytearray).  Returns the voice index used."""
         idx = self._resolve_voice(voice, channel)
         self._stop_streaming(idx)
         # Set the new buffer reference BEFORE telling C to play.
@@ -453,6 +458,7 @@ class AudioEngine:
         # GC can't free the buffer while C is using it.
         self._buf_refs[idx] = data
         _audiomix.voice_play_buffer(idx, data, len(data), loop)
+        return idx
 
     def tone(self, freq_hz, duration_ms=200, wave="square", channel="sfx", voice=None):
         """Play a procedural tone."""

--- a/firmware/bodn/soundboard_rules.py
+++ b/firmware/bodn/soundboard_rules.py
@@ -212,6 +212,11 @@ class SoundboardState:
         self.bank = 0  # current bank index 0–3
         self.playing_slots = set()  # currently-playing mini buttons
         self.playing_arcades = set()  # currently-playing arcade buttons
+        # {slot: voice_idx} — tracks which mixer voice each active slot uses,
+        # so we can detect per-sound completion instead of waiting for the
+        # whole SFX pool to drain.
+        self.slot_voices = {}
+        self.arcade_voices = {}
         self.volume = 50  # 0–100
         self.muted = False
         self.slots_present = [False] * NUM_MINI_BUTTONS
@@ -236,6 +241,8 @@ class SoundboardState:
         self.bank = bank & 0x3
         self.playing_slots.clear()
         self.playing_arcades.clear()
+        self.slot_voices.clear()
+        self.arcade_voices.clear()
         self._rescan()
 
     def _rescan(self, on_progress=None):
@@ -401,7 +408,27 @@ class SoundboardState:
             return None, arcade_wav_path(slot)
         return None, None
 
+    def mark_slot_voice(self, slot, voice):
+        """Record the mixer voice used by a slot press."""
+        self.slot_voices[slot] = voice
+
+    def mark_arcade_voice(self, slot, voice):
+        """Record the mixer voice used by an arcade press."""
+        self.arcade_voices[slot] = voice
+
+    def finish_slot(self, slot):
+        """Mark a single mini slot's sound as finished."""
+        self.playing_slots.discard(slot)
+        self.slot_voices.pop(slot, None)
+
+    def finish_arcade(self, slot):
+        """Mark a single arcade slot's sound as finished."""
+        self.playing_arcades.discard(slot)
+        self.arcade_voices.pop(slot, None)
+
     def on_playback_done(self):
         """Call when all SFX voices have finished."""
         self.playing_slots.clear()
         self.playing_arcades.clear()
+        self.slot_voices.clear()
+        self.arcade_voices.clear()

--- a/firmware/bodn/ui/soundboard.py
+++ b/firmware/bodn/ui/soundboard.py
@@ -91,6 +91,9 @@ class SoundboardScreen(Screen):
         self._slots_dirty = False  # only affected slots need redraw
         self._vol_dirty = False  # only volume bar needs redraw
         self._leds_dirty = True
+        # Slots whose sound finished this tick and need repainting.
+        self._finished_mini = set()
+        self._finished_arc = set()
         self._prev_bank = -1
         self._prev_volume = -1
         self._prev_muted = None
@@ -119,6 +122,8 @@ class SoundboardScreen(Screen):
         self._prev_muted = None
         self._flash = None
         self._prev_flash = None
+        self._finished_mini.clear()
+        self._finished_arc.clear()
         neo.clear_all_overrides()
 
     def exit(self):
@@ -184,12 +189,15 @@ class SoundboardScreen(Screen):
         for i in range(NUM_MINI_BUTTONS):
             if inp.btn_just_pressed[i]:
                 buf, path = state.press_slot(i)
+                voice = None
                 if buf:
-                    self._audio.play_buffer(buf, channel="sfx")
+                    voice = self._audio.play_buffer(buf, channel="sfx")
                 elif path:
-                    self._audio.play(path, channel="sfx")
+                    voice = self._audio.play(path, channel="sfx")
                 else:
                     self._audio.play_sound("boop", channel="ui")
+                if voice is not None:
+                    state.mark_slot_voice(i, voice)
                 self._prev_flash = self._flash
                 self._flash = ("mini", i, frame + _FLASH_FRAMES)
                 self._slots_dirty = True
@@ -199,21 +207,31 @@ class SoundboardScreen(Screen):
         for i in range(NUM_ARCADE_BUTTONS):
             if inp.arc_just_pressed[i]:
                 buf, path = state.press_arcade(i)
+                voice = None
                 if buf:
-                    self._audio.play_buffer(buf, channel="sfx")
+                    voice = self._audio.play_buffer(buf, channel="sfx")
                 elif path:
-                    self._audio.play(path, channel="sfx")
+                    voice = self._audio.play(path, channel="sfx")
                 else:
                     self._audio.play_sound("boop", channel="ui")
+                if voice is not None:
+                    state.mark_arcade_voice(i, voice)
                 self._prev_flash = self._flash
                 self._flash = ("arc", i, frame + _FLASH_FRAMES)
                 self._slots_dirty = True
                 self._leds_dirty = True
 
-        # --- Check if audio finished ---
-        if self._audio.sfx_active == 0:
-            if state.playing_slots or state.playing_arcades:
-                state.on_playback_done()
+        # --- Per-voice completion: each sound clears its own slot ---
+        for slot, voice in list(state.slot_voices.items()):
+            if not self._audio.voice_active(voice):
+                state.finish_slot(slot)
+                self._finished_mini.add(slot)
+                self._slots_dirty = True
+                self._leds_dirty = True
+        for slot, voice in list(state.arcade_voices.items()):
+            if not self._audio.voice_active(voice):
+                state.finish_arcade(slot)
+                self._finished_arc.add(slot)
                 self._slots_dirty = True
                 self._leds_dirty = True
 
@@ -332,6 +350,8 @@ class SoundboardScreen(Screen):
             self._dirty = False
             self._slots_dirty = False
             self._vol_dirty = False
+            self._finished_mini.clear()
+            self._finished_arc.clear()
             if self._full_clear:
                 self._full_clear = False
                 tft.fill(theme.BLACK)
@@ -398,15 +418,13 @@ class SoundboardScreen(Screen):
             else:
                 to_redraw_arc.add(cf[1])
 
-        # If playback just finished, redraw all previously-playing slots
-        if not state.playing_slots and not state.playing_arcades:
-            # All slots might need un-highlighting — redraw all present
-            for i in range(NUM_MINI_BUTTONS):
-                if state.slots_present[i]:
-                    to_redraw_mini.add(i)
-            for i in range(NUM_ARCADE_BUTTONS):
-                if state.arcade_present[i]:
-                    to_redraw_arc.add(i)
+        # Individual slots whose sound just finished need un-highlighting.
+        if self._finished_mini:
+            to_redraw_mini.update(self._finished_mini)
+            self._finished_mini.clear()
+        if self._finished_arc:
+            to_redraw_arc.update(self._finished_arc)
+            self._finished_arc.clear()
 
         for i in to_redraw_mini:
             x, y = self._slot_xy(i, margin, grid_top, cell_w, cell_h)


### PR DESCRIPTION
## Summary
- Soundboard was waiting for the whole SFX pool (`audio.sfx_active == 0`) before clearing any slot's box/LED state, so a long sound pinned every other slot's highlight and glow until it finished too.
- Now each press captures the mixer voice it allocated; every tick the screen polls `audio.voice_active(v)` per tracked voice and finishes just the slots whose voices went idle.

## Changes
- `AudioEngine.play()` / `play_buffer()` return the allocated voice idx; new public `voice_active(idx)`.
- `SoundboardState` gains `slot_voices` / `arcade_voices` dicts and `mark_*_voice` / `finish_slot` / `finish_arcade` helpers; `set_bank` and `on_playback_done` clear them too.
- `SoundboardScreen` marks the voice on press and redraws only the slots whose sounds have ended (`_finished_mini` / `_finished_arc`), replacing the old "all done → redraw everything" branch.

## Test plan
- [x] `uv run pytest tests/test_soundboard_rules.py` — 45 passed
- [x] `uv run ruff check` on changed files
- [ ] On device: play sound A (long) and sound B (short) together → B's box/LED clears when B ends, A stays lit until A ends
- [ ] On device: ≥ 3 overlapping sounds, staggered start/end → each slot clears independently
- [ ] Bank switch mid-playback still clears all highlights and LEDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)