### PR TITLE
fix: sequencer live-input snap uses press timestamp + fractional clock

### DIFF
--- a/cmodules/audiomix/audiomix.c
+++ b/cmodules/audiomix/audiomix.c
@@ -478,6 +478,43 @@ static mp_obj_t audiomix_clock_get_step(void) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(audiomix_clock_get_step_obj, audiomix_clock_get_step);
 
+// _audiomix.clock_get_pos() -> (step, sample_count, samples_per_step)
+//
+// Snapshot of the clock's fractional position.  Python computes
+// frac_step = step + sample_count / samples_per_step for accurate
+// quantization of live-played notes.  Double-reads current_step to
+// avoid returning an inconsistent (step, sample_count) pair when the
+// mixer task wraps sample_count on core 0 between our two reads.
+static mp_obj_t audiomix_clock_get_pos(void) {
+    if (audiomix_state == NULL) {
+        mp_obj_t zeros[3] = {
+            mp_obj_new_int(0), mp_obj_new_int(0), mp_obj_new_int(0),
+        };
+        return mp_obj_new_tuple(3, zeros);
+    }
+    seq_clock_t *clk = &audiomix_state->clock;
+    uint8_t step_a, step_b;
+    uint32_t sc, sps;
+    // Retry once if core 0 wrapped mid-read.  At audio rate the wrap
+    // window is a few instructions wide, so one retry is enough.
+    do {
+        step_a = clk->current_step;
+        sc = clk->sample_count;
+        sps = clk->samples_per_step;
+        step_b = clk->current_step;
+    } while (step_a != step_b);
+    // Clamp sample_count in case sps == 0 or sc briefly exceeds sps.
+    if (sps == 0) sc = 0;
+    else if (sc >= sps) sc = sps - 1;
+    mp_obj_t tup[3] = {
+        mp_obj_new_int(step_a),
+        mp_obj_new_int(sc),
+        mp_obj_new_int(sps),
+    };
+    return mp_obj_new_tuple(3, tup);
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(audiomix_clock_get_pos_obj, audiomix_clock_get_pos);
+
 // _audiomix.clock_set_perc(step, perc_mask)
 // perc_mask: bits 0-4 = tracks 0-4
 static mp_obj_t audiomix_clock_set_perc(mp_obj_t step_obj, mp_obj_t mask_obj) {
@@ -943,6 +980,7 @@ static const mp_rom_map_elem_t audiomix_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_clock_set_bpm),      MP_ROM_PTR(&audiomix_clock_set_bpm_obj) },
     { MP_ROM_QSTR(MP_QSTR_clock_set_steps),    MP_ROM_PTR(&audiomix_clock_set_steps_obj) },
     { MP_ROM_QSTR(MP_QSTR_clock_get_step),     MP_ROM_PTR(&audiomix_clock_get_step_obj) },
+    { MP_ROM_QSTR(MP_QSTR_clock_get_pos),      MP_ROM_PTR(&audiomix_clock_get_pos_obj) },
     { MP_ROM_QSTR(MP_QSTR_clock_set_perc),     MP_ROM_PTR(&audiomix_clock_set_perc_obj) },
     { MP_ROM_QSTR(MP_QSTR_clock_set_melody),   MP_ROM_PTR(&audiomix_clock_set_melody_obj) },
     { MP_ROM_QSTR(MP_QSTR_clock_set_perc_buffer), MP_ROM_PTR(&audiomix_clock_set_perc_buffer_obj) },

--- a/firmware/bodn/ui/input.py
+++ b/firmware/bodn/ui/input.py
@@ -160,12 +160,20 @@ class InputState:
         self.enc_btn_held = [False] * n_enc
         self.enc_btn_pressed = [False] * n_enc
         self.enc_btn_just_released = [False] * n_enc
