### PR TITLE
perf: part 2 — OTA import hoist, catface sort key, viper warning

### DIFF
--- a/firmware/bodn/tones.py
+++ b/firmware/bodn/tones.py
@@ -22,6 +22,16 @@ except ImportError:
     micropython = None
     _has_viper = False
 
+# Surface a one-time warning when the pure-Python fallback path is active.
+# Viper accelerates the tone-generation inner loops ~10-20x; on a firmware
+# build without viper support the fallback is silent today, which hides
+# what would otherwise be a visible audio perf cliff.
+if not _has_viper:
+    try:
+        print("tones: viper unavailable, using pure-Python fallback (~10-20x slower)")
+    except Exception:
+        pass
+
 # 256-entry sine lookup table (int16 range)
 _SINE_LUT = [int(32767 * math.sin(2 * math.pi * i / 256)) for i in range(256)]
 

--- a/firmware/bodn/ui/catface.py
+++ b/firmware/bodn/ui/catface.py
@@ -6,6 +6,11 @@
 from bodn.ui.screen import Screen
 from bodn.ui.secondary import CONTENT_SIZE
 
+
+def _by_y(p):
+    return p[1]
+
+
 # Emotion constants
 NEUTRAL = "neutral"
 CURIOUS = "curious"
@@ -211,7 +216,7 @@ def _fill_circle(tft, cx, cy, r, color):
 
 def _fill_triangle(tft, x0, y0, x1, y1, x2, y2, color):
     """Fill a triangle by scanline (simple, not performance-critical)."""
-    pts = sorted([(x0, y0), (x1, y1), (x2, y2)], key=lambda p: p[1])
+    pts = sorted([(x0, y0), (x1, y1), (x2, y2)], key=_by_y)
     (ax, ay), (bx, by), (cx, cy) = pts
 
     if ay == cy:

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -753,6 +753,8 @@ async def primary_task(
     ota_frame = 0
     next_ota_render_ms = 0
     _OTA_RENDER_INTERVAL_MS = 250  # ~4 fps — enough for a moving progress bar
+    from bodn.ui import ota as ota_ui
+
     while True:
         # ── OTA quiet mode ───────────────────────────────────
         # While a WiFi OTA is in progress, every ~20 ms we'd otherwise
@@ -769,8 +771,6 @@ async def primary_task(
             prev_ota = True
             now = ticks_ms()
             if ticks_diff(now, next_ota_render_ms) >= 0:
-                from bodn.ui import ota as ota_ui
-
                 try:
                     ota_ui.render(manager.tft, manager.theme, settings, ota_frame)
                     manager.tft.show()


### PR DESCRIPTION
## Summary

Follow-up to #193, working through the LOW/MEDIUM items on #187 that hold up on inspection. Most of the audit's LOW items turned out to be false positives (\`btn_rgb\` and \`_rule_565\` are already cached as locals; \`_flash_ttl\` is called once per state branch, not repeatedly; \`blippa\` \`split\` is off the hot path). The three genuine ones:

- **Hoist OTA UI import**: \`from bodn.ui import ota\` was inside the \`primary_task\` OTA polling loop. Caching aside, that's a module-dict lookup every 250 ms during an OTA. Moved up to the prelude.
- **Catface sort key**: \`_fill_triangle\` did \`sorted(..., key=lambda p: p[1])\`, allocating a closure per call. Now uses a module-level \`_by_y\`. (\`operator.itemgetter\` would be cleaner but MicroPython's stdlib doesn't ship \`operator\`.)
- **Viper fallback warning**: \`tones.py\` was silent when the viper fast path couldn't compile. The pure-Python fallback is ~10-20x slower for tone generation; a visible warning makes the regression obvious on a viper-less build.

## Test plan

- [x] \`uv run pytest\` (926 passed, including MicroPython import compat)
- [x] \`uv run ruff check\`, \`uv run black\`
- [ ] On-device: viper-less build prints the warning at boot
- [ ] On-device: OTA still works (module resolves correctly from the hoisted import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)