### PR TITLE
docs: sync CLAUDE.md, README, and docs/ with recent changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ bodn-esp32/
 │     ├─ stories/           # story package — scripts discovered at runtime on SD
 │     ├─ story_rules.py     # story graph validation + traversal (pure logic)
 │     ├─ temperature.py     # DS18B20 + SoC temperature monitoring
+│     ├─ tone_explorer_rules.py # Tone Lab / Ljudlabb state model (pure logic)
 │     ├─ tones.py           # procedural tone generation (pure logic)
 │     ├─ tts.py             # TTS playback helper (SD-first voice resolution)
 │     ├─ wav.py             # WAV header parser + streaming reader (pure logic)
@@ -121,6 +122,7 @@ bodn-esp32/
 │        ├─ admin_qr.py     # admin URL screen with QR code
 │        ├─ ambient.py      # AmbientClock (content) + StatusStrip (status)
 │        ├─ android.py      # boot-time Android-style status bar helper
+│        ├─ blippa.py       # Blippa free-play "blip any card" NFC mode
 │        ├─ catface.py      # cat face with emotions (secondary content)
 │        ├─ clock.py        # clock display mode
 │        ├─ demo.py         # LED playground mode
@@ -135,9 +137,11 @@ bodn-esp32/
 │        ├─ icon_browser.py # OpenMoji emoji sprite browser (settings)
 │        ├─ icons.py        # 16×16 bitmap icons (flash fallback)
 │        ├─ input.py        # unified input state with debouncing
+│        ├─ launch_splash.py # full-screen "Loading <mode>" splash for NFC launches
 │        ├─ logo.py         # pixel art boot logo (Norse mead vessel)
 │        ├─ mystery.py      # Mystery Box discovery game
 │        ├─ nfc_provision.py # NFC card set viewer + tag programming
+│        ├─ ota.py          # OTA firmware sync takeover status screen
 │        ├─ overlay.py      # session state overlay
 │        ├─ pause.py        # in-game pause menu (hold-to-open)
 │        ├─ rakna.py        # Räkna NFC math game screen
@@ -154,6 +158,8 @@ bodn-esp32/
 │        ├─ space.py        # Spaceship cockpit mode
 │        ├─ story.py        # branching story mode (scripts + TTS on SD)
 │        ├─ theme.py        # colour palette and layout constants
+│        ├─ tone_explorer.py # Tone Lab / Ljudlabb free-play screen
+│        ├─ tone_explorer_secondary.py # Tone Lab status / overflow display
 │        └─ widgets.py      # stateless draw helpers + sprite cache
 ├─ docs/
 │  ├─ assets.md             # SD/flash asset layout and resolver rules
@@ -187,7 +193,8 @@ bodn-esp32/
 │  ├─ generate_cards.py     # NFC card face PDF generator (OpenMoji → A4 PDF)
 │  ├─ convert_icons.py      # OpenMoji SVG → BDF sprite conversion for on-screen icons
 │  ├─ import_freesound.py   # import and licence-track Freesound.org samples
-│  └─ make_asset.py         # rasterise SVG sources into 4bpp BDF sprites
+│  ├─ make_asset.py         # rasterise SVG sources into 4bpp BDF sprites
+│  └─ size-review.py        # audit custom firmware for unused compiled features
 ├─ cmodules/                  # native C extensions (compiled into firmware)
 │  ├─ micropython.cmake       # top-level cmake: includes sub-modules
 │  ├─ audiomix/               # native audio mixer (_audiomix module, core 0)
@@ -211,6 +218,10 @@ bodn-esp32/
 │  │  ├─ micropython.cmake    # per-module cmake (INTERFACE lib)
 │  │  ├─ mcpinput.c/h         # Python bindings + core 1 scan task
 │  │  └─ scanner.c/h          # I2C read loop + edge detection
+│  ├─ life/                   # native Game of Life step kernel (_life module)
+│  │  ├─ micropython.cmake    # per-module cmake (INTERFACE lib)
+│  │  ├─ life_mod.c           # Python bindings
+│  │  └─ life.c/h             # step kernel (torus-wrap neighbour count)
 │  └─ neopixel/               # NeoPixel pattern engine (_neopixel module)
 │     ├─ micropython.cmake    # per-module cmake (INTERFACE lib)
 │     ├─ neopixel_mod.c/h     # Python bindings