+        # Press timestamps (ms) captured by the native scanner.  Only
+        # meaningful when the corresponding *_just_pressed flag is True;
+        # otherwise the value is stale.  Used by time-sensitive modes
+        # (e.g. Sequencer) to quantize live input against the audio clock.
+        self.btn_press_ts = [0] * n_btn
+        self.arc_press_ts = [0] * n_arc
 
         # Pending edge-latched state (accumulated by scan, consumed by consume)
         self._pend_btn_press = [False] * n_btn
         self._pend_btn_release = [False] * n_btn
         self._pend_arc_press = [False] * n_arc
         self._pend_arc_release = [False] * n_arc
+        self._pend_btn_press_ts = [0] * n_btn
+        self._pend_arc_press_ts = [0] * n_arc
         self._pend_enc_btn_press = [False] * n_enc
         self._pend_enc_btn_release = [False] * n_enc
         self._pend_enc_delta = [0] * n_enc
@@ -203,6 +211,7 @@ class InputState:
         prev_btn = self._prev_btn
         pend_bp = self._pend_btn_press
         pend_br = self._pend_btn_release
+        pend_bp_ts = self._pend_btn_press_ts
         on_press = self._on_press
 
         # Buttons
@@ -212,6 +221,7 @@ class InputState:
             btn_held[i] = cur
             if cur and not prev:
                 pend_bp[i] = True
+                pend_bp_ts[i] = now
                 if on_press:
                     on_press("btn", i)
             if not cur and prev:
@@ -230,6 +240,7 @@ class InputState:
         prev_arc = self._prev_arc
         pend_ap = self._pend_arc_press
         pend_ar = self._pend_arc_release
+        pend_ap_ts = self._pend_arc_press_ts
 
         for i, pin in enumerate(arc_pins):
             prev = prev_arc[i]
@@ -237,6 +248,7 @@ class InputState:
             arc_held[i] = cur
             if cur and not prev:
                 pend_ap[i] = True
+                pend_ap_ts[i] = now
                 if on_press:
                     on_press("arc", i)
             if not cur and prev:
@@ -280,17 +292,28 @@ class InputState:
                 pend_er[i] = True
             prev_enc_btn[i] = cur_btn
 
-    def native_press(self, kind, index):
-        """Latch a press edge from native C module events."""
+    def native_press(self, kind, index, ts_ms=None):
+        """Latch a press edge from native C module events.
+
+        ``ts_ms`` is the scanner's capture timestamp (ms since boot).
+        When omitted, falls back to ``self._time_ms()`` — callers that
+        have a real timestamp (e.g. from ``_mcpinput.get_events()``)
+        should pass it so that time-sensitive modes can compensate for
+        the frame-sync delay.
+        """
+        if ts_ms is None:
+            ts_ms = self._time_ms()
         on_press = self._on_press
         if kind == "btn" and index < len(self.btn_held):
             self.btn_held[index] = True
             self._pend_btn_press[index] = True
+            self._pend_btn_press_ts[index] = ts_ms
             if on_press:
                 on_press("btn", index)
         elif kind == "arc" and index < len(self.arc_held):
             self.arc_held[index] = True
             self._pend_arc_press[index] = True
+            self._pend_arc_press_ts[index] = ts_ms
             if on_press:
                 on_press("arc", index)
 
@@ -372,22 +395,30 @@ class InputState:
         # Buttons: copy latched edges, clear pending
         pend_bp = self._pend_btn_press
         pend_br = self._pend_btn_release
+        pend_bp_ts = self._pend_btn_press_ts
         bjp = self.btn_just_pressed
         bjr = self.btn_just_released
+        bp_ts = self.btn_press_ts
         for i in range(n_btn):
             bjp[i] = pend_bp[i]
             bjr[i] = pend_br[i]
+            if pend_bp[i]:
+                bp_ts[i] = pend_bp_ts[i]
             pend_bp[i] = False
             pend_br[i] = False
 
         # Arcade buttons
         pend_ap = self._pend_arc_press
         pend_ar = self._pend_arc_release
+        pend_ap_ts = self._pend_arc_press_ts
         ajp = self.arc_just_pressed
         ajr = self.arc_just_released
+        ap_ts = self.arc_press_ts
         for i in range(n_arc):
             ajp[i] = pend_ap[i]
             ajr[i] = pend_ar[i]
