### PR TITLE
fix: OTA boot crash, throughput, and progress-bar regression

### DIFF
--- a/boards/BODN_S3/mpconfigboard.h
+++ b/boards/BODN_S3/mpconfigboard.h
@@ -13,3 +13,9 @@
 // neither the Python bindings nor the C stack gets compiled.
 #define MICROPY_PY_BLUETOOTH                (0)
 #define MICROPY_PY_ESPNOW                   (0)
+
+// Stock ESP32 ROM level (EXTRA_FEATURES) only enables deflate
+// decompression; FULL_FEATURES is needed for DeflateIO.write. The web
+// UI precomputes HTML_GZ at import time to cut ~25 KB off every page
+// load over WiFi — without this the fallback serves raw HTML.
+#define MICROPY_PY_DEFLATE_COMPRESS         (1)

--- a/firmware/bodn/ui/secondary.py
+++ b/firmware/bodn/ui/secondary.py
@@ -151,11 +151,22 @@ class SecondaryDisplay:
     # -- Invalidation --
 
     def invalidate(self, zone="both"):
-        """Force a redraw. zone: 'content', 'status', or 'both'."""
+        """Force a redraw. zone: 'content', 'status', or 'both'.
+
+        Also re-enters the active screens so their own dirty-tracking
+        state resets. Without this, after an external clear (e.g. the
+        OTA takeover paints the full TFT), the manager fills the zone
+        black but the screen's render() sees nothing changed against
+        its cached state and skips drawing — leaving the zone blank.
+        """
         if zone in ("content", "both"):
             self._content_dirty = True
+            if self._content:
+                self._content.enter(self)
         if zone in ("status", "both"):
             self._status_dirty = True
+            if self._status:
+                self._status.enter(self)
 
     # -- Tick --
 

--- a/firmware/bodn/web.py
+++ b/firmware/bodn/web.py
@@ -18,7 +18,9 @@ from bodn import storage
 # Deadline in ticks_ms; once past it, ota_active() returns False and the
 # main render tasks go back to normal. Refreshed on every /api/upload
 # and /api/ota/* call, so an interrupted deploy recovers on its own.
-_OTA_QUIET_MS = 10_000
+# 30 s gives enough slack that a single slow file (OTA retry window is
+# 30-60 s) doesn't flip the screen back to the menu mid-sync.
+_OTA_QUIET_MS = 30_000
 
 
 def _mark_ota_active(settings):
@@ -351,10 +353,29 @@ async def _handle_upload(reader, writer, headers, settings=None):
             # request line.
             writer._keep_alive = False
         _record_free_delta(written)
-        # Bump per-sync counters for the status screen.
+        # Update per-sync counters for the status screen.
+        # Client sends X-File-Index (1-based position in its plan) so
+        # a retry (e.g. after the first attempt times out while the
+        # device is still writing) sets the counter idempotently
+        # instead of pushing it past the total — the "12/10" bug.
+        # Fall back to incrementing when the header is absent so older
+        # clients still see progress.
         if settings is not None:
