### PR TITLE
perf: review batch 187 (#189, #190, #192)

### DIFF
--- a/firmware/bodn/tts.py
+++ b/firmware/bodn/tts.py
@@ -23,6 +23,25 @@ except ImportError:
 from bodn.assets import resolve_voice
 from bodn.i18n import get_language
 
+# (lang, key) -> resolved path string, or None when the clip is missing.
+# resolve_voice() does up to four os.stat() calls per lookup on SD; caching
+# both hits and misses makes repeated TTS plays of the same key zero-I/O.
+# Bounded by (languages x keys) ~= a few hundred entries.
+_PATH_CACHE = {}
+
+# Sentinel so a cached "missing" (None) is distinguishable from "not cached".
+_MISS = object()
+
+
+def reset_cache():
+    """Drop cached TTS path lookups.
+
+    Call from anywhere that could invalidate paths at runtime (e.g. an SD
+    card hot-swap).  Language changes don't need this — entries are keyed
+    by (lang, key).
+    """
+    _PATH_CACHE.clear()
+
 
 def say(key, audio, channel="ui"):
     """Play a spoken audio clip for the given i18n key.
@@ -37,7 +56,11 @@ def say(key, audio, channel="ui"):
         generated TTS exists for this key.
     """
     lang = get_language()
-    resolved = resolve_voice("/sounds/tts/{}/{}.wav".format(lang, key))
+    cache_key = (lang, key)
+    resolved = _PATH_CACHE.get(cache_key, _MISS)
+    if resolved is _MISS:
+        resolved = resolve_voice("/sounds/tts/{}/{}.wav".format(lang, key))
+        _PATH_CACHE[cache_key] = resolved
     if resolved is None:
         return False
     audio.play(resolved, channel=channel)

--- a/firmware/bodn/ui/ambient.py
+++ b/firmware/bodn/ui/ambient.py
@@ -29,8 +29,10 @@ class AmbientClock(Screen):
         self._last_min = -1
 
     def needs_redraw(self):
-        t = time.localtime()
-        cur_min = t[4]
+        # time.time() returns an int on MicroPython, so minute-resolution
+        # change detection allocates nothing.  localtime() only runs in
+        # render() once per minute.
+        cur_min = time.time() // 60
         if cur_min != self._last_min:
             self._last_min = cur_min
             return True
@@ -78,8 +80,9 @@ class StatusStrip(Screen):
     def needs_redraw(self):
         changed = False
 
-        t = time.localtime()
-        cur_min = t[4]
+        # Minute-resolution gate using int seconds to avoid per-tick
+        # tuple allocation from time.localtime().
+        cur_min = time.time() // 60
         if cur_min != self._last_min:
             self._last_min = cur_min
             changed = True

--- a/firmware/bodn/ui/clock.py
+++ b/firmware/bodn/ui/clock.py
@@ -28,6 +28,8 @@ class ClockScreen(Screen):
         self._manager = None
         self._pause = PauseMenu(settings=settings)
         self._last_sec = -1
+        self._clock_str = ""
+        self._date_str = ""
         self._dirty = True
 
     def enter(self, manager):
@@ -52,28 +54,40 @@ class ClockScreen(Screen):
         if self._pause.is_open or self._pause.is_holding:
             return
 
-        # Time tick — partial push, no full render cycle
-        t = time.localtime()
-        if t[5] != self._last_sec and self._manager:
-            self._last_sec = t[5]
+        # Second-resolution gate: time.time() returns an int on MicroPython,
+        # so the tick check allocates nothing. Only call localtime() (which
+        # allocates a tuple) when the second has actually changed.
+        sec = time.time()
+        if sec != self._last_sec and self._manager:
+            self._last_sec = sec
+            t = time.localtime(sec)
+            self._clock_str = "{:02d}:{:02d}".format(t[3], t[4])
+            self._date_str = "{:04d}-{:02d}-{:02d}".format(t[0], t[1], t[2])
             tft = self._manager.tft
             theme = self._manager.theme
             text_y = theme.CENTER_Y + self._TEXT_REL_Y
             tft.fill_rect(0, text_y, theme.width, self._TEXT_H, theme.BLACK)
-            self._render_clock(tft, theme)
+            self._draw_clock(tft, theme)
             self._manager.request_show(0, text_y, theme.width, self._TEXT_H)
 
     def render(self, tft, theme, frame):
         """Full redraw — only called on transitions and pause menu changes."""
         self._dirty = False
         tft.fill(theme.BLACK)
-        self._render_clock(tft, theme)
+        if not self._clock_str:
+            sec = time.time()
+            self._last_sec = sec
+            t = time.localtime(sec)
+            self._clock_str = "{:02d}:{:02d}".format(t[3], t[4])
+            self._date_str = "{:04d}-{:02d}-{:02d}".format(t[0], t[1], t[2])
+        self._draw_clock(tft, theme)
         if self._pause.is_open:
             self._pause.render(tft, theme, frame)
 
-    def _render_clock(self, tft, theme):
-        t = time.localtime()
-        clock = "{:02d}:{:02d}".format(t[3], t[4])
-        date = "{:04d}-{:02d}-{:02d}".format(t[0], t[1], t[2])
-        draw_centered(tft, clock, theme.CENTER_Y - 20, theme.CYAN, theme.width, scale=2)
-        draw_centered(tft, date, theme.CENTER_Y + 10, theme.WHITE, theme.width)
+    def _draw_clock(self, tft, theme):
+        draw_centered(
+            tft, self._clock_str, theme.CENTER_Y - 20, theme.CYAN, theme.width, scale=2
+        )
+        draw_centered(
+            tft, self._date_str, theme.CENTER_Y + 10, theme.WHITE, theme.width
+        )

--- a/firmware/bodn/ui/screen.py
+++ b/firmware/bodn/ui/screen.py
@@ -139,7 +139,11 @@ class ScreenManager:
 
     def push(self, screen):
         """Push a screen onto the stack."""
-        gc.collect()
+        # No gc.collect() here: push() keeps the outgoing screen alive in the
+        # stack, so nothing has just been freed for a collect to reclaim. The
+        # ~200 ms stall this used to add sat on the most common user action
+        # (home -> mode). Collects still run on pop()/replace(), which is
+        # where exit() actually releases sprites and caches.
         self._stack.append(screen)
         self._dirty = True
         # Reset gesture detector so leftover button state (e.g. the press
@@ -154,6 +158,9 @@ class ScreenManager:
             return None
         screen = self._stack.pop()
         screen.exit()
+        # exit() just released the screen's sprites/caches; collect while we
+        # know the heap has fresh garbage and the user is already expecting
+        # a navigation pause.
         gc.collect()
         self._dirty = True
         # Notify the newly-revealed screen so it can reset partial-draw state
@@ -171,6 +178,7 @@ class ScreenManager:
             self._stack[-1] = screen
         else:
             self._stack.append(screen)
+        # Same reasoning as pop(): the outgoing exit() just freed assets.
         gc.collect()
         self._dirty = True
         screen.enter(self)

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -3,12 +3,13 @@
 from unittest.mock import MagicMock, patch
 
 from bodn.i18n import init, set_language
-from bodn.tts import say
+from bodn.tts import reset_cache, say
 
 
 class TestSay:
     def setup_method(self):
         init("sv")
+        reset_cache()
 
     def test_returns_true_when_voice_resolves(self):
         audio = MagicMock()
@@ -79,3 +80,23 @@ class TestSay:
         audio.play.assert_called_once_with(
             "/sounds/tts/sv/bat_low.wav", channel="music"
         )
+
+    def test_path_cache_reuses_resolver_result(self):
+        audio = MagicMock()
+        with patch(
+            "bodn.tts.resolve_voice",
+            return_value="/sounds/tts/sv/simon_watch.wav",
+        ) as mock_resolve:
+            say("simon_watch", audio)
+            say("simon_watch", audio)
+            say("simon_watch", audio)
+        assert mock_resolve.call_count == 1
+        assert audio.play.call_count == 3
+
+    def test_path_cache_records_misses(self):
+        audio = MagicMock()
+        with patch("bodn.tts.resolve_voice", return_value=None) as mock_resolve:
+            assert say("missing_key", audio) is False
+            assert say("missing_key", audio) is False
+        assert mock_resolve.call_count == 1
+        audio.play.assert_not_called()


### PR DESCRIPTION
## Summary

Lands three of the five starter sub-issues from the #187 perf review. The other two closed as false positives after source verification.

- **#189** — drop per-tick \`time.localtime()\` in \`clock.py\` and \`ambient.py\` (both AmbientClock and StatusStrip). Uses \`time.time()\` (int seconds on MicroPython, no allocation) for the change-detection gate; only calls \`localtime()\` when the second/minute actually rolls over. Also caches formatted clock/date strings in \`ClockScreen\` so a full re-render reuses them.
- **#190** — \`tts.say()\` caches \`resolve_voice()\` results per \`(lang, key)\`, including misses. Drops up to four \`os.stat()\` calls per repeat TTS play on SD. Added \`reset_cache()\` for SD hot-swap.
- **#192** — drop \`gc.collect()\` from \`ScreenManager.push()\`. Outgoing screen stays alive on push, so there's nothing for a collect to reclaim. The ~200 ms stall sat on the most common user action (home → mode). \`pop()\` and \`replace()\` keep their collects — both run \`screen.exit()\` first, and the user is already in a nav pause.

Closed without code changes (see issue comments): #188 (synchronous-load path, direct \`tft.show\` is correct), #191 (collect ordering was already correct).

## Test plan

- [x] \`uv run pytest\` (926 passed, including two new TTS cache tests)
- [x] \`uv run ruff check\`, \`uv run black\`
- [ ] On-device: enter/exit a mode and verify no 200 ms stall on entry
- [ ] On-device: run a TTS-heavy mode (Simon, Räkna) and verify no functional regression
- [ ] On-device: watch the clock on secondary display for a minute to confirm it still ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)