+            if pend_ap[i]:
+                ap_ts[i] = pend_ap_ts[i]
             pend_ap[i] = False
             pend_ar[i] = False
 

--- a/firmware/bodn/ui/sequencer.py
+++ b/firmware/bodn/ui/sequencer.py
@@ -38,6 +38,13 @@ _METRO_VOICE = const(7)
 _METRO_HI = const(1200)  # downbeat accent
 _METRO_LO = const(800)  # other beats
 
+# Record offset compensation (ms) — subtracted from a press timestamp
+# before quantizing, so the snap target matches what the user HEARD when
+# they pressed (the mixer's I2S buffer queue delays audio by ~15-25 ms).
+# Same concept as Ableton's "Recording Input Latency" / MPC's "Rec Offset".
+# Tune by ear; 20 ms is the default for this I2S setup.
+_REC_OFFSET_MS = const(20)
+
 # Drum sample names on SD — index matches arcade button hardware index
 _DRUM_NAMES = ["hihat", "snare", "kick", "tom", "crash"]
 
@@ -288,12 +295,25 @@ class SequencerScreen(Screen):
             self._flash_msg = t("seq_cleared")
             self._flash_end = now + 1000
 
+        # --- Advance playhead (C clock drives timing) ---
+        # Done BEFORE input handling so eng._frac reflects the current
+        # fractional position when we quantize live presses.
+        if eng.state == PLAYING:
+            c_step, sc, sps = _audiomix.clock_get_pos()
+            eng.step = c_step
+            if sps > 0:
+                eng._frac = c_step + sc / sps
+            else:
+                eng._frac = float(c_step)
+            eng.step_advanced = c_step != self._prev_step
+
         # --- Arcade buttons: percussion ---
         any_toggled_on = False
         perc_changed = False
         for i in range(NUM_PERC_TRACKS):
             if i < len(inp.arc_just_pressed) and inp.arc_just_pressed[i]:
-                step, val = eng.toggle_perc(i)
+                snap = self._snap_step(inp.arc_press_ts[i], now)
+                step, val = eng.toggle_perc(i, step=snap)
                 perc_changed = True
                 self._sync_step_to_clock(step)
                 if val:
@@ -306,7 +326,8 @@ class SequencerScreen(Screen):
         # --- Mini buttons: melody ---
         for i in range(8):
             if i < len(inp.btn_just_pressed) and inp.btn_just_pressed[i]:
-                step, val = eng.set_melody(i)
+                snap = self._snap_step(inp.btn_press_ts[i], now)
+                step, val = eng.set_melody(i, step=snap)
                 self._sync_step_to_clock(step)
                 if val:
                     any_toggled_on = True
@@ -321,13 +342,6 @@ class SequencerScreen(Screen):
             if self._c_leds:
                 self._sync_track_active()
             self._dirty = True
-
-        # --- Advance playhead (C clock drives timing) ---
-        if eng.state == PLAYING:
-            c_step = _audiomix.clock_get_step()
-            eng.step = c_step
-            eng._frac = float(c_step)  # keep nearest_step() in sync
-            eng.step_advanced = c_step != self._prev_step
 
         # Update prev_step in update() so step_advanced is frame-accurate
         self._prev_step = eng.step
@@ -360,6 +374,30 @@ class SequencerScreen(Screen):
         if self._flash_msg and now >= self._flash_end:
             self._flash_msg = None
             self._dirty = True
+
+    # ------------------------------------------------------------------
+    # Live-input quantization
+    # ------------------------------------------------------------------
+
+    def _snap_step(self, press_ts_ms, now_ms):
+        """Quantize a live button press to the nearest grid step.
+
+        Uses the scanner's capture timestamp (``press_ts_ms``) to undo
+        the frame-sync delay, then subtracts ``_REC_OFFSET_MS`` so the
+        snap target matches what the user heard at press time.  When the
+        clock isn't running (setup-before-play), falls back to the
+        engine's own ``nearest_step()``.
+        """
+        eng = self._engine
+        if eng.state != PLAYING or eng._ms_per_step <= 0:
+            return eng.nearest_step()
+        age_ms = time.ticks_diff(now_ms, press_ts_ms) + _REC_OFFSET_MS
+        n = eng.n_steps
+        # Wrap into [0, n); float modulo with positive modulus always
+        # returns a non-negative result, so a press just before step 0
+        # (age > frac) snaps correctly to step n-1.
+        frac_at_press = (eng._frac - age_ms / eng._ms_per_step) % n
+        return int(frac_at_press + 0.5) % n
 
     # ------------------------------------------------------------------
     # C clock grid sync

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -690,12 +690,12 @@ async def input_scan_task(mcp, mcp2, inp, switches=None):
         try:
             # Drain debounced events from C module
             events = _mcpinput.get_events()