-            settings["_ota_files_done"] = settings.get("_ota_files_done", 0) + 1
-            settings["_ota_bytes_done"] = settings.get("_ota_bytes_done", 0) + written
+            idx = headers.get("x-file-index")
+            if idx is not None:
+                try:
+                    settings["_ota_files_done"] = max(
+                        settings.get("_ota_files_done", 0), int(idx)
+                    )
+                except (TypeError, ValueError):
+                    settings["_ota_files_done"] = settings.get("_ota_files_done", 0) + 1
+            else:
+                settings["_ota_files_done"] = settings.get("_ota_files_done", 0) + 1
+            total_b = settings.get("_ota_total_bytes", 0)
+            new_bytes = settings.get("_ota_bytes_done", 0) + written
+            if total_b > 0 and new_bytes > total_b:
+                new_bytes = total_b
+            settings["_ota_bytes_done"] = new_bytes
         t_resp0 = ticks()
         await _send_json(
             writer,
@@ -571,7 +592,10 @@ async def _handle_request(reader, writer, request_line, session_mgr, settings):
             # Pre-gzipped ~10 KB vs ~35 KB raw — cuts radio time and drain()
             # latency on every full page load. Browsers always send gzip in
             # Accept-Encoding; the raw path remains as a safety net.
-            if "gzip" in headers.get("accept-encoding", "").lower():
+            if (
+                HTML_GZ is not None
+                and "gzip" in headers.get("accept-encoding", "").lower()
+            ):
                 await _send(
                     writer,
                     200,

--- a/firmware/bodn/web_ui.py
+++ b/firmware/bodn/web_ui.py
@@ -671,13 +671,20 @@ def _precompute_gzip(s):
 
         buf = io.BytesIO()
         d = deflate.DeflateIO(buf, deflate.GZIP)
+        # Stock ESP32 MicroPython at ROM_LEVEL_EXTRA_FEATURES ships the
+        # deflate module for decompression only; DeflateIO.write doesn't
+        # exist. Fall back to serving raw HTML — the caller checks for
+        # None and picks the uncompressed branch.
         d.write(raw)
         d.close()
         return buf.getvalue()
-    except ImportError:
-        import gzip  # CPython (host tests)
+    except (ImportError, AttributeError):
+        try:
+            import gzip  # CPython (host tests)
 
-        return gzip.compress(raw)
+            return gzip.compress(raw)
+        except ImportError:
+            return None
 
 
 HTML_GZ = _precompute_gzip(HTML)

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -1133,7 +1133,7 @@ async def housekeeping_task(session_mgr, settings, audio=None, pwm=None):
         await asyncio.sleep_ms(500)
 
 
-async def nfc_scan_task(manager, mode_screens, session_mgr, audio):
+async def nfc_scan_task(manager, mode_screens, session_mgr, audio, settings):
     """Poll NFC reader cooperatively and route tags globally.
 
     Uses the PN532 two-phase API via ``NFCReader.scan_cooperative`` so a
@@ -1177,6 +1177,16 @@ async def nfc_scan_task(manager, mode_screens, session_mgr, audio):
         # sleep or soft reboot when PN532 needs time to come up).
         if not reader.available():
             await asyncio.sleep_ms(2000)
+            continue
+
+        # Pause NFC polling during WiFi OTA — scan_cooperative's I2C
+        # transactions + its 40 ms of awaits per cycle compete with the
+        # upload handler's await reader.read() points, dropping WiFi
+        # throughput to ~1-4 KB/s. primary_task and secondary_task
+        # already step aside on ota_active; this keeps NFC in line.
+        if ota_active(settings):
+            prev_uid = None
+            await asyncio.sleep_ms(500)
             continue
 
         # Provisioning screens hold the bus for a blocking write — skip
@@ -1389,7 +1399,7 @@ async def main():
     if audio:
         tasks.append(audio.start())
     # Always start NFC task — it retries init if hardware wasn't ready at boot
-    tasks.append(nfc_scan_task(manager, mode_screens, session_mgr, audio))
+    tasks.append(nfc_scan_task(manager, mode_screens, session_mgr, audio, settings))
     await asyncio.gather(*tasks)
 
 

--- a/tools/ota-push.py
+++ b/tools/ota-push.py
@@ -200,6 +200,7 @@ def push(
     if plan_files > 0:
         _ota_begin(client, plan_files, plan_bytes, token)
 
+    file_index = 0
     for rel_path in FILES:
         local = FIRMWARE_DIR / rel_path
         if not local.exists():
@@ -216,8 +217,10 @@ def push(
             skipped += 1
             continue
         remote = "/" + rel_path
+        file_index += 1
         hdrs = {
             "X-Path": remote,
+            "X-File-Index": str(file_index),
             "Content-Type": "application/octet-stream",
         }
         if token:


### PR DESCRIPTION
## Summary

- **Boot crash**: stock ESP32 MicroPython at `ROM_LEVEL_EXTRA_FEATURES` ships `deflate` for decompression only, so `DeflateIO.write` (added in #181) doesn't exist and boot trips `AttributeError` before `main.py` runs. Guarded the precompute and gated `HTML_GZ` on `is not None`; enabled `MICROPY_PY_DEFLATE_COMPRESS` in the custom board config so rebuilds keep the ~25 KB-per-page saving.
- **WiFi OTA throughput (1-4 KB/s)**: `nfc_scan_task` didn't check `ota_active(settings)`. After #176 the scan does real I2C work every ~300 ms, and its awaits interleaved with the upload handler's socket reads. NFC now pauses during OTA like primary/secondary already did.
- **Progress bar overshoot (12/10)**: slow throughput pushed individual files past the client's 30 s first-attempt timeout -- the device had already finished writing and bumped the files-done counter, and the client retried the same body. Client now sends `X-File-Index`; device uses `max(current, idx)` so retries are idempotent. Bytes counter clamped at `total_bytes` as a safety net. `_OTA_QUIET_MS` bumped 10 s -> 30 s so the OTA takeover screen doesn't flip back to the menu mid-sync.

## Test plan

- [x] `uv run pytest` (924 passed)
- [x] `uv run ruff check` + `ruff format`
- [ ] USB-flash to recover from the boot crash
- [ ] Full `./tools/deploy.sh` --wifi push shows normal throughput and a steady `N / TOTAL` progress bar
- [ ] Rebuild firmware with the new `MICROPY_PY_DEFLATE_COMPRESS` flag and confirm the web UI loads gzipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)