### PR TITLE
fix(rulefollow): align colours to caps, fix restart crash, full-word labels

### DIFF
--- a/firmware/bodn/rulefollow_rules.py
+++ b/firmware/bodn/rulefollow_rules.py
@@ -41,12 +41,14 @@ SWITCH_AFTER_MAX = const(6)  # max correct before rule switch
 # Opposite mapping: 0↔2, 1↔3 (diagonal swap in 2×2 grid)
 _OPPOSITE = (2, 3, 0, 1)
 
-# Button colors (RGB, matching theme.BTN_RGB for buttons 0–3)
+# Button colours — aligned 1:1 with the physical mini-button caps 0–3
+# (see theme.BTN_RGB: green, blue, white, yellow). Opposite pairs are the
+# diagonal swap 0↔2, 1↔3 (green↔white, blue↔yellow).
 BTN_COLORS = [
-    (255, 0, 0),  # Red
-    (0, 255, 0),  # Green
-    (0, 0, 255),  # Blue
-    (255, 255, 0),  # Yellow
+    (0, 200, 0),  # 0: green
+    (0, 100, 255),  # 1: blue
+    (255, 255, 255),  # 2: white
+    (255, 220, 0),  # 3: yellow
 ]
 
 # Rule colors (RGB) — blue for match, orange for opposite

--- a/firmware/bodn/ui/rulefollow.py
+++ b/firmware/bodn/ui/rulefollow.py
@@ -5,7 +5,7 @@ from micropython import const
 from bodn import config
 from bodn.ui.screen import Screen
 from bodn.ui.input import BrightnessControl
-from bodn.ui.widgets import draw_centered, draw_button_grid
+from bodn.ui.widgets import draw_centered, fill_circle, draw_circle
 from bodn.ui.pause import PauseMenu
 from bodn.i18n import t
 from bodn.rulefollow_rules import (
@@ -26,6 +26,11 @@ from bodn.neo import neo
 from bodn.ui.catface import NEUTRAL, CURIOUS, HAPPY
 
 NAV = const(0)  # config.ENC_NAV
+
+# Full colour names for buttons 0–3 (matches BTN_COLORS order).
+# BTN_NAMES in theme.py is a 3-char abbreviation sized for Mystery's
+# narrow 8-cell row; here we want the readable word.
+_COLOR_KEYS = ("color_green", "color_blue", "color_white", "color_yellow")
 
 # Map game states to cat emotions
 _STATE_EMOTIONS = {
@@ -89,8 +94,8 @@ class RuleFollowScreen(Screen):
         neo.clear_all_overrides()
         # Pre-cache RGB565 conversions (avoids theme.rgb() calls per render)
         rgb = manager.theme.rgb
-        self._rule_565 = {r: rgb(*RULE_COLORS[r]) for r in RULE_COLORS}
-        self._btn_565 = [rgb(*BTN_COLORS[i]) for i in range(NUM_BUTTONS)]
+        self._rule_565 = [rgb(*c) for c in RULE_COLORS]
+        self._btn_565 = [rgb(*c) for c in BTN_COLORS]
 
     def exit(self):
         neo.all_off()
@@ -334,24 +339,20 @@ class RuleFollowScreen(Screen):
             by = 24
             tft.fill_rect(bx, by, block_size, block_size, stim_color)
 
-            # Button grid below
+            # Button swatches below — colour circles matching the physical
+            # cap colours 1:1. No text labels: the child matches by colour.
             btn_y = by + block_size + 12
-            btn_names = theme.BTN_NAMES[:NUM_BUTTONS]
-            btn_held = held[:NUM_BUTTONS]
-            cell_w = w // 4 - 4
-            cell_h = h - btn_y - 20
-            btn_x0 = (w - 4 * cell_w) // 2
-            draw_button_grid(
-                tft,
-                theme,
-                btn_names,
-                btn_held,
-                cols=4,
-                x0=btn_x0,
-                y0=btn_y,
-                cell_w=cell_w,
-                cell_h=cell_h,
-            )
+            cell_w = w // NUM_BUTTONS
+            cell_h = h - btn_y - 24
+            r = min(cell_w, cell_h) // 2 - 4
+            cy = btn_y + cell_h // 2
+            for i in range(NUM_BUTTONS):
+                cx = i * cell_w + cell_w // 2
+                color = self._btn_565[i]
+                if i < len(held) and held[i]:
+                    fill_circle(tft, cx, cy, r, color)
+                else:
+                    draw_circle(tft, cx, cy, r, color)
 
             # Score bar
             tft.fill_rect(0, h - 18, w, 18, theme.BLACK)
@@ -391,7 +392,7 @@ class RuleFollowScreen(Screen):
                 )
                 draw_centered(
                     tft,
-                    theme.BTN_NAMES[eng.correct_button],
+                    t(_COLOR_KEYS[eng.correct_button]),
                     h // 2 + block // 2 + 8,
                     theme.WHITE,
                     w,


### PR DESCRIPTION
## Summary

Three bugs in Rule Follow, all surfaced during one play session.

**1. Restart left the GAME_OVER screen on display.** \`enter()\` built the
RGB565 cache with \`{r: rgb(*RULE_COLORS[r]) for r in RULE_COLORS}\` —
\`for r in RULE_COLORS\` iterates tuples, then \`RULE_COLORS[r]\` indexes
the list with a tuple and raises \`TypeError: list indices must be
integers, not tuple\`. \`enter()\` aborted with \`_rule_565 = None\`, so
every subsequent render of an active state failed mid-\`_render_game\`.
The \`tft.fill(BLACK)\` happened in the framebuffer, but the exception
prevented \`show_dirty()\` from pushing it, so the score + "Bra jobbat!"
stayed visible. The home screen captured the original error and showed
it on return — that's the "list of indices must be integers, not tuples"
error you saw on exit. Fixed by switching to a list comprehension over
the tuples directly.

**2. Only yellow guessed correctly.** \`BTN_COLORS\` was
red/green/blue/yellow, but the physical mini-button caps at indices 0–3
are green/blue/white/yellow. Only yellow happened to align, so matching
worked only for that cap. Aligned the engine palette to the physical
caps (matching \`theme.BTN_RGB[:4]\`).

**3. Cut-off labels.** The WRONG screen used \`theme.BTN_NAMES\`, which
is the 3-char abbreviation sized for Mystery's narrow 8-cell row — in
Swedish that's literally "Grö" (the "n" is cut off). Switched to the
existing \`color_*\` i18n keys for the full word ("Grön", "Blå", etc.).
Replaced the 4-cell button grid in STIMULUS with a row of colour
circles (Simon-style); labels were only shown while held and the
colour itself is what the child matches.

## Test plan

- [ ] Enter Rule Follow, play to GAME_OVER, press a cap to restart — the score/"Bra jobbat!" should clear and SHOW_RULE should render
- [ ] Quit via pause menu — no error on home screen on return
- [ ] In match mode, each of the 4 active caps (green, blue, white, yellow) should register correctly when its colour is the stimulus
- [ ] In opposite mode, diagonal swap green↔white, blue↔yellow
- [ ] WRONG screen shows the full Swedish colour name ("Grön" not "Grö")

🤖 Generated with [Claude Code](https://claude.com/claude-code)