@@ -316,12 +327,13 @@ source ~/esp-idf/export.sh                        # once per terminal session
 ./tools/build-firmware.sh flash                    # build + flash
 ./tools/build-firmware.sh clean                    # clean build directory
 # The custom firmware is stock MicroPython + _audiomix, _spidma, _draw,
-# _mcpinput, and _neopixel C modules. Each has a Python fallback:
+# _mcpinput, _neopixel, and _life C modules. Each has a Python fallback:
 #   _audiomix  → AudioEngine falls back to the viper/IRQ path
 #   _spidma    → display writes fall back to blocking machine.SPI
 #   _draw      → bodn.ui.draw falls back to pure-Python framebuf helpers
 #   _mcpinput  → MCP23017 input scanned on the main loop
 #   _neopixel  → bodn.neo falls back to the built-in neopixel module
+#   _life      → life_rules.step falls back to pure Python
 
 # SD card asset sync (build + copy in one step — runs all 3 steps above)
 uv run python tools/sd-sync.py                    # auto-detect BODN* SD card on macOS
@@ -378,11 +390,13 @@ breakdown. Status at a glance:
 1. **Hardware bring-up** — complete (dual displays, inputs, LEDs, thermal).
 2. **Audio basics** — complete (16-voice native C mixer, TTS, hand-recordings).
    Record/replay from INMP441 still outstanding.
-3. **Kid-facing UI** — 12 game modes shipped (Mystery, Simon, Flöde, Rule
+3. **Kid-facing UI** — 14 game modes shipped (Mystery, Simon, Flöde, Rule
    Follow, Garden, Soundboard, Sequencer, High-Five, Space, Story, Sortera,
-   Räkna). Record & replay still planned.
-4. **Parental controls** — complete (web UI, session limits, PIN, OTA).
+   Räkna, Tone Lab / Ljudlabb, Blippa). Record & replay still planned.
+4. **Parental controls** — complete (web UI, session limits, PIN, OTA,
+   NFC tag provisioning from the browser).
 5. **Quality-of-life** — complete (battery, thermal, diagnostics, SD card,
    asset resolver, custom firmware build, boot-log persistence).
-6. **NFC card games** — PN532 driver + provisioning UI shipped; Sortera,
-   Räkna, and launcher card sets live. More card sets planned.
+6. **NFC card games** — PN532 driver + on-device + web-UI provisioning
+   shipped; Sortera, Räkna, and launcher card sets live. More card sets
+   planned.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ mythology — the drink that granted wisdom and poetic inspiration.
 A colourful, tactile device that grows with a child (starting around age 4):
 
 - **Press buttons and turn knobs** → hear sounds, see colours and animations
-- **Play games** → Simon memory, Mystery Box discovery, Flöde flow puzzles, Rule Follow, Garden of Life, Soundboard, Spaceship cockpit, Story Mode, High-Five Friends, Sequencer
+- **Play games** → Simon memory, Mystery Box discovery, Flöde flow puzzles, Rule Follow, Garden of Life, Soundboard, Spaceship cockpit, Story Mode, High-Five Friends, Sequencer, Tone Lab (free-play sound design), Blippa (free-play NFC)
 - **NFC card games** → scan physical cards for Sortera (classification) and Räkna (math); launcher cards start any game mode (PN532 reader + NTAG213 stickers)
 - **Offline spoken audio** → Piper TTS generates Swedish and English narration for game instructions and stories; hand-recorded WAVs can transparently override any line
-- **Parental controls** → session time limits, break enforcement, quiet hours, lockdown — all configured from a phone via a local web UI
+- **Parental controls** → session time limits, break enforcement, quiet hours, lockdown, NFC tag provisioning — all configured from a phone via a local web UI
 
 ## Hardware
 
@@ -78,6 +78,7 @@ firmware/
     storage.py          # JSON settings & session history on flash
     stories/            # story package (scripts discovered at runtime on SD)
     temperature.py      # DS18B20 + SoC temperature monitoring
+    tone_explorer_rules.py # Tone Lab / Ljudlabb state model (pure logic)
     tones.py            # procedural tone generation (pure logic)
     tts.py              # TTS playback helper (SD-first voice resolution)
     wav.py              # WAV header parser + streaming reader (pure logic)
