### PR TITLE
fix: web UI WiFi panel — show live SSID, never echo password (#169)

### DIFF
--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -606,7 +606,26 @@ async def _handle_request(reader, writer, request_line, session_mgr, settings):
             # Strip runtime-only keys (non-serializable objects like _pwm,
             # _idle_tracker, plus internal lists like _all_modes).
             public = {k: v for k, v in settings.items() if not k.startswith("_")}
+            # Never echo the WiFi password back. The UI gets a
+            # `wifi_pass_set` flag instead and only sends a new password
+            # when the user actually wants to replace it.
+            stored_pass = public.pop("wifi_pass", "")
+            public["wifi_pass_set"] = bool(stored_pass)
             await _send_json(writer, public)
+
+        elif method == "GET" and path == "/api/wifi/status":
+            from bodn import wifi as _wifi
+
+            data = {
+                "wifi_mode": settings.get("wifi_mode", "ap"),
+                "stored_ssid": settings.get("wifi_ssid", ""),
+                "live_ssid": _wifi.live_ssid(),
+                "connected": _wifi.is_sta_connected(),
+                "ip": _wifi.get_ip(),
+                "hostname": settings.get("hostname", "bodn"),
+                "wifi_pass_set": bool(settings.get("wifi_pass", "")),
+            }
+            await _send_json(writer, data)
 
         elif method == "POST" and path == "/api/settings":
             if body:
@@ -658,9 +677,16 @@ async def _handle_request(reader, writer, request_line, session_mgr, settings):
 
         elif method == "POST" and path == "/api/wifi":
             if body:
-                for k in ("wifi_mode", "wifi_ssid", "wifi_pass", "hostname"):
+                for k in ("wifi_mode", "wifi_ssid", "hostname"):
                     if k in body:
                         settings[k] = body[k]
+                # Only overwrite the stored password when the client sends
+                # a non-empty value. The UI leaves the field blank to mean
+                # "keep the existing password" — clearing it here would
+                # silently brick STA mode on the next reboot.
+                new_pass = body.get("wifi_pass")
+                if new_pass:
+                    settings["wifi_pass"] = new_pass
                 storage.save_settings(settings)
             writer._keep_alive = False  # we're about to reset
             await _send_json(writer, {"ok": True})

--- a/firmware/bodn/web_ui.py
+++ b/firmware/bodn/web_ui.py
@@ -201,9 +201,10 @@ th{color:#aaa}
 </div>
 
 <div id="wifi" class="panel">
+<div id="wifi-status" style="font-size:0.85em;color:#aaa;margin-bottom:10px"></div>
 <div class="field"><label>Mode</label><select class="input-field" id="wifi_mode"><option value="ap">Access Point</option><option value="sta">Connect to network</option></select></div>
 <div class="field"><label>SSID</label><input class="input-field" type="text" id="wifi_ssid"></div>
-<div class="field"><label>Password</label><input class="input-field" type="password" id="wifi_pass"></div>
+<div class="field"><label>Password</label><input class="input-field" type="password" id="wifi_pass" placeholder="Type a new password to replace"><p id="wifi-pass-hint" style="font-size:0.75em;color:#666;margin-top:4px"></p></div>
 <div class="field"><label>Hostname</label><input class="input-field" type="text" id="hostname" placeholder="bodn"><p style="font-size:0.75em;color:#666;margin-top:4px">Device will be reachable at <span id="hostname-preview">bodn</span>.local</p></div>
 <button class="btn btn-primary" onclick="saveWifi()">Save &amp; Reboot</button>
 <div id="wifi-msg" class="msg"></div>
@@ -219,6 +220,7 @@ if(id==='history')loadHistory();
 if(id==='stats')loadStats();
 if(id==='debug')loadBootLog();
 if(id==='nfc')loadNFC();
+if(id==='wifi')loadWifiStatus();
 }
 function updRv(el,id,suf){document.getElementById(id).textContent=el.value+suf}
 function badgeClass(s){
@@ -293,7 +295,7 @@ if(tzEl&&!tzEl.options.length){for(var o=-12;o<=14;o++){var op=document.createEl
 ['max_session_min','max_sessions_day','break_min','volume'].forEach(function(k){
 var el=document.getElementById(k);if(el&&d[k]!=null)el.value=d[k];
 });
-['quiet_start','quiet_end','wifi_ssid','wifi_pass','wifi_mode','ui_pin','ota_token','language','hostname'].forEach(function(k){
+['quiet_start','quiet_end','wifi_ssid','wifi_mode','ui_pin','ota_token','language','hostname'].forEach(function(k){
 var el=document.getElementById(k);if(el&&d[k]!=null)el.value=d[k]||'';
 });
 if(tzEl&&d.tz_offset!=null)tzEl.value=d.tz_offset;
@@ -436,12 +438,40 @@ msg.textContent=r.ok?'Saved!':'Error';
 setTimeout(function(){msg.className='msg'},2000);
 if(r.ok&&body.ui_pin){document.cookie='bodn_pin='+body.ui_pin+';path=/;SameSite=Strict'}
 }
+async function loadWifiStatus(){
+var st=document.getElementById('wifi-status');
+var hint=document.getElementById('wifi-pass-hint');
+var pw=document.getElementById('wifi_pass');
+var ssid=document.getElementById('wifi_ssid');
+try{
+var r=await fetch('/api/wifi/status');var d=await r.json();
+var parts=[];
+if(d.connected){
+parts.push('Currently connected to <b style="color:#27ae60">'+(d.live_ssid||'(unknown SSID)')+'</b>');
+if(d.ip&&d.ip!=='0.0.0.0')parts.push('IP <code>'+d.ip+'</code>');
+}else if((d.wifi_mode||'')==='ap'){
+parts.push('Running in <b>Access Point</b> mode');
+if(d.ip&&d.ip!=='0.0.0.0')parts.push('IP <code>'+d.ip+'</code>');
+}else{
+parts.push('Not connected');
+}
+if(st)st.innerHTML=parts.join(' &middot; ');
+// If no SSID is stored but the radio is associated, prefill the input
+// with the live SSID so the user doesn't have to re-type it.
+if(ssid&&!ssid.value&&d.live_ssid)ssid.value=d.live_ssid;
+if(hint)hint.textContent=d.wifi_pass_set?'Password is stored. Leave blank to keep it; type a new one to replace.':'No password stored.';
+if(pw)pw.placeholder=d.wifi_pass_set?'Leave blank to keep current password':'Enter network password';
+}catch(e){if(st)st.textContent='WiFi status unavailable.';}
+}
 async function saveWifi(){
 var hn=document.getElementById('hostname').value.trim()||'bodn';
 var body={wifi_mode:document.getElementById('wifi_mode').value,
 wifi_ssid:document.getElementById('wifi_ssid').value,
-wifi_pass:document.getElementById('wifi_pass').value,
 hostname:hn};
+// Only send wifi_pass when the user actually typed a new one. Sending an
+// empty string would wipe the stored password on the device.
+var pw=document.getElementById('wifi_pass').value;
+if(pw)body.wifi_pass=pw;
 var r=await fetch('/api/wifi',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
 var msg=document.getElementById('wifi-msg');
 msg.className=r.ok?'msg ok':'msg err';

--- a/firmware/bodn/wifi.py
+++ b/firmware/bodn/wifi.py
@@ -48,6 +48,37 @@ def get_ip():
     return "0.0.0.0"
 
 
+def is_sta_connected():
+    """Return True if the station interface is currently associated."""
+    try:
+        sta = network.WLAN(network.STA_IF)
+        return bool(sta.active() and sta.isconnected())
+    except Exception:
+        return False
+
+
+def live_ssid():
+    """Return the SSID the station interface is currently associated with.
+
+    Falls back to '' when the radio isn't connected or the port doesn't
+    expose `essid`/`ssid` via `WLAN.config`.
+    """
+    try:
+        sta = network.WLAN(network.STA_IF)
+        if not (sta.active() and sta.isconnected()):
+            return ""
+    except Exception:
+        return ""
+    for key in ("essid", "ssid"):
+        try:
+            val = sta.config(key)
+            if val:
+                return val
+        except Exception:
+            continue
+    return ""
+
+
 def _set_hostname(hostname="bodn"):
     """Set the network hostname so mDNS advertises <hostname>.local.
 

--- a/tests/test_web_wifi.py
+++ b/tests/test_web_wifi.py
@@ -1,0 +1,259 @@
+"""Regression tests for the WiFi section of the parental-controls web UI.
+
+Issue #169: the SSID/password fields rendered empty even when the device was
+connected to a network, and the stored password was echoed back to the
+browser. The fix introduces a /api/wifi/status endpoint that surfaces the
+live SSID, strips the password from /api/settings, and lets POST /api/wifi
+keep the existing password when the form leaves the field blank.
+"""
+
+import asyncio
+import json
+import sys
+import types
+
+import pytest
+
+# bodn.web pulls in bodn.web_ui which imports several display-related
+# modules; the conftest stubs cover those, but bodn.web also imports
+# `hashlib` lazily for OTA — present on CPython, fine.
+from bodn import web, wifi
+
+
+class _FakeReader:
+    def __init__(self, data: bytes):
+        self._buf = data
+
+    async def readline(self):
+        idx = self._buf.find(b"\n")
+        if idx == -1:
+            line, self._buf = self._buf, b""
+            return line
+        line, self._buf = self._buf[: idx + 1], self._buf[idx + 1 :]
+        return line
+
+    async def read(self, n):
+        chunk, self._buf = self._buf[:n], self._buf[n:]
+        return chunk
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.buf = bytearray()
+        self._keep_alive = False
+
+    def write(self, data):
+        self.buf.extend(data)
+
+    async def drain(self):
+        return None
+
+
+class _FakeSession:
+    state = "IDLE"
+    time_remaining_s = 0
+    cooldown_remaining_s = 0
+    sessions_today = 0
+    sessions_remaining = 0
+    mode = None
+
+
+def _request(method, path, body=None, cookie=None):
+    headers = ["Host: test", "Connection: close"]
+    if cookie:
+        headers.append("Cookie: " + cookie)
+    body_bytes = b""
+    if body is not None:
+        body_bytes = json.dumps(body).encode()
+        headers.append("Content-Type: application/json")
+        headers.append("Content-Length: {}".format(len(body_bytes)))
+    request_line = "{} {} HTTP/1.1\r\n".format(method, path).encode()
+    rest = ("\r\n".join(headers) + "\r\n\r\n").encode() + body_bytes
+    return request_line, _FakeReader(rest)
+
+
+def _run(method, path, settings, body=None, cookie=None):
+    request_line, reader = _request(method, path, body=body, cookie=cookie)
+    writer = _FakeWriter()
+    asyncio.run(
+        web._handle_request(reader, writer, request_line, _FakeSession(), settings)
+    )
+    raw = bytes(writer.buf)
+    head, _, payload = raw.partition(b"\r\n\r\n")
+    status_line = head.split(b"\r\n", 1)[0].decode()
+    return status_line, payload
+
+
+def _json_response(payload):
+    return json.loads(payload.decode())
+
+
+@pytest.fixture
+def settings():
+    # Minimal subset of DEFAULT_SETTINGS — we only exercise WiFi/auth paths.
+    return {
+        "wifi_mode": "sta",
+        "wifi_ssid": "HomeNet",
+        "wifi_pass": "supersecret",
+        "hostname": "bodn",
+        "ui_pin": "",
+        "ota_token": "",
+    }
+
+
+# --- /api/settings ----------------------------------------------------------
+
+
+def test_settings_endpoint_strips_wifi_password(settings):
+    status, payload = _run("GET", "/api/settings", settings)
+    assert "200" in status
+    data = _json_response(payload)
+    assert "wifi_pass" not in data, "stored password must not leak to clients"
+    assert data["wifi_pass_set"] is True
+    assert data["wifi_ssid"] == "HomeNet"
+
+
+def test_settings_wifi_pass_set_false_when_no_password(settings):
+    settings["wifi_pass"] = ""
+    _, payload = _run("GET", "/api/settings", settings)
+    data = _json_response(payload)
+    assert data["wifi_pass_set"] is False
+
+
+# --- /api/wifi/status -------------------------------------------------------
+
+
+def test_wifi_status_reports_stored_and_live_ssid(monkeypatch, settings):
+    monkeypatch.setattr(wifi, "live_ssid", lambda: "Wokwi-GUEST")
+    monkeypatch.setattr(wifi, "is_sta_connected", lambda: True)
+    monkeypatch.setattr(wifi, "get_ip", lambda: "10.13.37.2")
+
+    _, payload = _run("GET", "/api/wifi/status", settings)
+    data = _json_response(payload)
+    assert data == {
+        "wifi_mode": "sta",
+        "stored_ssid": "HomeNet",
+        "live_ssid": "Wokwi-GUEST",
+        "connected": True,
+        "ip": "10.13.37.2",
+        "hostname": "bodn",
+        "wifi_pass_set": True,
+    }
+
+
+def test_wifi_status_when_disconnected(monkeypatch, settings):
+    settings["wifi_mode"] = "ap"
+    settings["wifi_ssid"] = ""
+    settings["wifi_pass"] = ""
+    monkeypatch.setattr(wifi, "live_ssid", lambda: "")
+    monkeypatch.setattr(wifi, "is_sta_connected", lambda: False)
+    monkeypatch.setattr(wifi, "get_ip", lambda: "192.168.4.1")
+
+    _, payload = _run("GET", "/api/wifi/status", settings)
+    data = _json_response(payload)
+    assert data["connected"] is False
+    assert data["live_ssid"] == ""
+    assert data["wifi_pass_set"] is False
+    assert data["wifi_mode"] == "ap"
+
+
+# --- POST /api/wifi ---------------------------------------------------------
+
+
+def _post_wifi_no_reset(monkeypatch, settings, body):
+    """POST /api/wifi without actually rebooting the host."""
+    saved = {"called": False}
+
+    def fake_save(s):
+        saved["called"] = True
+
+    monkeypatch.setattr(web.storage, "save_settings", fake_save)
+
+    fake_machine = types.ModuleType("machine")
+    fake_machine.reset = lambda: (_ for _ in ()).throw(SystemExit)
+    monkeypatch.setitem(sys.modules, "machine", fake_machine)
+
+    # asyncio.sleep_ms is patched in conftest; the reset SystemExit terminates
+    # the coroutine after the response is queued.
+    request_line, reader = _request("POST", "/api/wifi", body=body)
+    writer = _FakeWriter()
+    try:
+        asyncio.run(
+            web._handle_request(reader, writer, request_line, _FakeSession(), settings)
+        )
+    except SystemExit:
+        pass
+    return saved["called"], writer
+
+
+def test_post_wifi_keeps_password_when_blank(monkeypatch, settings):
+    saved, _ = _post_wifi_no_reset(
+        monkeypatch,
+        settings,
+        {
+            "wifi_mode": "sta",
+            "wifi_ssid": "NewNet",
+            "wifi_pass": "",
+            "hostname": "bodn",
+        },
+    )
+    assert saved is True
+    assert settings["wifi_ssid"] == "NewNet"
+    # Critical: blank password must not wipe the stored credential.
+    assert settings["wifi_pass"] == "supersecret"
+
+
+def test_post_wifi_replaces_password_when_provided(monkeypatch, settings):
+    _post_wifi_no_reset(
+        monkeypatch,
+        settings,
+        {
+            "wifi_mode": "sta",
+            "wifi_ssid": "NewNet",
+            "wifi_pass": "freshpass",
+            "hostname": "bodn",
+        },
+    )
+    assert settings["wifi_pass"] == "freshpass"
+
+
+def test_post_wifi_omitted_password_keeps_existing(monkeypatch, settings):
+    """Field absent from the JSON body is treated the same as blank."""
+    _post_wifi_no_reset(
+        monkeypatch,
+        settings,
+        {"wifi_mode": "sta", "wifi_ssid": "NewNet", "hostname": "bodn"},
+    )
+    assert settings["wifi_pass"] == "supersecret"
+
+
+# --- wifi.live_ssid / is_sta_connected --------------------------------------
+
+
+def test_live_ssid_returns_empty_when_inactive():
+    sta = sys.modules["network"].WLAN(0)
+    sta._active = False
+    sta._connected = False
+    assert wifi.live_ssid() == ""
+    assert wifi.is_sta_connected() is False
+
+
+def test_live_ssid_reads_essid_when_connected(monkeypatch):
+    sta = sys.modules["network"].WLAN(0)
+    sta._active = True
+    sta._connected = True
+
+    def fake_config(*args, **kwargs):
+        if args and args[0] == "essid":
+            return "MyHomeWiFi"
+        raise ValueError("unsupported")
+
+    monkeypatch.setattr(sta, "config", fake_config, raising=False)
+    # The module-level WLAN factory always returns a fresh instance, so
+    # patch the factory to return our prepared one.
+    monkeypatch.setattr(
+        sys.modules["network"], "WLAN", lambda iface=0: sta, raising=False
+    )
+
+    assert wifi.is_sta_connected() is True
+    assert wifi.live_ssid() == "MyHomeWiFi"


### PR DESCRIPTION
The Settings → WiFi panel rendered empty SSID/password fields whenever the
device had connected through any path other than POST /api/wifi (Wokwi-GUEST
fallback, REPL `wlan.connect()`, OTA push, wiped settings.json), because the
form was bound directly to `wifi_ssid`/`wifi_pass` in settings.json.

- Add `wifi.live_ssid()` / `wifi.is_sta_connected()` helpers that read the
  STA radio state.
- Add `GET /api/wifi/status` returning the live SSID, stored SSID, mode, IP,
  hostname, and a `wifi_pass_set` flag (boolean — never the password
  itself).
- Strip `wifi_pass` from `GET /api/settings`; expose `wifi_pass_set` only.
- `POST /api/wifi` now only overwrites the stored password when a non-empty
  value is supplied, so leaving the form blank keeps the existing one.
- Web UI: show "Currently connected to <SSID>" above the form, prefill the
  SSID input from the live value when none is stored, and switch the
  password field to a "leave blank to keep current" pattern.