-            for ev_type, pin, _t in events:
+            for ev_type, pin, ts in events:
                 mapping = _pin_map.get(pin)
                 if mapping:
                     kind, idx = mapping
                     if ev_type == _mcpinput.PRESS:
-                        inp.native_press(kind, idx)
+                        inp.native_press(kind, idx, ts)
                     else:
                         inp.native_release(kind, idx)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -506,6 +506,11 @@ class _FakeAudiomix:
     def clock_get_step(self):
         return 0
 
+    def clock_get_pos(self):
+        # (step, sample_count, samples_per_step).  Tests that exercise
+        # fractional-step quantization monkey-patch this attribute.
+        return (0, 0, 0)
+
     def clock_clear_grid(self):
         pass
 
@@ -561,6 +566,7 @@ for _attr in (
     "clock_start",
     "clock_stop",
     "clock_get_step",
+    "clock_get_pos",
     "clock_clear_grid",
     "clock_set_perc",
     "clock_set_perc_buffer",
@@ -594,6 +600,7 @@ _mcpinput_stub.led_mode = _mcpinput_noop
 _mcpinput_stub.led_set_whack_pins = _mcpinput_noop
 _mcpinput_stub.led_set_whack_target = _mcpinput_noop
 _mcpinput_stub.led_get_whack_result = lambda: (False, False)
+_mcpinput_stub.led_set_track_active = _mcpinput_noop
 for _name, _val in (
     ("PRESS", 1),
     ("RELEASE", 2),

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -425,3 +425,75 @@ def test_brightness_consistent_across_instances():
             bc.update(d, v)
     values = [bc.value for bc in controls]
     assert len(set(values)) == 1  # all identical
+
+
+# ---------------------------------------------------------------------------
+# Press-timestamp plumbing (for live-jam quantization in Sequencer)
+# ---------------------------------------------------------------------------
+
+
+def _make_arcade_input(n_btn=8, n_arc=5, n_enc=3):
+    buttons = [FakePin() for _ in range(n_btn)]
+    switches = [FakePin() for _ in range(2)]
+    encoders = [FakeEncoder() for _ in range(n_enc)]
+    arcade = [FakePin() for _ in range(n_arc)]
+    t = [0]
+
+    def time_ms():
+        return t[0]
+
+    inp = InputState(buttons, switches, encoders, time_ms, arcade_pins=arcade)
+    return inp, buttons, arcade, t
+
+
+def test_native_press_records_timestamp():
+    inp, _, _, t = _make_arcade_input()
+    t[0] = 1234
+    inp.native_press("arc", 2, 1100)  # scanner captured this press at t=1100
+    inp.consume()
+    assert inp.arc_just_pressed[2]
+    assert inp.arc_press_ts[2] == 1100
+    # Other channels unchanged.
+    assert not inp.arc_just_pressed[0]
+
+
+def test_native_press_defaults_to_now():
+    inp, _, _, t = _make_arcade_input()
+    t[0] = 500
+    inp.native_press("btn", 1)  # no timestamp → fall back to time_ms()
+    inp.consume()
+    assert inp.btn_just_pressed[1]
+    assert inp.btn_press_ts[1] == 500
+
+
+def test_python_scan_captures_press_timestamp():
+    inp, btns, _, t = _make_arcade_input()
+    # First quiet scan so the button starts in the released state.
+    t[0] = 0
+    inp.scan()
+    inp.consume()
+
+    btns[3]._val = 0  # press
+    t[0] = 10
+    inp.scan()
+    t[0] = 50  # settle past debounce (15ms)
+    inp.scan()
+    inp.consume()
+    assert inp.btn_just_pressed[3]
+    assert inp.btn_press_ts[3] == 50  # latched at the scan where edge fired
+
+
+def test_press_ts_stable_while_not_pressed():
+    """arc_press_ts is only refreshed on a new press; otherwise stale value
+    is kept.  Consumers must gate on arc_just_pressed before reading."""
+    inp, _, _, t = _make_arcade_input()
+    t[0] = 100
+    inp.native_press("arc", 0, 100)
+    inp.consume()
+    assert inp.arc_press_ts[0] == 100
+
+    # No new press; consume() again.  arc_just_pressed clears, ts persists.
+    t[0] = 999
+    inp.consume()
+    assert not inp.arc_just_pressed[0]
+    assert inp.arc_press_ts[0] == 100  # stale but harmless

--- a/tests/test_sequencer_snap.py
+++ b/tests/test_sequencer_snap.py
@@ -1,0 +1,93 @@
+"""Tests for Sequencer live-input quantization (_snap_step).
+
+The snap maps a button-press timestamp (captured by the input scanner
+and preserved all the way through consume()) to the nearest grid step.
+It uses the C clock's fractional position (via clock_get_pos) and
+subtracts _REC_OFFSET_MS so the snap target matches what the user
+heard at the moment of pressing.
+"""
+
+from bodn.sequencer_rules import PLAYING, STOPPED
+from bodn.ui.sequencer import SequencerScreen, _REC_OFFSET_MS
+
+
+def _make_screen_playing(bpm=90, n_steps=8, frac=0.0):
+    """Build a SequencerScreen with its engine forced into PLAYING state
+    at a known fractional playhead position, without invoking enter()."""
+    s = SequencerScreen(overlay=None)
+    eng = s._engine
+    eng.set_bpm(bpm)
+    if n_steps != eng.n_steps:
+        eng.set_steps(n_steps)
+    eng.state = PLAYING
+    eng.step = int(frac) % n_steps
+    eng._frac = frac
+    return s
+
+
+def test_snap_falls_back_when_stopped():
+    s = SequencerScreen(overlay=None)
+    assert s._engine.state == STOPPED
+    # Regardless of timestamps, a stopped clock uses nearest_step() = 0.
+    assert s._snap_step(press_ts_ms=0, now_ms=0) == 0
+
+
+def test_snap_same_instant_compensates_audio_latency():
+    """A press whose timestamp equals 'now' still gets the rec-offset
+    pushed back in time, so at frac=0 a late-ish press snaps to the
+    previous step (n_steps - 1)."""
+    s = _make_screen_playing(bpm=90, frac=0.0)
+    ms_per_step = s._engine._ms_per_step  # 333ms at 90bpm
+    assert ms_per_step > _REC_OFFSET_MS  # sanity
+    # press_ts == now → age = _REC_OFFSET_MS (≈20ms).
+    # frac_at_press = 0 - 20/333 = -0.06 → wraps to ~7.94 in an 8-step grid
+    # → rounds to step 0 again (snap does not "jump backwards" for a
+    # press essentially on the downbeat).
+    assert s._snap_step(press_ts_ms=100, now_ms=100) == 0
+
+
+def test_snap_rounds_forward_when_past_midpoint():
+    """A press 60% of the way through step 2 should snap to step 3,
+    not step 2 — this is the behaviour the old floor-snap lacked."""
+    s = _make_screen_playing(bpm=90, frac=2.6)
+    # Fresh press — compensate only the rec offset, which at 90 BPM is
+    # 20/333 ≈ 0.06 step back → 2.54 → rounds to 3.
+    assert s._snap_step(press_ts_ms=100, now_ms=100) == 3
+
+
+def test_snap_uses_old_timestamp_to_undo_frame_delay():
+    """The timestamp comes from the 500Hz scanner, but the UI frame may
+    run ~16ms later.  Using ts_ms recovers the original snap target."""
+    s = _make_screen_playing(bpm=90, frac=3.15)
+    # Assume the scanner saw the press 50ms ago; subtracting 50ms + 20ms
+    # rec offset → 70/333 ≈ 0.21 step back → 2.94 → rounds to step 3.
+    assert s._snap_step(press_ts_ms=30, now_ms=100) == 3
+
+
+def test_snap_wraps_across_loop_boundary():
+    """A press late in step 7 of an 8-step loop, where the playhead has
+    already wrapped to a tiny positive frac in the new bar, must still
+    snap to the logical target (step 0)."""
+    s = _make_screen_playing(bpm=90, n_steps=8, frac=0.1)
+    # frac_at_press = 0.1 - 20/333 ≈ 0.04 → rounds to step 0.  Good.
+    assert s._snap_step(press_ts_ms=100, now_ms=100) == 0
+
+    # Same scenario but with a real delay: 50ms ago, frac=0.1
+    # frac_at_press = 0.1 - 70/333 ≈ -0.11 → wraps to ~7.89 → rounds to 0
+    # (since 7.89 rounds up to 8 → mod 8 = 0).
+    assert s._snap_step(press_ts_ms=50, now_ms=100) == 0
+
+
+def test_snap_wraps_to_last_step_when_press_earlier_in_bar():
+    """A press whose back-compensated position lands unambiguously in
+    the previous bar must resolve to the correct modular step index."""
+    s = _make_screen_playing(bpm=90, n_steps=8, frac=0.1)
+    # 200ms ago → 0.1 - 220/333 ≈ -0.56 → wraps to ~7.44 → rounds to 7.
+    assert s._snap_step(press_ts_ms=0, now_ms=200) == 7
+
+
+def test_snap_still_works_in_16_step_grid():
+    s = _make_screen_playing(bpm=120, n_steps=16, frac=10.7)
+    # 120bpm → ms_per_step = 60000/(120*2) = 250ms
+    # frac_at_press = 10.7 - 20/250 = 10.62 → rounds to 11.
+    assert s._snap_step(press_ts_ms=0, now_ms=0) == 11


### PR DESCRIPTION
The loop sequencer quantized live percussion and melody presses to the
playhead's *integer* step — equivalent to flooring — because the UI
was setting `eng._frac = float(c_step)`.  A tap landing 90% of the way
through step 2 therefore stuck to step 2, not step 3.  Combined with
input latency from the I2S output buffer and frame-sync delay, this is
the "adjacent slot" feel users reported when jamming against the
metronome.

Three changes, layered:

1. Expose true fractional position from the C clock.  New
   `_audiomix.clock_get_pos()` returns `(step, sample_count,
   samples_per_step)` via a double-read of `current_step` to avoid
   stale/wrap-torn snapshots.  The sequencer now computes
   `_frac = step + sample_count/samples_per_step`.
2. Preserve press timestamps end-to-end.  The MCP23017 scanner already
   captured them; main.py now forwards the ms value through
   `inp.native_press(kind, idx, ts_ms)`, which latches it into new
   `btn_press_ts` / `arc_press_ts` public arrays alongside the
   `*_just_pressed` flags.
3. Quantize at press time, not frame time.  A new helper
   `SequencerScreen._snap_step(press_ts, now)` back-computes the
   fractional step at the moment of the press and rounds.  It also
   subtracts `_REC_OFFSET_MS` (20 ms) to compensate for audio output
   latency — the same concept as Ableton's "Recording Input Latency"
   or MPC's "Rec Offset", so the snap target matches what the child
   actually *heard* when they hit the button.

Tests: added `tests/test_sequencer_snap.py` (7 cases covering
forward-rounding, frame-delay recovery, loop-boundary wrap, and
16-step grids) and 4 new cases in `tests/test_input.py` for the
timestamp plumbing.  Extended `conftest.py` with `clock_get_pos` and
`led_set_track_active` stubs.  Full suite: 880 passed, 26 skipped.

https://claude.ai/code/session_019bCZXKmSrgBRDuBbtgJ3Lx