@@ -86,7 +87,7 @@ firmware/
     wifi.py             # WiFi connect (STA / AP) + mDNS + runtime control
     *_rules.py          # pure-logic game engines: mystery, simon, flode,
                         #   rulefollow, life, soundboard, space, story,
-                        #   sequencer, highfive, sortera, rakna
+                        #   sequencer, highfive, sortera, rakna, tone_explorer
     ui/
       screen.py         # Screen base class + ScreenManager
       theme.py          # colour palette and layout constants
@@ -114,6 +115,9 @@ firmware/
       story.py                # branching story mode (scripts + TTS on SD)
       sortera.py              # Sortera NFC classification game
       rakna.py                # Räkna NFC math game
+      tone_explorer.py           # Tone Lab / Ljudlabb free-play screen
+      tone_explorer_secondary.py # Tone Lab secondary display content
+      blippa.py               # Blippa free-play "blip any card" NFC mode
       clock.py          # clock display mode
       catface.py        # animated cat face (secondary content)
       ambient.py        # AmbientClock + StatusStrip (secondary display)
@@ -125,11 +129,13 @@ firmware/
       admin_qr.py       # admin URL screen with QR code
       nfc_provision.py  # NFC card set viewer + provisioning
       icon_browser.py   # OpenMoji emoji sprite browser
+      launch_splash.py  # full-screen "Loading <mode>" splash for NFC launches
+      ota.py            # OTA firmware sync takeover status screen
 ```
 
 ### Native C modules
 
-Five C modules in `cmodules/` compile into a custom MicroPython firmware build
+Six C modules in `cmodules/` compile into a custom MicroPython firmware build
 (see `tools/build-firmware.sh`). Each has a Python fallback so stock
 MicroPython still runs — the board definition lives in `boards/BODN_S3/`.
 
@@ -140,6 +146,7 @@ MicroPython still runs — the board definition lives in `boards/BODN_S3/`.
 | `_draw` | Bitmap fonts, sprite blit, primitives with alpha blending |
 | `_mcpinput` | Deterministic MCP23017 input scanner (core 1 task) |
 | `_neopixel` | NeoPixel pattern engine (animations run in C, not Python) |
+| `_life` | Game of Life step kernel (torus-wrap, falls back to Python) |
 
 ## Getting started
 
@@ -157,8 +164,8 @@ see [`docs/getting-started.md`](docs/getting-started.md).
 # Install host tools (mpremote, ruff, black)
 uv sync
 
-# Deploy firmware to the device
-./tools/sync.sh
+# Deploy firmware to the device (auto-detects USB vs WiFi via bodn.local)
+./tools/deploy.sh
 
 # Open a REPL
 uv run mpremote connect auto repl
@@ -311,8 +318,8 @@ See [`docs/roadmap.md`](docs/roadmap.md) for detailed milestones.
 
 1. ~~**Hardware bring-up**~~ — display, buttons, encoders ✓
 2. ~~**Audio basics**~~ — tones, WAV playback, native C mixer on core 0 ✓
-3. **Kid-facing UI** — 12 game modes shipped (incl. Sortera + Räkna NFC games); record & replay still planned
-4. ~~**Parental controls**~~ — web UI, session limits, PIN, OTA sync ✓
+3. **Kid-facing UI** — 14 game modes shipped (incl. Sortera + Räkna NFC games, Tone Lab, Blippa); record & replay still planned
+4. ~~**Parental controls**~~ — web UI, session limits, PIN, OTA sync, NFC tag provisioning from the browser ✓
 5. **Quality-of-life** — battery indicator, temperature monitoring, i18n (Swedish/English), offline TTS ✓
 6. **NFC integration** — PN532 driver, Sortera + Räkna shipped; more card-based modes on deck
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,11 +82,15 @@ Verify on the REPL: `import _audiomix` and `import _spidma` should both succeed.
 ## 2. Deploy firmware
 
 ```bash
