### PR TITLE
fix: reduce tone lab input-to-sound latency

### DIFF
--- a/cmodules/audiomix/mixer.c
+++ b/cmodules/audiomix/mixer.c
@@ -711,10 +711,13 @@ const char *mixer_init(const mixer_config_t *cfg, audiomix_state_t **state_out) 
     // Configure I2S via ESP-IDF new driver
     i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(
         I2S_NUM_0, I2S_ROLE_MASTER);
-    // DMA config: 8 descriptors × 256 frames = 2048 frames total
-    // At 16kHz stereo 16-bit: 2048 frames × 4 bytes = 8192 bytes ≈ 128ms buffer
-    // Each descriptor holds 256 frames = 16ms — matches our mix chunk size
-    chan_cfg.dma_desc_num = 8;
+    // DMA config: 3 descriptors × 256 frames = 768 frames total
+    // At 16kHz stereo 16-bit: 768 frames × 4 bytes = 3072 bytes ≈ 48ms buffer
+    // Each descriptor holds 256 frames = 16ms — matches our mix chunk size.
+    // Kept shallow so pitch/wave changes in Tone Lab become audible quickly;
+    // the mixer runs on a dedicated core-0 task so underruns are rare even
+    // with only 3 descriptors of slack.
+    chan_cfg.dma_desc_num = 3;
     chan_cfg.dma_frame_num = 256;
 
     esp_err_t err = i2s_new_channel(&chan_cfg, &s_i2s_handle, NULL);

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -184,7 +184,7 @@ def create_hardware():
         scl=config.I2C_SCL,
         freq=400_000,
         mcp_addr=config.MCP23017_ADDR,
-        debounce_ms=12,
+        debounce_ms=4,
         int_pin=-1,
     )
     from bodn.native_i2c import NativeI2C


### PR DESCRIPTION
## Summary

- Tone Lab felt sluggish: ~175 ms worst-case from arcade button press to audible tone, making musical play feel out of sync.
- The dominant latency source turned out to be the I2S DMA pipeline (8 descriptors x 256 frames = ~128 ms buffered audio), with the 12 ms input debounce on top.
- Dropped \`dma_desc_num\` 8 -> 3 (~48 ms buffer) and \`_mcpinput.debounce_ms\` 12 -> 4. New worst case ~55 ms, confirmed "surprisingly responsive" in Tone Lab on device.

## Trade-off

The mixer runs as a pinned FreeRTOS task so Python GC can't starve it -- the deep buffer was really only protecting against flash-write critical sections and WiFi ISR bursts. 48 ms should still absorb those, but if clicks appear during settings saves / session writes / OTA activity, bump to \`dma_desc_num = 4\` (~64 ms). If mini buttons start double-triggering, raise debounce to 6-8 ms or split per pin kind.

## Test plan

- [x] Tone Lab on device: pitch changes and gate-mode retriggers feel immediate
- [ ] Sequencer and Space (heavier audio workloads): listen for underrun clicks
- [ ] Flash-write paths (settings save, session end, OTA push): listen for clicks during writes
- [ ] Mini buttons across modes (Mystery, Simon effects, pause menu): confirm no double-presses

🤖 Generated with [Claude Code](https://claude.com/claude-code)