### PR TITLE
feat: NFC tag provisioning from the web UI (#170)

### DIFF
--- a/firmware/bodn/nfc.py
+++ b/firmware/bodn/nfc.py
@@ -381,6 +381,98 @@ def is_scan_suspended():
 
 
 # ---------------------------------------------------------------------------
+# Shared provisioning state
+# ---------------------------------------------------------------------------
+#
+# The reader is a single shared resource between the on-device provisioning
+# screen (ui/nfc_provision.py) and the web UI (web.py → /api/nfc/provision/*).
+# Both need to suspend background scanning and drive a blocking PN532 write;
+# if they race, one overwrites the other and the user sees silent failures.
+#
+# ``provision_acquire`` gates access on a single owner string ("device" or
+# "web").  Whichever UI opens second sees ``state="busy"`` from
+# ``provision_state`` and should refuse to start its own write.
+
+_provision = {
+    "state": "idle",  # idle | armed | writing | ok | fail
+    "owner": None,  # "device" | "web" | None
+    "mode": None,
+    "card_id": None,
+    "error": None,
+}
+
+
+def provision_state():
+    """Return a snapshot of the current provisioning state."""
+    return {
+        "state": _provision["state"],
+        "owner": _provision["owner"],
+        "mode": _provision["mode"],
+        "card_id": _provision["card_id"],
+        "error": _provision["error"],
+    }
+
+
+def provision_acquire(owner, mode=None, card_id=None):
+    """Take ownership of the reader for provisioning.
+
+    The same owner re-acquiring rearms with a new (mode, card_id) target.
+    A different owner attempting to acquire while someone else holds the
+    reader is rejected.  Also suspends background scanning so the write
+    doesn't race with the cooperative scan on the shared I2C bus.
+
+    Returns True on success, False if another owner already holds it.
+    """
+    cur = _provision["owner"]
+    if cur is not None and cur != owner:
+        return False
+    _provision["state"] = "armed" if mode is not None else "idle"
+    _provision["owner"] = owner
+    _provision["mode"] = mode
+    _provision["card_id"] = card_id
+    _provision["error"] = None
+    suspend_scan(True)
+    return True
+
+
+def provision_release(owner=None):
+    """Release ownership of the reader.
+
+    If ``owner`` is given, only release when it matches the current owner
+    (prevents the device screen from clobbering a web-side write that's
+    still in flight, and vice versa).  Passing ``None`` unconditionally
+    resets the state — used for module reinit in tests.
+    """
+    if (
+        owner is not None
+        and _provision["owner"] is not None
+        and _provision["owner"] != owner
+    ):
+        return False
+    _provision["state"] = "idle"
+    _provision["owner"] = None
+    _provision["mode"] = None
+    _provision["card_id"] = None
+    _provision["error"] = None
+    suspend_scan(False)
+    return True
+
+
+def provision_mark(owner, state, error=None):
+    """Update the state field within the current ownership.
+
+    No-op when the caller isn't the current owner — prevents a stale
+    handler from overwriting state after the UI that acquired the lock
+    has already released it.
+    """
+    if _provision["owner"] != owner:
+        return False
+    _provision["state"] = state
+    _provision["error"] = error
+    return True
+
+
+# ---------------------------------------------------------------------------
 # NFC reader (PN532 hardware driver)
 # ---------------------------------------------------------------------------
 

--- a/firmware/bodn/ui/nfc_provision.py
+++ b/firmware/bodn/ui/nfc_provision.py
@@ -75,17 +75,19 @@ class NFCProvisionScreen(Screen):
         self._state = "menu"
         self._title_sprite = make_label_sprite(t("settings_nfc"), 0xFFFF, scale=2)
         self._load_sets()
-        # Exclusive NFC access: otherwise the background scanner reads the
-        # tag first and launches its target mode, stealing the card before
-        # the user can write a new payload to it.
-        from bodn.nfc import suspend_scan
+        # Take the provisioning lock as owner="device".  Also suspends the
+        # background scanner (otherwise it reads the tag first and launches
+        # its target mode, stealing the card before the user can write a
+        # new payload to it) and makes the web UI's NFC panel show "busy"
+        # while this screen is open.
+        from bodn.nfc import provision_acquire
 
-        suspend_scan(True)
+        provision_acquire("device")
 
     def exit(self):
-        from bodn.nfc import suspend_scan
+        from bodn.nfc import provision_release
 
-        suspend_scan(False)
+        provision_release("device")
 
     def _load_sets(self):
         try:
@@ -188,6 +190,13 @@ class NFCProvisionScreen(Screen):
                     if self._card_idx < len(self._cards) - 1:
                         self._card_idx += 1
                 self._write_state = _IDLE
+                # Reflect back to the shared state so the web UI stops
+                # showing a stale "writing" badge after the device result
+                # finishes displaying.  Ownership stays on "device" —
+                # only the transient state resets.
+                from bodn.nfc import provision_mark
+
+                provision_mark("device", "idle")
                 self._dirty = True
                 self._full_clear = True
             return
@@ -225,7 +234,13 @@ class NFCProvisionScreen(Screen):
 
         # Background scan is already suspended for the whole screen
         # lifetime (enter/exit), so the I2C bus is exclusive here.
-        from bodn.nfc import encode_tag_data
+        from bodn.nfc import encode_tag_data, provision_acquire, provision_mark
+
+        # Refresh the (mode, card_id) target on the shared provisioning
+        # state so the web UI's /status endpoint can show what the device
+        # is writing to while busy.
+        provision_acquire("device", mode=mode, card_id=card_id)
+        provision_mark("device", "writing")
 
         try:
             data = encode_tag_data(mode, card_id)
@@ -233,12 +248,15 @@ class NFCProvisionScreen(Screen):
             if ok:
                 self._write_state = _OK
                 self._written_count += 1
+                provision_mark("device", "ok")
             else:
                 print("NFC: write returned False for", card_id)
                 self._write_state = _FAIL
+                provision_mark("device", "fail", "write returned False")
         except Exception as e:
             print("NFC: write error:", e)
             self._write_state = _FAIL
+            provision_mark("device", "fail", str(e))
 
         self._write_ms = time.ticks_ms()
         self._dirty = True

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -386,6 +386,99 @@ async def _handle_upload(reader, writer, headers, settings=None):
         await _send_json(writer, {"error": str(e)}, 500)
 
 
+async def _handle_provision_start(writer, body):
+    """Arm the NFC reader to write the next presented tag.
+
+    Body: ``{"mode": <card-set-name>, "card_id": <id-or-null>}``.  When
+    ``card_id`` is omitted the tag is written as a launcher-style mode
+    card (no card id).  Returns 409 if the on-device screen or another
+    web session already holds the reader, or 503 if the PN532 isn't
+    detected.  On success the handler spawns a background task to drive
+    the write and returns ``{"ok": true}`` immediately — the client
+    polls ``GET /api/nfc/provision/status`` for the outcome.
+    """
+    from bodn.nfc import (
+        NFCReader,
+        encode_tag_data,
+        load_card_set,
+        lookup_card,
+        provision_acquire,
+        provision_state,
+    )
+
+    mode = body.get("mode")
+    card_id = body.get("card_id")  # may be None for launcher-style mode cards
+    if not mode:
+        await _send_json(writer, {"error": "mode required"}, 400)
+        return
+
+    # Validate the target card exists in its set.  A typo here would
+    # otherwise write a dead URL onto the tag with no visible failure.
+    cs = load_card_set(mode)
+    if cs is None:
+        await _send_json(writer, {"error": "unknown mode: " + str(mode)}, 404)
+        return
+    if card_id is not None and lookup_card(mode, card_id) is None:
+        await _send_json(writer, {"error": "unknown card: " + str(card_id)}, 404)
+        return
+
+    reader = NFCReader()
+    if not reader.available():
+        await _send_json(writer, {"error": "NFC reader not available"}, 503)
+        return
+
+    cur = provision_state()
+    if cur["owner"] is not None and cur["owner"] != "web":
+        await _send_json(
+            writer,
+            {"error": "reader busy", "owner": cur["owner"], "state": cur["state"]},
+            409,
+        )
+        return
+
+    if not provision_acquire("web", mode=mode, card_id=card_id):
+        await _send_json(writer, {"error": "reader busy"}, 409)
+        return
+
+    data = encode_tag_data(mode, card_id)
+    try:
+        asyncio.create_task(_run_web_provision_write(reader, data))
+    except (AttributeError, RuntimeError):
+        # No running event loop (host tests).  Run synchronously so the
+        # state still transitions for callers that poll /status.
+        await _run_web_provision_write(reader, data)
+
+    await _send_json(writer, {"ok": True, "mode": mode, "card_id": card_id})
+
+
+async def _run_web_provision_write(reader, data):
+    """Background task that performs a single tag write for the web UI.
+
+    Keeps the HTTP handler responsive: /start returns immediately and
+    the client polls /status for the final state.  Any exception is
+    captured and surfaced through ``provision_mark`` rather than
+    propagating to the asyncio loop.
+    """
+    from bodn.nfc import provision_mark, provision_state
+
+    provision_mark("web", "writing")
+    try:
+        ok = reader.write(data)
+    except Exception as e:
+        provision_mark("web", "fail", str(e))
+        return
+
+    # The client may have cancelled while the write was in flight; in
+    # that case provision_mark is a no-op because ownership is already
+    # cleared, which is exactly what we want.
+    if provision_state()["owner"] != "web":
+        return
+    if ok:
+        provision_mark("web", "ok")
+    else:
+        provision_mark("web", "fail", "write returned False")
+
+
 async def _handle_request(reader, writer, request_line, session_mgr, settings):
     """Parse HTTP request and route to handler.
 
@@ -736,8 +829,49 @@ async def _handle_request(reader, writer, request_line, session_mgr, settings):
             except Exception as e:
                 await _send_json(writer, {"error": str(e)}, 500)
 
-        # NFC provisioning endpoints (POST /api/nfc/provision/*) will be
-        # added when the PN532 hardware reader is available (issue #121).
+        # --- NFC provisioning endpoints ---
+        #
+        # Shared with the on-device provisioning screen via
+        # bodn.nfc.provision_* — the first UI to call provision_acquire
+        # holds the reader until it releases, so the two can't race on
+        # the PN532's I2C bus.
+
+        elif method == "GET" and path == "/api/nfc/provision/status":
+            try:
+                from bodn.nfc import provision_state, NFCReader
+
+                snap = provision_state()
+                snap["reader_available"] = NFCReader().available()
+                await _send_json(writer, snap)
+            except Exception as e:
+                await _send_json(writer, {"error": str(e)}, 500)
+
+        elif method == "POST" and path == "/api/nfc/provision/start":
+            try:
+                await _handle_provision_start(writer, body or {})
+            except Exception as e:
+                await _send_json(writer, {"error": str(e)}, 500)
+
+        elif method == "POST" and path == "/api/nfc/provision/cancel":
+            try:
+                from bodn.nfc import provision_release, provision_state
+
+                cur = provision_state()
+                # Only the web side can cancel via this endpoint — the
+                # device screen manages its own lifecycle and a rogue
+                # web client shouldn't be able to boot the parent out
+                # of an open provisioning screen.
+                if cur["owner"] == "web":
+                    provision_release("web")
+                    await _send_json(writer, {"ok": True})
+                else:
+                    await _send_json(
+                        writer,
+                        {"ok": False, "reason": "not owned by web"},
+                        409,
+                    )
+            except Exception as e:
+                await _send_json(writer, {"error": str(e)}, 500)
 
         else:
             await _send(writer, 404, "text/plain", "Not found")

--- a/firmware/bodn/web_ui.py
+++ b/firmware/bodn/web_ui.py
@@ -195,7 +195,13 @@ th{color:#aaa}
 <h3 style="color:#e94560;font-size:0.95em;margin-bottom:8px">Card Sets</h3>
 <div id="nfc-sets"><p style="font-size:0.8em;color:#666">Loading...</p></div>
 <h3 style="margin-top:16px;color:#e94560;font-size:0.95em;margin-bottom:8px">Provisioning</h3>
-<p style="font-size:0.8em;color:#666">Tag provisioning requires NFC reader hardware. See <a href="https://github.com/mandakan/bodn-esp32/issues/121" style="color:#e94560">#121</a>.</p>
+<div id="nfc-prov">
+<div class="field"><label>Card set</label><select class="input-field" id="prov-mode" onchange="provPopulateCards()"></select></div>
+<div class="field"><label>Card</label><select class="input-field" id="prov-card"></select><p style="font-size:0.75em;color:#666;margin-top:4px">Choose &quot;&mdash; launcher &mdash;&quot; to write a mode-launcher tag with no card id.</p></div>
+<button class="btn btn-primary" id="prov-write-btn" onclick="provStart()">Write next tag</button>
+<button class="btn" id="prov-cancel-btn" onclick="provCancel()" style="display:none;background:#555;color:#fff;margin-top:8px">Cancel</button>
+<div id="prov-status" style="text-align:center;padding:10px;margin-top:10px;border-radius:6px;background:#16213e;font-size:0.85em;color:#aaa">Loading status&hellip;</div>
+</div>
 <h3 style="margin-top:16px;color:#e94560;font-size:0.95em;margin-bottom:8px">UID Cache</h3>
 <div id="nfc-cache"><p style="font-size:0.8em;color:#666">Loading...</p></div>
 </div>
@@ -516,12 +522,15 @@ html+='</tbody></table>';
 el.innerHTML=html;
 }catch(e){el.innerHTML='<p style="font-size:0.8em;color:#e94560">Failed to load boot log.</p>';}
 }
+var provSets={};
+var provPollTimer=null;
 async function loadNFC(){
 try{
 var r=await fetch('/api/nfc/sets');var sets=await r.json();
 var el=document.getElementById('nfc-sets');
-if(sets.error){el.innerHTML='<p style="color:#e94560">'+sets.error+'</p>';return;}
-if(!sets.length){el.innerHTML='<p style="color:#aaa;font-size:0.8em">No card sets found on SD card.</p>';return;}
+if(sets.error){el.innerHTML='<p style="color:#e94560">'+sets.error+'</p>';}
+else if(!sets.length){el.innerHTML='<p style="color:#aaa;font-size:0.8em">No card sets found on SD card.</p>';}
+else{
 var html='';
 sets.forEach(function(s){
 html+='<div style="background:#16213e;border-radius:8px;padding:10px;margin:6px 0">';
@@ -530,17 +539,84 @@ html+=' <span style="color:#aaa;font-size:0.8em">v'+s.version+' &middot; '+s.car
 html+='</div>';
 });
 el.innerHTML=html;
+}
+await provLoadSets(sets);
 }catch(e){document.getElementById('nfc-sets').innerHTML='<p style="color:#e94560;font-size:0.8em">Error loading card sets.</p>';}
 try{
 var cr=await fetch('/api/nfc/cache');var cache=await cr.json();
 var ce=document.getElementById('nfc-cache');
 var keys=Object.keys(cache);
-if(!keys.length){ce.innerHTML='<p style="color:#aaa;font-size:0.8em">Empty (no tags scanned yet).</p>';return;}
+if(!keys.length){ce.innerHTML='<p style="color:#aaa;font-size:0.8em">Empty (no tags scanned yet).</p>';}
+else{
 var html='<table style="width:100%;border-collapse:collapse;font-size:0.8em"><thead><tr><th style="text-align:left;padding:4px;color:#aaa">UID</th><th style="text-align:left;padding:4px;color:#aaa">Mode</th><th style="text-align:left;padding:4px;color:#aaa">Card</th></tr></thead><tbody>';
 keys.forEach(function(uid){html+='<tr><td style="font-family:monospace;padding:4px">'+uid+'</td><td style="padding:4px">'+cache[uid].mode+'</td><td style="padding:4px">'+cache[uid].id+'</td></tr>';});
 html+='</tbody></table>';
 ce.innerHTML=html;
+}
 }catch(e){}
+provStartPolling();
+}
+async function provLoadSets(sets){
+var sel=document.getElementById('prov-mode');
+if(!sel)return;
+if(!sets||!sets.length){sel.innerHTML='<option value="">(no card sets found)</option>';document.getElementById('prov-card').innerHTML='';return;}
+if(sel.options.length===sets.length&&sel.value)return;
+sel.innerHTML='';
+sets.forEach(function(s){var o=document.createElement('option');o.value=s.mode;o.textContent=s.mode+' ('+s.card_count+')';sel.appendChild(o);});
+await provPopulateCards();
+}
+async function provPopulateCards(){
+var mode=document.getElementById('prov-mode').value;
+var cardSel=document.getElementById('prov-card');
+if(!mode){cardSel.innerHTML='';return;}
+if(!provSets[mode]){
+try{var r=await fetch('/api/nfc/set/'+encodeURIComponent(mode));provSets[mode]=await r.json();}
+catch(e){cardSel.innerHTML='<option value="">(error loading set)</option>';return;}
+}
+var cs=provSets[mode];
+cardSel.innerHTML='';
+var launch=document.createElement('option');launch.value='';launch.textContent='— launcher —';cardSel.appendChild(launch);
+(cs.cards||[]).forEach(function(c){var o=document.createElement('option');o.value=c.id;var lbl=c.label_sv||c.label_en||c.id;o.textContent=c.id+' ('+lbl+')';cardSel.appendChild(o);});
+}
+function provRender(s){
+var el=document.getElementById('prov-status');
+var btn=document.getElementById('prov-write-btn');
+var cancel=document.getElementById('prov-cancel-btn');
+if(!el)return;
+var msg='',colour='#16213e',txt='#aaa';
+if(s.reader_available===false){msg='NFC reader not detected.';colour='#16213e';txt='#e94560';btn.disabled=true;}
+else if(s.owner==='device'){msg='Device screen is using the reader. Close it on the device to write from here.';colour='#16213e';txt='#f39c12';btn.disabled=true;}
+else if(s.state==='armed'||s.state==='writing'){msg=(s.state==='armed'?'Hold a tag on the reader…':'Writing…')+' ('+s.mode+(s.card_id?'/'+s.card_id:'')+')';colour='#0f3460';txt='#e94560';btn.disabled=true;}
+else if(s.state==='ok'){msg='Tag written: '+s.mode+(s.card_id?'/'+s.card_id:'')+'.';colour='#1a3a1a';txt='#27ae60';btn.disabled=false;}
+else if(s.state==='fail'){msg='Write failed'+(s.error?': '+s.error:'')+'.';colour='#3a1a1a';txt='#e94560';btn.disabled=false;}
+else{msg='Ready.';colour='#16213e';txt='#aaa';btn.disabled=false;}
+el.style.background=colour;el.style.color=txt;el.textContent=msg;
+cancel.style.display=(s.owner==='web'&&(s.state==='armed'||s.state==='writing'))?'block':'none';
+}
+async function provPoll(){
+try{var r=await fetch('/api/nfc/provision/status');var s=await r.json();provRender(s);}
+catch(e){/* drop a single poll */}
+}
+function provStartPolling(){
+if(provPollTimer)return;
+provPoll();
+provPollTimer=setInterval(provPoll,1000);
+}
+async function provStart(){
+var mode=document.getElementById('prov-mode').value;
+var card=document.getElementById('prov-card').value;
+if(!mode)return;
+var body={mode:mode};
+if(card)body.card_id=card;
+try{
+var r=await fetch('/api/nfc/provision/start',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+if(!r.ok){var err=await r.json().catch(function(){return{error:'HTTP '+r.status};});provRender({reader_available:true,state:'fail',error:err.error||('HTTP '+r.status)});return;}
+}catch(e){provRender({reader_available:true,state:'fail',error:String(e)});return;}
+provPoll();
+}
+async function provCancel(){
+try{await fetch('/api/nfc/provision/cancel',{method:'POST'});}catch(e){}
+provPoll();
 }
 var hnEl=document.getElementById('hostname');
 if(hnEl)hnEl.addEventListener('input',function(){document.getElementById('hostname-preview').textContent=this.value.trim()||'bodn'});

--- a/tests/test_nfc_provision_web.py
+++ b/tests/test_nfc_provision_web.py
@@ -1,0 +1,367 @@
+"""Tests for the web UI NFC provisioning endpoints (issue #170).
+
+Covers:
+- GET /api/nfc/provision/status returns the shared provisioning snapshot.
+- POST /api/nfc/provision/start arms the reader and triggers a write.
+- POST /api/nfc/provision/cancel releases web ownership.
+- Concurrency guard: the web side refuses to start while owner=="device".
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from bodn import nfc, web
+
+# ---------------------------------------------------------------------------
+# Test scaffolding (mirrors test_web_wifi.py — kept local to avoid coupling)
+# ---------------------------------------------------------------------------
+
+
+class _FakeReader:
+    def __init__(self, data: bytes):
+        self._buf = data
+
+    async def readline(self):
+        idx = self._buf.find(b"\n")
+        if idx == -1:
+            line, self._buf = self._buf, b""
+            return line
+        line, self._buf = self._buf[: idx + 1], self._buf[idx + 1 :]
+        return line
+
+    async def read(self, n):
+        chunk, self._buf = self._buf[:n], self._buf[n:]
+        return chunk
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.buf = bytearray()
+        self._keep_alive = False
+
+    def write(self, data):
+        self.buf.extend(data)
+
+    async def drain(self):
+        return None
+
+
+class _FakeSession:
+    state = "IDLE"
+    time_remaining_s = 0
+    cooldown_remaining_s = 0
+    sessions_today = 0
+    sessions_remaining = 0
+    mode = None
+
+
+def _request(method, path, body=None):
+    headers = ["Host: test", "Connection: close"]
+    body_bytes = b""
+    if body is not None:
+        body_bytes = json.dumps(body).encode()
+        headers.append("Content-Type: application/json")
+        headers.append("Content-Length: {}".format(len(body_bytes)))
+    request_line = "{} {} HTTP/1.1\r\n".format(method, path).encode()
+    rest = ("\r\n".join(headers) + "\r\n\r\n").encode() + body_bytes
+    return request_line, _FakeReader(rest)
+
+
+def _run(method, path, settings, body=None):
+    request_line, reader = _request(method, path, body=body)
+    writer = _FakeWriter()
+    asyncio.run(
+        web._handle_request(reader, writer, request_line, _FakeSession(), settings)
+    )
+    raw = bytes(writer.buf)
+    head, _, payload = raw.partition(b"\r\n\r\n")
+    status_line = head.split(b"\r\n", 1)[0].decode()
+    try:
+        data = json.loads(payload.decode())
+    except (ValueError, UnicodeDecodeError):
+        data = None
+    return status_line, data
+
+
+@pytest.fixture
+def settings():
+    return {
+        "wifi_mode": "ap",
+        "wifi_ssid": "",
+        "wifi_pass": "",
+        "hostname": "bodn",
+        "ui_pin": "",
+        "ota_token": "",
+    }
+
+
+class _FakePN532:
+    """Minimal PN532 stub with a configurable write result."""
+
+    def __init__(self, write_ok=True, uid=b"\x04\xaa\xbb\xcc"):
+        self.write_ok = write_ok
+        self._uid = uid
+        self.writes = []
+
+    def read_passive_target(self, timeout_ms=500):
+        return self._uid
+
+    def ntag_write(self, page, chunk):
+        self.writes.append((page, bytes(chunk)))
+        return self.write_ok
+
+
+_TEST_CARD_SETS = {
+    "sortera": {
+        "mode": "sortera",
+        "version": 1,
+        "dimensions": ["animal"],
+        "cards": [{"id": "cat_red", "label_sv": "katt", "label_en": "cat"}],
+    }
+}
+
+
+@pytest.fixture
+def reader_available(monkeypatch):
+    """Install a fake PN532 + stub card-set loaders.
+
+    Host tests don't have /nfc/*.json on disk, so we patch the loaders
+    module-wide.  The endpoint re-imports them at call time, so the
+    patch takes effect even though web.py already imported bodn.nfc.
+    """
+    old_pn = nfc._pn532
+    old_shed = nfc._shed
+    pn = _FakePN532(write_ok=True)
+    nfc._pn532 = pn
+    nfc._shed = False
+    monkeypatch.setattr(nfc, "load_card_set", lambda mode: _TEST_CARD_SETS.get(mode))
+
+    def fake_lookup(mode, card_id):
+        cs = _TEST_CARD_SETS.get(mode)
+        if cs is None:
+            return None
+        for c in cs.get("cards", []):
+            if c["id"] == card_id:
+                return c
+        return None
+
+    monkeypatch.setattr(nfc, "lookup_card", fake_lookup)
+    # Ensure provisioning state is clean before each test.
+    nfc.provision_release()
+    try:
+        yield pn
+    finally:
+        nfc._pn532 = old_pn
+        nfc._shed = old_shed
+        nfc.provision_release()
+
+
+# ---------------------------------------------------------------------------
+# Shared state module (bodn.nfc.provision_*)
+# ---------------------------------------------------------------------------
+
+
+class TestProvisionState:
+    def test_initial_state_is_idle(self):
+        nfc.provision_release()
+        snap = nfc.provision_state()
+        assert snap["state"] == "idle"
+        assert snap["owner"] is None
+
+    def test_acquire_sets_owner_and_suspends_scan(self):
+        nfc.provision_release()
+        assert nfc.is_scan_suspended() is False
+        assert nfc.provision_acquire("web", "sortera", "cat_red") is True
+        snap = nfc.provision_state()
+        assert snap["owner"] == "web"
+        assert snap["state"] == "armed"
+        assert snap["mode"] == "sortera"
+        assert snap["card_id"] == "cat_red"
+        assert nfc.is_scan_suspended() is True
+        nfc.provision_release("web")
+        assert nfc.is_scan_suspended() is False
+
+    def test_different_owner_rejected(self):
+        nfc.provision_release()
+        assert nfc.provision_acquire("device") is True
+        # Web must not be able to steal the reader from the device screen.
+        assert nfc.provision_acquire("web", "sortera", "cat_red") is False
+        assert nfc.provision_state()["owner"] == "device"
+        nfc.provision_release("device")
+
+    def test_same_owner_reacquire_rearms(self):
+        nfc.provision_release()
+        assert nfc.provision_acquire("web", "sortera", "cat_red") is True
+        assert nfc.provision_acquire("web", "rakna", "num_3") is True
+        snap = nfc.provision_state()
+        assert snap["mode"] == "rakna"
+        assert snap["card_id"] == "num_3"
+        nfc.provision_release("web")
+
+    def test_release_with_wrong_owner_is_noop(self):
+        nfc.provision_release()
+        nfc.provision_acquire("device")
+        assert nfc.provision_release("web") is False
+        assert nfc.provision_state()["owner"] == "device"
+        nfc.provision_release("device")
+
+    def test_mark_only_updates_for_current_owner(self):
+        nfc.provision_release()
+        nfc.provision_acquire("web", "sortera", "cat_red")
+        assert nfc.provision_mark("web", "writing") is True
+        assert nfc.provision_state()["state"] == "writing"
+        # A stale handler with the wrong owner must not clobber state.
+        assert nfc.provision_mark("device", "ok") is False
+        assert nfc.provision_state()["state"] == "writing"
+        nfc.provision_release("web")
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestProvisionEndpoints:
+    def test_status_reports_reader_available_and_idle(self, settings, reader_available):
+        status, data = _run("GET", "/api/nfc/provision/status", settings)
+        assert "200" in status
+        assert data["state"] == "idle"
+        assert data["owner"] is None
+        assert data["reader_available"] is True
+
+    def test_status_reports_reader_unavailable(self, settings):
+        old_pn = nfc._pn532
+        nfc._pn532 = None
+        try:
+            status, data = _run("GET", "/api/nfc/provision/status", settings)
+            assert "200" in status
+            assert data["reader_available"] is False
+        finally:
+            nfc._pn532 = old_pn
+
+    def test_start_without_reader_returns_503(self, settings, monkeypatch):
+        old_pn = nfc._pn532
+        nfc._pn532 = None
+        monkeypatch.setattr(
+            nfc, "load_card_set", lambda mode: _TEST_CARD_SETS.get(mode)
+        )
+        monkeypatch.setattr(
+            nfc,
+            "lookup_card",
+            lambda mode, cid: next(
+                (
+                    c
+                    for c in _TEST_CARD_SETS.get(mode, {}).get("cards", [])
+                    if c["id"] == cid
+                ),
+                None,
+            ),
+        )
+        nfc.provision_release()
+        try:
+            status, data = _run(
+                "POST",
+                "/api/nfc/provision/start",
+                settings,
+                {"mode": "sortera", "card_id": "cat_red"},
+            )
+            assert "503" in status
+            assert "error" in data
+        finally:
+            nfc._pn532 = old_pn
+
+    def test_start_requires_mode(self, settings, reader_available):
+        status, data = _run("POST", "/api/nfc/provision/start", settings, {})
+        assert "400" in status
+        assert "error" in data
+
+    def test_start_rejects_unknown_mode(self, settings, reader_available):
+        status, data = _run(
+            "POST",
+            "/api/nfc/provision/start",
+            settings,
+            {"mode": "not-a-real-mode"},
+        )
+        assert "404" in status
+
+    def test_start_rejects_unknown_card_id(self, settings, reader_available):
+        status, data = _run(
+            "POST",
+            "/api/nfc/provision/start",
+            settings,
+            {"mode": "sortera", "card_id": "definitely-not-a-card"},
+        )
+        assert "404" in status
+
+    def test_start_writes_and_transitions_to_ok(self, settings, reader_available):
+        status, data = _run(
+            "POST",
+            "/api/nfc/provision/start",
+            settings,
+            {"mode": "sortera", "card_id": "cat_red"},
+        )
+        assert "200" in status
+        assert data["ok"] is True
+        # The host-test fallback in _handle_provision_start runs the write
+        # synchronously when no running event loop is available, so by
+        # the time we poll /status the state has already transitioned.
+        _, snap = _run("GET", "/api/nfc/provision/status", settings)
+        assert snap["state"] == "ok"
+        assert snap["owner"] == "web"
+        assert reader_available.writes  # at least one page written
+
+    def test_start_surfaces_write_failure(self, settings, reader_available):
+        reader_available.write_ok = False
+        _run(
+            "POST",
+            "/api/nfc/provision/start",
+            settings,
+            {"mode": "sortera", "card_id": "cat_red"},
+        )
+        _, snap = _run("GET", "/api/nfc/provision/status", settings)
+        assert snap["state"] == "fail"
+        assert snap["error"]
+
+    def test_start_is_refused_when_device_holds_reader(
+        self, settings, reader_available
+    ):
+        nfc.provision_acquire("device")
+        try:
+            status, data = _run(
+                "POST",
+                "/api/nfc/provision/start",
+                settings,
+                {"mode": "sortera", "card_id": "cat_red"},
+            )
+            assert "409" in status
+            assert data["owner"] == "device"
+        finally:
+            nfc.provision_release("device")
+
+    def test_status_shows_device_owner_when_device_holds(
+        self, settings, reader_available
+    ):
+        nfc.provision_acquire("device")
+        try:
+            _, snap = _run("GET", "/api/nfc/provision/status", settings)
+            assert snap["owner"] == "device"
+        finally:
+            nfc.provision_release("device")
+
+    def test_cancel_releases_web_ownership(self, settings, reader_available):
+        nfc.provision_acquire("web", "sortera", "cat_red")
+        status, data = _run("POST", "/api/nfc/provision/cancel", settings)
+        assert "200" in status
+        assert data["ok"] is True
+        assert nfc.provision_state()["owner"] is None
+
+    def test_cancel_refuses_to_clear_device_ownership(self, settings, reader_available):
+        nfc.provision_acquire("device")
+        try:
+            status, _ = _run("POST", "/api/nfc/provision/cancel", settings)
+            assert "409" in status
+            assert nfc.provision_state()["owner"] == "device"
+        finally:
+            nfc.provision_release("device")


### PR DESCRIPTION
The web UI NFC tab showed a stale placeholder pointing at #121 — which
has long since closed and shipped working PN532 hardware. This wires the
web panel up to the same write path the on-device provisioning screen
already uses.

- Shared provisioning state in bodn/nfc.py (provision_acquire/release/
  mark) gates the reader between the device screen and the web UI so
  only one drives the PN532 at a time. The loser of the race sees
  "busy" instead of silently stealing writes.
- Three new endpoints — GET /api/nfc/provision/status, POST /start,
  POST /cancel. /start validates (mode, card_id) against the loaded
  card set, acquires ownership, and spawns the write as a background
  task so the HTTP handler stays responsive.
- Web UI panel replaces the placeholder with card-set + card pickers,
  a Write-next-tag button, and a status readout polled every second.
- ui/nfc_provision.py now acquires owner="device" on enter and
  releases on exit; it also reflects write progress through
  provision_mark so the web UI's busy indicator tracks the device
  screen live.

Tests: 18 new tests cover the shared state machine and the three HTTP
endpoints, including the device-vs-web concurrency guard.