-# Copy all firmware files to the device
-./tools/sync.sh
+# Copy all firmware files to the device (auto-detects USB vs WiFi via bodn.local)
+./tools/deploy.sh
+
+# Or force a specific transport:
+./tools/deploy.sh --usb             # USB (mpremote)
+./tools/deploy.sh --wifi 192.168.1.143   # WiFi push to a specific IP
 ```
 
-This uses `mpremote` under the hood. The device resets automatically after deploy.
+`deploy.sh` wraps `tools/sync.sh` (USB) and `tools/ota-push.py` (WiFi) — use it as the default entry point. The device resets automatically after deploy.
 
 ## 3. Connect to the serial console
 
@@ -296,7 +300,7 @@ machine.soft_reset()   # re-runs boot.py + main.py
 | Problem | Fix |
 |---------|-----|
 | No serial output at all | Wrong USB port — use the UART port (CH340X), not OTG |
-| `No module named 'bodn'` | Firmware not deployed — run `./tools/sync.sh` |
+| `No module named 'bodn'` | Firmware not deployed — run `./tools/deploy.sh` |
 | Port not found (`/dev/cu.usbserial-*`) | Install CH340 driver: [macOS driver](https://www.wch-ic.com/downloads/CH341SER_MAC_ZIP.html) |
 | `BOOT [NET] fail` | Normal on first boot — WiFi defaults to AP mode. Connect to the "Bodn" network |
 | `BOOT [NTP] warn` | No internet access — harmless, just means clock isn't synced |
@@ -304,13 +308,13 @@ machine.soft_reset()   # re-runs boot.py + main.py
 | MCP23017 not found (missing from I2C scan) | Check I2C wiring (SCL→47, SDA→48), 3.3V power, and RESET tied to VCC. Run `from bodn.i2c_diag import run; run()` |
 | MCP pins fluctuate with no buttons pressed | Long button wires need 4.7kΩ external pull-ups to 3.3V (internal 100kΩ too weak for >10cm wires) |
 | Encoders skip steps or behave erratically | Add 4.7kΩ pull-ups on CLK/DT lines. Check wire length and routing away from power lines |
-| Can't Ctrl-C to REPL (encoder IRQ blocks it) | Create `/skip_main` flag file (see §7), or press RST and run `./tools/sync.sh --minimal` within 1s |
+| Can't Ctrl-C to REPL (encoder IRQ blocks it) | Create `/skip_main` flag file (see §7), or press RST and run `./tools/deploy.sh --usb` within 1s |
 | Display shows corrupted pixels or colour shifts | SPI clock too high for your wiring. Lower `TFT_SPI_BAUDRATE` in `firmware/bodn/config.py` from 80 MHz to 40 MHz (or 26 MHz). No firmware rebuild needed — just sync Python files. Long wires and breadboard connections are especially sensitive to high SPI clocks |
 | Display works but has occasional glitches | Same as above — try 40 MHz. Also check that SPI wires (SCK, MOSI, CS, DC) are short (<10cm) and routed away from power lines |
 
 ## 10. Next steps
 
 - **Wokwi simulation**: see the [README](../README.md#wokwi-simulation) for running in the simulator
-- **OTA updates**: once WiFi is working, use `tools/ota-push.py` to push firmware without USB
+- **OTA updates**: once WiFi is working, `./tools/deploy.sh` will auto-pick the WiFi path via `bodn.local` mDNS (or use `tools/ota-push.py` directly). Full syncs land in ~2 minutes with a takeover status screen on the device
 - **Parental controls**: connect to the device's IP in a browser to configure session limits
 - **Pin reference**: see `docs/wiring.md` for the full auto-generated pinout

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -216,7 +216,7 @@ NAV doubles as parameter B in game modes — rotation controls speed/cursor, sho
 
 Chain order: Stick A DOUT → Stick B DIN → Stick B DOUT → Lid Ring DIN.
 
-Brightness is capped in software per zone: sticks at 25% (64/255), lid ring at 12.5% (32/255) for ambient glow. For strips longer than ~0.5 m, inject 5V power at the midpoint to prevent voltage drop and color shift at the far end.
+Brightness is capped in software per zone: sticks at 25% (64/255), lid ring at 12.5% (32/255) for ambient glow. A global hard cap (`NEOPIXEL_MAX_BRIGHTNESS` in `firmware/bodn/config.py`, default 128/255) is enforced at the `bodn.neo` choke point — pattern brightness is clamped and per-pixel RGB values are scaled — to protect the 5 V buck-boost and LED strip from full-white current surges. Raising it to 255 restores a zero-cost fast path. For strips longer than ~0.5 m, inject 5V power at the midpoint to prevent voltage drop and color shift at the far end.
 
 NeoPixel VDD is powered from the DC-DC converter's 5V output (see [Power distribution](#power-distribution) below), ensuring stable voltage on both USB and battery.
 
@@ -261,7 +261,8 @@ Source: [OLIMEX/ESP32-S3-DevKit-LiPo on GitHub](https://github.com/OLIMEX/ESP32-
 Board: **Olimex ESP32-S3-DevKit-LiPo** (Rev B)
 
 - Module: ESP32-S3-WROOM-1-N8R8 (8 MB flash + 8 MB PSRAM)
-- Dual-core Xtensa LX7 @ 240 MHz, 512 KB internal SRAM
+- Dual-core Xtensa LX7 @ 240 MHz (SoC turbo), 512 KB internal SRAM
+- Custom partition table (`boards/BODN_S3/partitions-bodn-8MiB.csv`): 2× 2.1 MiB OTA app slots + 3.7 MiB VFS. Changing the layout requires a USB reflash with erase — VFS data does not survive a layout change.
 - Wi-Fi 802.11 b/g/n + Bluetooth 5 (LE)
 - Two USB-C ports: one for UART (programming/console via CH340X), one for OTG/JTAG
 - Built-in LiPo charger (BL4054B, 100 mA with default 10k prog resistor)
@@ -667,8 +668,8 @@ Core firmware, UI sounds, and navigation all live on flash. Only media assets (s
 arcade sounds, images, animations) require the SD card.
 
 **Asset management workflow:** Pop the card into a PC card reader and copy files directly —
-this is the primary method for bulk loading. The existing WiFi sync tools (`sync.sh`,
-`ota-push.py`) push firmware to flash only and do not touch SD card content.
+this is the primary method for bulk loading. The existing deploy tools (`deploy.sh`,
+`sync.sh`, `ota-push.py`) push firmware to flash only and do not touch SD card content.
 See `docs/assets.md` for the directory structure.
 
 ## GPIO budget

--- a/docs/nfc.md
+++ b/docs/nfc.md
@@ -168,3 +168,14 @@ from bodn.nfc import (
 | `/api/nfc/sets` | GET | List available card sets |
 | `/api/nfc/set/{mode}` | GET | Full card set data |
 | `/api/nfc/cache` | GET | UID cache contents |
+| `/api/nfc/provision/start` | POST | Begin a browser-driven provisioning session (arms the PN532 to write the next tag it sees). On-device UI defers while a web session is active. |
+| `/api/nfc/provision/status` | GET | Poll the outcome of the current provisioning session (idle / waiting / written / error). |
+| `/api/nfc/provision/cancel` | POST | Release the provisioning lock without writing. |
+
+### Provisioning paths
+
+Tags can be written from **two** places — the on-device `NFC` settings
+screen and the parental web UI (NFC panel). Both share the same PN532
+driver and a single cross-process lock (`bodn.nfc.provision_*`) so only
+one path can hold the reader at a time. The other path shows a "busy"
+indicator until the session is released.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,6 +47,8 @@
 - [x] **Story Mode** — branching stories read aloud via SD-loaded TTS packages
 - [x] **Sortera** — NFC classification game (DCCS-style, 16 animal cards)
 - [x] **Räkna** — NFC math game (levels 1–6, from counting to symbolic equations)
+- [x] **Tone Lab / Ljudlabb** — free-play sound design (pitch, waveform, effects, gated output)
+- [x] **Blippa** — free-play NFC "blip any card" mode with instant audio/visual feedback
 - [x] Pause menu (hold-to-open), session overlay, in-game wind-down animation
 - [x] Secondary display content per game mode (cat face, ambient clock, status strip)
 - [x] i18n with Swedish default and English fallback (å/ä/ö extended font glyphs)
@@ -81,7 +83,13 @@
 - [x] Thermal protection (software-only safeguard for LiPo — shed load at 50 °C, sleep at 60 °C)
 - [x] SD card support for bulk media (mounted at boot, graceful fallback if absent)
 - [x] Asset resolver (`bodn.assets.resolve` / `resolve_voice`) with SD-first / flash-fallback precedence
-- [x] Custom MicroPython firmware build with native C modules (`_audiomix`, `_spidma`, `_draw`, `_mcpinput`, `_neopixel`)
+- [x] Custom MicroPython firmware build with native C modules (`_audiomix`, `_spidma`, `_draw`, `_mcpinput`, `_neopixel`, `_life`)
+- [x] Custom 8 MiB partition table (2× app slots + VFS) wired into BODN_S3 board build
+- [x] ESP32-S3 running at 240 MHz for smoother UI + audio under load
+- [x] Configurable NeoPixel max-brightness cap to protect power + thermals
+- [x] OTA sync speedup (10–15 min → ~2 min) with dedicated takeover status screen
+- [x] `tools/deploy.sh` entry point: auto-detects USB vs WiFi (via `bodn.local` mDNS)
+- [x] `tools/size-review.py` for auditing unused compiled firmware features
 - [x] Boot log persistence to flash, viewable via the web UI
 
 ## Milestone 6: NFC card games
@@ -89,7 +97,7 @@
 - [x] NFC tag format (self-describing NDEF Text Records) and card-set schema
 - [x] PN532 NFC reader driver (I2C, polling task, power-gated rail)
 - [x] Robust tag writing with retries and PN532 recovery
-- [x] NFC provisioning UI (card set viewer, programming, UID cache)
+- [x] NFC provisioning UI (card set viewer, programming, UID cache) — on-device *and* web UI
 - [x] Card-face PDF generator (OpenMoji emoji → A4, 85×54 mm, 2×4 per page)
 - [x] Sortera card set (16 animal cards × 4 colours) with runtime filter by programmed tags
 - [x] Räkna card set (numbers, operators, equation builders — levels 1–6)

--- a/docs/soundboard.md
+++ b/docs/soundboard.md
@@ -44,7 +44,7 @@ Sounds live on internal flash. The directory structure is mandatory; filenames a
 **WAV format**: 16-bit mono, 22 050 Hz. ~44 KB per second of audio.
 Files not in this exact structure are ignored — dumping files in `/sounds/` directly has no effect.
 
-Upload via `sync.sh`, `ota-push.py`, or the web UI (planned).
+Upload via `deploy.sh` (wraps `sync.sh` / `ota-push.py`), or the web UI (planned). For bulk media, write files directly to the SD card via a PC card reader — the SD card asset pipeline runs through `tools/sd-sync.py`.
 
 ## manifest.json
 


### PR DESCRIPTION
## Summary
Catches documentation up to the last ~50 commits — several new modules, tools, and features had landed without a matching doc pass.

- **New game modes surfaced**: Tone Lab / Ljudlabb and Blippa added to the README feature list, CLAUDE.md layout tree, roadmap snapshot, and `docs/roadmap.md` (count now 14, was 12).
- **New firmware modules indexed**: `tone_explorer_rules.py`, `ui/{blippa,launch_splash,ota,tone_explorer,tone_explorer_secondary}.py`, plus the `_life` native C module in `cmodules/life/` (fallback note added to the custom-firmware section).
- **New tool indexed**: `tools/size-review.py`.
- **Deploy story unified**: stale `sync.sh`-only references in README, getting-started, hardware, and soundboard docs now point at `./tools/deploy.sh` (USB/WiFi auto-detection via `bodn.local` mDNS).
- **Hardware facts refreshed**: 240 MHz SoC turbo annotated, custom 8 MiB partition table noted on the DevKit-Lipo entry, and the runtime-configurable `NEOPIXEL_MAX_BRIGHTNESS` cap added to the NeoPixel section.
- **NFC docs**: added `/api/nfc/provision/*` endpoints and a "Provisioning paths" subsection covering the on-device + web UI dual path with shared PN532 lock.
- **Getting-started**: OTA section notes the ~2-minute sync with takeover status screen.

No code changes — docs only.

## Test plan
- [ ] Skim CLAUDE.md layout tree against `ls firmware/bodn/ firmware/bodn/ui/ cmodules/ tools/`
- [ ] Verify README game-mode list matches current modes
- [ ] Verify `docs/roadmap.md` Milestone 3 reflects shipped modes
- [ ] Verify `docs/nfc.md` Web API table matches `firmware/bodn/web.py` endpoints
- [ ] `grep -r "sync\.sh" docs/ README.md` — remaining hits should only be the ones that reference the file by name intentionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)