### PR TITLE
audio: click-free crossfades, GC stalls, and follow-up fixes

### DIFF
--- a/cmodules/audiomix/audiomix.c
+++ b/cmodules/audiomix/audiomix.c
@@ -127,12 +127,16 @@ static mp_obj_t audiomix_voice_tone(size_t n_args, const mp_obj_t *args) {
     uint32_t samples = (audiomix_state->sample_rate * dur_ms) / 1000;
 
     if (fade && (v->source_type == SRC_BUFFER || v->source_type == SRC_TONE)) {
+        // TONE pending uses the sequential fade-out path; setting up a
+        // simultaneous-read pending tone (with its own modulation/LFO state)
+        // would be considerably more code for an edge case.
         v->writing = 1;
         v->pending_source = SRC_TONE;
         v->pending_tone_freq = freq;
         v->pending_tone_samples = samples;
         v->pending_tone_wave = (uint8_t)wave;
         v->fade_out = 1;
+        v->xfade_samples_left = 0;
         v->stop_req = 0;
         v->writing = 0;
         return mp_const_none;
@@ -141,6 +145,7 @@ static mp_obj_t audiomix_voice_tone(size_t n_args, const mp_obj_t *args) {
     v->writing = 1;
     v->source_type = SRC_NONE;
     v->pending_source = SRC_NONE;
+    v->xfade_samples_left = 0;
     v->tone_freq = freq;
     v->tone_samples_left = samples;
     v->tone_phase = 0;
@@ -325,16 +330,26 @@ static mp_obj_t audiomix_voice_play_buffer(size_t n_args, const mp_obj_t *args) 
 
     audiomix_voice_t *v = &audiomix_state->voices[idx];
 
-    // Fade-and-swap path: existing source plays out a short fade-out, then
-    // the mixer activates the pending source with its own fade-in. Avoids
-    // the click that an instantaneous swap would produce.
+    // Fade-and-swap path: avoid the click that an instantaneous source
+    // change would produce.
+    //   BUFFER → BUFFER: equal-power crossfade (xfade_samples_left).
+    //   TONE   → BUFFER: sequential — old source faded out over 1 ms, then
+    //                    mixer activates pending with its own fade_in.
     if (fade && (v->source_type == SRC_BUFFER || v->source_type == SRC_TONE)) {
         v->writing = 1;
         v->pending_source = SRC_BUFFER;
         v->pending_buf_ptr = bufinfo.buf;
         v->pending_buf_len = n_bytes;
+        v->pending_buf_pos = 0;
         v->pending_loop = loop ? 1 : 0;
-        v->fade_out = 1;
+        if (v->source_type == SRC_BUFFER) {
+            v->xfade_samples_total = AUDIOMIX_XFADE_SAMPLES;
+            v->xfade_samples_left = AUDIOMIX_XFADE_SAMPLES;
+            v->fade_out = 0;
+        } else {
+            v->fade_out = 1;
+            v->xfade_samples_left = 0;
+        }
         v->stop_req = 0;
         v->writing = 0;
         return mp_const_none;
@@ -343,6 +358,7 @@ static mp_obj_t audiomix_voice_play_buffer(size_t n_args, const mp_obj_t *args) 
     v->writing = 1;
     v->source_type = SRC_NONE;
     v->pending_source = SRC_NONE;  // discard any older pending swap
+    v->xfade_samples_left = 0;
     v->buf_ptr = bufinfo.buf;
     v->buf_len = n_bytes;
     v->buf_pos = 0;

--- a/cmodules/audiomix/audiomix.c
+++ b/cmodules/audiomix/audiomix.c
@@ -338,27 +338,27 @@ static mp_obj_t audiomix_voice_play_buffer(size_t n_args, const mp_obj_t *args) 
     if (fade && (v->source_type == SRC_BUFFER || v->source_type == SRC_TONE)) {
         v->writing = 1;
         if (v->source_type == SRC_BUFFER && v->xfade_samples_left > 0) {
-            // A crossfade is already in flight — just retarget the pending
-            // buffer without resetting xfade_samples_left. The old keeps
-            // fading out exactly as it was; the rising "new" weight now
-            // mixes the latest target instead of the now-stale one. No
-            // amplitude discontinuity, just a brief timbre change as the
-            // sin²(t) weight applies to a different signal.
+            // A crossfade is already in flight. Substituting pending_*
+            // in place would discontinuously change the signal that the
+            // rising sin²(t) weight is mixing — buffer B's mid-loop
+            // sample suddenly becomes buffer C's start-of-loop sample,
+            // producing a click at high weight values.
             //
-            // Without this, fast zone changes (e.g. throttle spun quickly
-            // through two drone zones) produce an audible click because
-            // the mid-fade output (≈0.5×old + 0.5×first-new) jumps back
-            // to 1.0×old when the crossfade restarts at t=0.
-            v->pending_buf_ptr = bufinfo.buf;
-            v->pending_buf_len = n_bytes;
-            v->pending_buf_pos = 0;
-            v->pending_loop = loop ? 1 : 0;
+            // Queue the new target instead. The mixer activates it as
+            // the new pending the moment the current crossfade promotes
+            // (xfade_samples_left == 0). Subsequent retargets just
+            // overwrite this slot, so the latest target wins.
+            v->next_pending_buf_ptr = bufinfo.buf;
+            v->next_pending_buf_len = n_bytes;
+            v->next_pending_loop = loop ? 1 : 0;
+            v->next_pending_set = 1;
         } else {
             v->pending_source = SRC_BUFFER;
             v->pending_buf_ptr = bufinfo.buf;
             v->pending_buf_len = n_bytes;
             v->pending_buf_pos = 0;
             v->pending_loop = loop ? 1 : 0;
+            v->next_pending_set = 0;
             if (v->source_type == SRC_BUFFER) {
                 v->xfade_samples_total = AUDIOMIX_XFADE_SAMPLES;
                 v->xfade_samples_left = AUDIOMIX_XFADE_SAMPLES;
@@ -376,6 +376,7 @@ static mp_obj_t audiomix_voice_play_buffer(size_t n_args, const mp_obj_t *args) 
     v->writing = 1;
     v->source_type = SRC_NONE;
     v->pending_source = SRC_NONE;  // discard any older pending swap
+    v->next_pending_set = 0;
     v->xfade_samples_left = 0;
     v->buf_ptr = bufinfo.buf;
     v->buf_len = n_bytes;

--- a/cmodules/audiomix/audiomix.c
+++ b/cmodules/audiomix/audiomix.c
@@ -337,18 +337,36 @@ static mp_obj_t audiomix_voice_play_buffer(size_t n_args, const mp_obj_t *args) 
     //                    mixer activates pending with its own fade_in.
     if (fade && (v->source_type == SRC_BUFFER || v->source_type == SRC_TONE)) {
         v->writing = 1;
-        v->pending_source = SRC_BUFFER;
-        v->pending_buf_ptr = bufinfo.buf;
-        v->pending_buf_len = n_bytes;
-        v->pending_buf_pos = 0;
-        v->pending_loop = loop ? 1 : 0;
-        if (v->source_type == SRC_BUFFER) {
-            v->xfade_samples_total = AUDIOMIX_XFADE_SAMPLES;
-            v->xfade_samples_left = AUDIOMIX_XFADE_SAMPLES;
-            v->fade_out = 0;
+        if (v->source_type == SRC_BUFFER && v->xfade_samples_left > 0) {
+            // A crossfade is already in flight — just retarget the pending
+            // buffer without resetting xfade_samples_left. The old keeps
+            // fading out exactly as it was; the rising "new" weight now
+            // mixes the latest target instead of the now-stale one. No
+            // amplitude discontinuity, just a brief timbre change as the
+            // sin²(t) weight applies to a different signal.
+            //
+            // Without this, fast zone changes (e.g. throttle spun quickly
+            // through two drone zones) produce an audible click because
+            // the mid-fade output (≈0.5×old + 0.5×first-new) jumps back
+            // to 1.0×old when the crossfade restarts at t=0.
+            v->pending_buf_ptr = bufinfo.buf;
+            v->pending_buf_len = n_bytes;
+            v->pending_buf_pos = 0;
+            v->pending_loop = loop ? 1 : 0;
         } else {
-            v->fade_out = 1;
-            v->xfade_samples_left = 0;
+            v->pending_source = SRC_BUFFER;
+            v->pending_buf_ptr = bufinfo.buf;
+            v->pending_buf_len = n_bytes;
+            v->pending_buf_pos = 0;
+            v->pending_loop = loop ? 1 : 0;
+            if (v->source_type == SRC_BUFFER) {
+                v->xfade_samples_total = AUDIOMIX_XFADE_SAMPLES;
+                v->xfade_samples_left = AUDIOMIX_XFADE_SAMPLES;
+                v->fade_out = 0;
+            } else {
+                v->fade_out = 1;
+                v->xfade_samples_left = 0;
+            }
         }
         v->stop_req = 0;
         v->writing = 0;

--- a/cmodules/audiomix/audiomix.c
+++ b/cmodules/audiomix/audiomix.c
@@ -103,7 +103,10 @@ static mp_obj_t audiomix_get_volume(void) {
 static MP_DEFINE_CONST_FUN_OBJ_0(audiomix_get_volume_obj, audiomix_get_volume);
 
 // ---------------------------------------------------------------------------
-// _audiomix.voice_tone(idx, freq_hz, duration_ms, wave)
+// _audiomix.voice_tone(idx, freq_hz, duration_ms, wave, fade=0)
+//
+// fade: 1 = pend a fade-out then swap (only when an existing source is
+// playing); 0 = immediate swap (legacy).
 // ---------------------------------------------------------------------------
 
 static mp_obj_t audiomix_voice_tone(size_t n_args, const mp_obj_t *args) {
@@ -118,12 +121,28 @@ static mp_obj_t audiomix_voice_tone(size_t n_args, const mp_obj_t *args) {
     uint32_t freq     = mp_obj_get_int(args[1]);
     uint32_t dur_ms   = mp_obj_get_int(args[2]);
     uint32_t wave     = mp_obj_get_int(args[3]);
+    bool fade = (n_args >= 5) && mp_obj_is_true(args[4]);
 
     audiomix_voice_t *v = &audiomix_state->voices[idx];
+    uint32_t samples = (audiomix_state->sample_rate * dur_ms) / 1000;
+
+    if (fade && (v->source_type == SRC_BUFFER || v->source_type == SRC_TONE)) {
+        v->writing = 1;
+        v->pending_source = SRC_TONE;
+        v->pending_tone_freq = freq;
+        v->pending_tone_samples = samples;
+        v->pending_tone_wave = (uint8_t)wave;
+        v->fade_out = 1;
+        v->stop_req = 0;
+        v->writing = 0;
+        return mp_const_none;
+    }
+
     v->writing = 1;
     v->source_type = SRC_NONE;
+    v->pending_source = SRC_NONE;
     v->tone_freq = freq;
-    v->tone_samples_left = (audiomix_state->sample_rate * dur_ms) / 1000;
+    v->tone_samples_left = samples;
     v->tone_phase = 0;
     v->tone_lfsr = 0xACE1;
     v->tone_wave = wave;
@@ -133,6 +152,7 @@ static mp_obj_t audiomix_voice_tone(size_t n_args, const mp_obj_t *args) {
     v->env_total_samples = 0;
     v->loop = 0;
     v->fade_in = 1;
+    v->fade_out = 0;
     v->stop_req = 0;
     // Clear any modulation state so a fresh one-shot starts clean.
     v->mod_lfo_pitch_rate_cHz = 0;
@@ -155,7 +175,7 @@ static mp_obj_t audiomix_voice_tone(size_t n_args, const mp_obj_t *args) {
 
     return mp_const_none;
 }
-static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiomix_voice_tone_obj, 4, 4,
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiomix_voice_tone_obj, 4, 5,
                                             audiomix_voice_tone);
 
 // ---------------------------------------------------------------------------
@@ -279,7 +299,12 @@ static mp_obj_t audiomix_voice_eof(mp_obj_t idx_obj) {
 static MP_DEFINE_CONST_FUN_OBJ_1(audiomix_voice_eof_obj, audiomix_voice_eof);
 
 // ---------------------------------------------------------------------------
-// _audiomix.voice_play_buffer(idx, buf, n_bytes, loop)
+// _audiomix.voice_play_buffer(idx, buf, n_bytes, loop, fade=0)
+//
+// fade: 1 = pend a fade-out then swap (only when an existing source is
+// playing); 0 = immediate swap (legacy).  The actual fade length is fixed
+// at AUDIOMIX_FADE_SAMPLES; the argument is a boolean-ish toggle so callers
+// can opt out for low-latency SFX.
 // ---------------------------------------------------------------------------
 
 static mp_obj_t audiomix_voice_play_buffer(size_t n_args, const mp_obj_t *args) {
@@ -296,15 +321,34 @@ static mp_obj_t audiomix_voice_play_buffer(size_t n_args, const mp_obj_t *args) 
     uint32_t n_bytes = mp_obj_get_int(args[2]);
     if (n_bytes > bufinfo.len) n_bytes = bufinfo.len;
     bool loop = mp_obj_is_true(args[3]);
+    bool fade = (n_args >= 5) && mp_obj_is_true(args[4]);
 
     audiomix_voice_t *v = &audiomix_state->voices[idx];
+
+    // Fade-and-swap path: existing source plays out a short fade-out, then
+    // the mixer activates the pending source with its own fade-in. Avoids
+    // the click that an instantaneous swap would produce.
+    if (fade && (v->source_type == SRC_BUFFER || v->source_type == SRC_TONE)) {
+        v->writing = 1;
+        v->pending_source = SRC_BUFFER;
+        v->pending_buf_ptr = bufinfo.buf;
+        v->pending_buf_len = n_bytes;
+        v->pending_loop = loop ? 1 : 0;
+        v->fade_out = 1;
+        v->stop_req = 0;
+        v->writing = 0;
+        return mp_const_none;
+    }
+
     v->writing = 1;
     v->source_type = SRC_NONE;
+    v->pending_source = SRC_NONE;  // discard any older pending swap
     v->buf_ptr = bufinfo.buf;
     v->buf_len = n_bytes;
     v->buf_pos = 0;
     v->loop = loop ? 1 : 0;
     v->fade_in = 1;
+    v->fade_out = 0;
     v->stop_req = 0;
     audiomix_state->seq_counter++;
     v->start_seq = audiomix_state->seq_counter;
@@ -313,7 +357,7 @@ static mp_obj_t audiomix_voice_play_buffer(size_t n_args, const mp_obj_t *args) 
 
     return mp_const_none;
 }
-static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiomix_voice_play_buffer_obj, 4, 4,
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiomix_voice_play_buffer_obj, 4, 5,
                                             audiomix_voice_play_buffer);
 
 // ---------------------------------------------------------------------------

--- a/cmodules/audiomix/audiomix.h
+++ b/cmodules/audiomix/audiomix.h
@@ -39,6 +39,13 @@
 // Fade length in samples
 #define AUDIOMIX_FADE_SAMPLES   16  // 1ms @ 16kHz
 
+// Source-swap crossfade length: BUFFER → BUFFER swaps overlap the old
+// source's fade-out with the new source's fade-in over this many samples
+// using equal-power (cos²/sin²) weights. 80 samples = 5 ms at 16 kHz —
+// long enough that the brain stops perceiving a transition, short enough
+// to feel instantaneous.
+#define AUDIOMIX_XFADE_SAMPLES  80
+
 // Waveform crossfade length (samples) for phase-preserving tone_wave swaps.
 // 48 ≈ 3ms at 16kHz — short enough to feel "instant", long enough to mask
 // the sample-value jump between differently-shaped oscillators.
@@ -150,17 +157,25 @@ typedef struct {
     uint32_t buf_len;                   // total bytes
     volatile uint32_t buf_pos;          // current read offset (core 1 advances)
 
-    // Pending source — captured by Python when fading out the current source.
-    // The mixer's fade_out handler reads these fields after the fade chunk
-    // and activates the new source instead of going to SRC_NONE. SRC_NONE in
-    // pending_source = no pending swap.
+    // Pending source — captured by Python when swapping a BUFFER/TONE
+    // source on a held voice. Two activation paths:
+    //   - xfade_samples_left > 0: equal-power crossfade with the current
+    //     source over xfade_samples_total samples (BUFFER → BUFFER only).
+    //   - fade_out = 1: sequential 1 ms fade-out of the current source,
+    //     then immediate activation of pending (used for any → TONE and
+    //     for TONE → BUFFER, where simultaneous read of both sources
+    //     would be more code than the seam is worth).
+    // SRC_NONE in pending_source = no pending swap.
     volatile audiomix_source_t pending_source;
     volatile uint8_t  pending_loop;
     const uint8_t    *pending_buf_ptr;
     uint32_t          pending_buf_len;
+    volatile uint32_t pending_buf_pos;     // mixer advances during crossfade
     uint32_t          pending_tone_freq;
     uint32_t          pending_tone_samples;
     uint8_t           pending_tone_wave;
+    volatile uint32_t xfade_samples_left;  // 0 = no crossfade in progress
+    uint32_t          xfade_samples_total; // for weight = i/total mapping
 
     // Age tracking for voice stealing
     volatile uint32_t start_seq;

--- a/cmodules/audiomix/audiomix.h
+++ b/cmodules/audiomix/audiomix.h
@@ -16,7 +16,13 @@
 
 #define AUDIOMIX_NUM_VOICES     16
 
-#define AUDIOMIX_RINGBUF_SIZE   2048  // bytes per voice (64ms @ 16kHz mono 16-bit)
+// Per-voice ring buffer for SRC_RINGBUF (streamed WAV) sources. The buffer
+// must be large enough to ride out the longest stall of the Python feeder
+// task on core 1 -- i.e. the worst slow frame from rendering, GC, or SD
+// contention. 8192 bytes = 256 ms at 16 kHz mono 16-bit, comfortably
+// above the 80-200 ms slow frames seen during scenario transitions.
+// PSRAM cost: 16 voices × 8 KB = 128 KB (negligible on the 8 MB part).
+#define AUDIOMIX_RINGBUF_SIZE   8192
 #define AUDIOMIX_MONO_BUF_SIZE  512   // bytes per mono read (256 samples = 16ms)
 
 // Scope tap: post-mix mono samples captured for visualisation.

--- a/cmodules/audiomix/audiomix.h
+++ b/cmodules/audiomix/audiomix.h
@@ -150,6 +150,18 @@ typedef struct {
     uint32_t buf_len;                   // total bytes
     volatile uint32_t buf_pos;          // current read offset (core 1 advances)
 
+    // Pending source — captured by Python when fading out the current source.
+    // The mixer's fade_out handler reads these fields after the fade chunk
+    // and activates the new source instead of going to SRC_NONE. SRC_NONE in
+    // pending_source = no pending swap.
+    volatile audiomix_source_t pending_source;
+    volatile uint8_t  pending_loop;
+    const uint8_t    *pending_buf_ptr;
+    uint32_t          pending_buf_len;
+    uint32_t          pending_tone_freq;
+    uint32_t          pending_tone_samples;
+    uint8_t           pending_tone_wave;
+
     // Age tracking for voice stealing
     volatile uint32_t start_seq;
 } audiomix_voice_t;

--- a/cmodules/audiomix/audiomix.h
+++ b/cmodules/audiomix/audiomix.h
@@ -47,10 +47,14 @@
 
 // Source-swap crossfade length: BUFFER → BUFFER swaps overlap the old
 // source's fade-out with the new source's fade-in over this many samples
-// using equal-power (cos²/sin²) weights. 80 samples = 5 ms at 16 kHz —
-// long enough that the brain stops perceiving a transition, short enough
-// to feel instantaneous.
-#define AUDIOMIX_XFADE_SAMPLES  80
+// using equal-power (cos²/sin²) weights. 240 samples = 15 ms at 16 kHz.
+//
+// 5 ms (80) was mathematically click-free but a few spectrally dissimilar
+// pairs (low-engine-loop ↔ high-engine-loop) still produced a perceptible
+// morph at that length. 15 ms eliminates the seam entirely without
+// feeling laggy as a control response. PSRAM cost is one stack-resident
+// scratch of 2 × XFADE_SAMPLES bytes per active crossfade.
+#define AUDIOMIX_XFADE_SAMPLES  240
 
 // Waveform crossfade length (samples) for phase-preserving tone_wave swaps.
 // 48 ≈ 3ms at 16kHz — short enough to feel "instant", long enough to mask

--- a/cmodules/audiomix/audiomix.h
+++ b/cmodules/audiomix/audiomix.h
@@ -187,6 +187,18 @@ typedef struct {
     volatile uint32_t xfade_samples_left;  // 0 = no crossfade in progress
     uint32_t          xfade_samples_total; // for weight = i/total mapping
 
+    // "Next pending" — set by Python when a fade=True swap arrives while
+    // an existing crossfade is still in flight. Substituting pending_* in
+    // place would jump the rising-weight signal mid-mix and produce a
+    // click; instead we queue here, and the mixer activates this as the
+    // new pending the moment the current crossfade completes. Multiple
+    // retargets in quick succession overwrite each other so only the
+    // latest target wins.
+    volatile uint8_t  next_pending_set;
+    const uint8_t    *next_pending_buf_ptr;
+    uint32_t          next_pending_buf_len;
+    uint8_t           next_pending_loop;
+
     // Age tracking for voice stealing
     volatile uint32_t start_seq;
 } audiomix_voice_t;

--- a/cmodules/audiomix/mixer.c
+++ b/cmodules/audiomix/mixer.c
@@ -592,14 +592,58 @@ static void mix_task(void *arg) {
 
             uint32_t n;
             if (v->fade_out) {
-                // Read just enough for a fade-out ramp, then kill voice
+                // Read just enough for a fade-out ramp, then kill voice or
+                // activate the pending source if one was queued by Python
+                // via voice_play_buffer/voice_tone(..., fade=True).
                 n = voice_read(state, v, voice_buf, AUDIOMIX_FADE_SAMPLES);
                 if (n > 0) {
                     tonegen_fade(voice_buf, n, 0, 1, AUDIOMIX_FADE_SAMPLES);
                 }
                 v->fade_out = 0;
-                v->source_type = SRC_NONE;
-                ringbuf_reset(&v->ringbuf);
+                if (v->pending_source == SRC_BUFFER) {
+                    v->buf_ptr = v->pending_buf_ptr;
+                    v->buf_len = v->pending_buf_len;
+                    v->buf_pos = 0;
+                    v->loop = v->pending_loop;
+                    v->fade_in = 1;
+                    state->seq_counter++;
+                    v->start_seq = state->seq_counter;
+                    v->pending_source = SRC_NONE;
+                    v->source_type = SRC_BUFFER;
+                } else if (v->pending_source == SRC_TONE) {
+                    v->tone_freq = v->pending_tone_freq;
+                    v->tone_samples_left = v->pending_tone_samples;
+                    v->tone_phase = 0;
+                    v->tone_lfsr = 0xACE1;
+                    v->tone_wave = v->pending_tone_wave;
+                    v->tone_wave_pending = v->pending_tone_wave;
+                    v->tone_wave_xfade_left = 0;
+                    v->tone_sustain = 0;
+                    v->env_total_samples = 0;
+                    v->loop = 0;
+                    v->fade_in = 1;
+                    // Reset modulation so a fresh tone starts clean.
+                    v->mod_lfo_pitch_rate_cHz = 0;
+                    v->mod_lfo_pitch_depth_cents = 0;
+                    v->mod_lfo_pitch_phase = 0;
+                    v->mod_lfo_amp_rate_cHz = 0;
+                    v->mod_lfo_amp_depth_q15 = 0;
+                    v->mod_lfo_amp_phase = 0;
+                    v->mod_bend_cents_per_s = 0;
+                    v->mod_bend_current_cents = 0;
+                    v->mod_bend_limit_cents = 0;
+                    v->mod_stutter_rate_cHz = 0;
+                    v->mod_stutter_duty_q15 = 0;
+                    v->mod_stutter_phase = 0;
+                    v->mod_stutter_gate_q15 = 32767;
+                    state->seq_counter++;
+                    v->start_seq = state->seq_counter;
+                    v->pending_source = SRC_NONE;
+                    v->source_type = SRC_TONE;
+                } else {
+                    v->source_type = SRC_NONE;
+                    ringbuf_reset(&v->ringbuf);
+                }
             } else {
                 n = voice_read(state, v, voice_buf, max_samples);
             }

--- a/cmodules/audiomix/mixer.c
+++ b/cmodules/audiomix/mixer.c
@@ -654,10 +654,26 @@ static void mix_task(void *arg) {
                     v->loop = v->pending_loop;
                     v->fade_in = 0;        // already at full amplitude
                     v->fade_out = 0;
-                    v->pending_source = SRC_NONE;
                     state->seq_counter++;
                     v->start_seq = state->seq_counter;
                     // source_type stays SRC_BUFFER throughout
+
+                    // If Python queued another retarget while this crossfade
+                    // was in flight, activate it now as the new pending and
+                    // start a fresh crossfade. Chains cleanly through any
+                    // number of rapid zone changes without ever clicking.
+                    if (v->next_pending_set) {
+                        v->pending_buf_ptr = v->next_pending_buf_ptr;
+                        v->pending_buf_len = v->next_pending_buf_len;
+                        v->pending_buf_pos = 0;
+                        v->pending_loop = v->next_pending_loop;
+                        v->next_pending_set = 0;
+                        v->xfade_samples_total = AUDIOMIX_XFADE_SAMPLES;
+                        v->xfade_samples_left = AUDIOMIX_XFADE_SAMPLES;
+                        // pending_source stays SRC_BUFFER
+                    } else {
+                        v->pending_source = SRC_NONE;
+                    }
                 }
             } else if (v->fade_out) {
                 // Read just enough for a fade-out ramp, then kill voice or

--- a/cmodules/audiomix/mixer.c
+++ b/cmodules/audiomix/mixer.c
@@ -591,7 +591,75 @@ static void mix_task(void *arg) {
             if (v->source_type == SRC_NONE || v->writing) continue;
 
             uint32_t n;
-            if (v->fade_out) {
+            if (v->xfade_samples_left > 0 && v->pending_source == SRC_BUFFER
+                    && v->source_type == SRC_BUFFER) {
+                // BUFFER → BUFFER equal-power crossfade. Read xfade_n samples
+                // from the active source and the pending source in parallel,
+                // mix them with cos²/sin² weights so total power stays flat
+                // through the transition. When xfade_samples_left hits zero,
+                // promote pending → active in place.
+                uint32_t xfade_n = v->xfade_samples_left;
+                if (xfade_n > max_samples) xfade_n = max_samples;
+
+                int16_t scratch_b[AUDIOMIX_XFADE_SAMPLES];
+                uint32_t na = voice_read(state, v, voice_buf, xfade_n);
+
+                uint32_t nb = 0;
+                if (v->pending_buf_ptr != NULL && v->pending_buf_len > 0) {
+                    uint32_t max_bytes = xfade_n * 2;
+                    uint32_t remaining = v->pending_buf_len - v->pending_buf_pos;
+                    uint32_t to_copy = (remaining < max_bytes) ? remaining : max_bytes;
+                    to_copy = (to_copy / 2) * 2;
+                    if (to_copy > 0) {
+                        memcpy(scratch_b, v->pending_buf_ptr + v->pending_buf_pos, to_copy);
+                        v->pending_buf_pos += to_copy;
+                        nb = to_copy / 2;
+                    }
+                    if (v->pending_buf_pos >= v->pending_buf_len && v->pending_loop) {
+                        v->pending_buf_pos = 0;
+                    }
+                }
+
+                uint32_t produced = (na > nb) ? na : nb;
+                uint32_t total = v->xfade_samples_total;
+                if (total == 0) total = 1;
+                uint32_t done = total - v->xfade_samples_left;
+                for (uint32_t i = 0; i < produced; i++) {
+                    // Quarter-cycle phase: t_phase = (done+i) / total * 16384
+                    // (Q16 phase units; full cycle = 65536, quarter = 16384).
+                    uint32_t t_phase = ((done + i) * 16384u) / total;
+                    if (t_phase > 16384u) t_phase = 16384u;
+                    int16_t a = (i < na) ? voice_buf[i] : 0;
+                    int16_t b = (i < nb) ? scratch_b[i] : 0;
+                    int16_t wb = tonegen_lfo_sine(t_phase);             // sin(t·π/2)
+                    int16_t wa = tonegen_lfo_sine(t_phase + 16384u);    // cos(t·π/2)
+                    int32_t mix = ((int32_t)a * wa + (int32_t)b * wb) >> 15;
+                    // Equal-power weights can sum to ~1.414× when sources are
+                    // correlated (e.g. same loop crossfading to itself).
+                    // Saturate to int16 to avoid wraparound on the cast.
+                    if (mix > 32767) mix = 32767;
+                    else if (mix < -32768) mix = -32768;
+                    voice_buf[i] = (int16_t)mix;
+                }
+                n = produced;
+                v->xfade_samples_left -= produced;
+
+                if (v->xfade_samples_left == 0) {
+                    // Promote pending to active. The new buf_pos continues from
+                    // where the crossfade left it so the new source is sample-
+                    // accurate (no skip when the splice ends).
+                    v->buf_ptr = v->pending_buf_ptr;
+                    v->buf_len = v->pending_buf_len;
+                    v->buf_pos = v->pending_buf_pos;
+                    v->loop = v->pending_loop;
+                    v->fade_in = 0;        // already at full amplitude
+                    v->fade_out = 0;
+                    v->pending_source = SRC_NONE;
+                    state->seq_counter++;
+                    v->start_seq = state->seq_counter;
+                    // source_type stays SRC_BUFFER throughout
+                }
+            } else if (v->fade_out) {
                 // Read just enough for a fade-out ramp, then kill voice or
                 // activate the pending source if one was queued by Python
                 // via voice_play_buffer/voice_tone(..., fade=True).
@@ -603,7 +671,7 @@ static void mix_task(void *arg) {
                 if (v->pending_source == SRC_BUFFER) {
                     v->buf_ptr = v->pending_buf_ptr;
                     v->buf_len = v->pending_buf_len;
-                    v->buf_pos = 0;
+                    v->buf_pos = v->pending_buf_pos;
                     v->loop = v->pending_loop;
                     v->fade_in = 1;
                     state->seq_counter++;

--- a/cmodules/mcpinput/mcpinput.c
+++ b/cmodules/mcpinput/mcpinput.c
@@ -114,6 +114,10 @@ static MP_DEFINE_CONST_FUN_OBJ_0(mcpinput_suppress_held_obj, mcpinput_suppress_h
 
 // ---------------------------------------------------------------------------
 // _mcpinput.get_events() -> list of (type, pin, time_ms) tuples
+//
+// Allocates a fresh list every call -- convenient but wasteful when polled
+// at 200 Hz from an idle device (~40 bytes per call even when empty).
+// Use drain_events(buf) below for the hot path.
 // ---------------------------------------------------------------------------
 
 static mp_obj_t mcpinput_get_events(void) {
@@ -146,6 +150,52 @@ static mp_obj_t mcpinput_get_events(void) {
     return list;
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(mcpinput_get_events_obj, mcpinput_get_events);
+
+// ---------------------------------------------------------------------------
+// _mcpinput.drain_events(list) -> int (count drained)
+//
+// Zero-allocation steady-state: clears `list` and appends one tuple per
+// pending event. When the device is idle (the common case) the list stays
+// empty and no allocations happen at all. Tuples are still allocated when
+// events fire, but those are bursts bounded by physical input rate, not
+// the 200 Hz polling rate.
+//
+// The caller owns `list` and reuses it across calls; MicroPython lists keep
+// their backing array on .clear(), so once it's grown to handle a typical
+// burst the storage is reused indefinitely.
+// ---------------------------------------------------------------------------
+
+static mp_obj_t mcpinput_drain_events(mp_obj_t list_obj) {
+    mp_obj_list_t *list = MP_OBJ_TO_PTR(list_obj);
+    if (!mp_obj_is_type(list_obj, &mp_type_list)) {
+        mp_raise_TypeError(MP_ERROR_TEXT("expected list"));
+    }
+    list->len = 0;  // .clear() without freeing the backing array
+
+    if (mcpinput_state == NULL) {
+        return mp_obj_new_int(0);
+    }
+
+    mcpinput_eventbuf_t *eb = &mcpinput_state->events;
+    uint32_t rd = eb->rd;
+    uint32_t wr = eb->wr;
+    uint32_t count = (wr - rd) & (MCPINPUT_EVENT_BUF_SIZE - 1);
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint32_t idx = (rd + i) & (MCPINPUT_EVENT_BUF_SIZE - 1);
+        mcpinput_event_t *ev = &eb->events[idx];
+        mp_obj_t tuple[3] = {
+            mp_obj_new_int(ev->type),
+            mp_obj_new_int(ev->pin),
+            mp_obj_new_int(ev->time_ms),
+        };
+        mp_obj_list_append(list_obj, mp_obj_new_tuple(3, tuple));
+    }
+
+    eb->rd = wr;
+    return mp_obj_new_int(count);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(mcpinput_drain_events_obj, mcpinput_drain_events);
 
 // ---------------------------------------------------------------------------
 // _mcpinput.read_state() -> int (16-bit bitmask of debounced pressed state)
@@ -534,6 +584,7 @@ static const mp_rom_map_elem_t mcpinput_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_scan_resume), MP_ROM_PTR(&mcpinput_scan_resume_obj) },
     { MP_ROM_QSTR(MP_QSTR_suppress_held), MP_ROM_PTR(&mcpinput_suppress_held_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_events),  MP_ROM_PTR(&mcpinput_get_events_obj) },
+    { MP_ROM_QSTR(MP_QSTR_drain_events), MP_ROM_PTR(&mcpinput_drain_events_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_state),  MP_ROM_PTR(&mcpinput_read_state_obj) },
     { MP_ROM_QSTR(MP_QSTR_i2c_write),   MP_ROM_PTR(&mcpinput_i2c_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_i2c_read),    MP_ROM_PTR(&mcpinput_i2c_read_obj) },

--- a/docs/PERFORMANCE_GUIDELINES.md
+++ b/docs/PERFORMANCE_GUIDELINES.md
@@ -395,6 +395,63 @@ WiFi is one of the largest power and latency contributors.
   - Prefer simple dicts, tuples, and small classes over deeply nested objects.
 - Cleanly separate **configuration data** from runtime state so saving/loading settings is cheap.
 
+### 7.1 Avoiding GC stalls
+
+MicroPython's mark-and-sweep GC stalls core 1 for 300-500 ms when the live heap is large (we run with 8 MB PSRAM). One stall is enough to underrun the I2S audio buffer (~96 ms slack), so the rule is:
+
+> **Code that runs more often than once per render frame must not allocate.**
+
+The expensive idioms are not what you'd expect — they're the convenient ones:
+
+- `enumerate(seq)` allocates a fresh iterator every call.
+- `range(n)` allocates a fresh range object every call.
+- Generator expressions (`any(d != 0 for d in xs)`) allocate the generator.
+- `any(list)` / `all(list)` allocate a list iterator.
+- `f"{x}"` and `"{}".format(x)` allocate a new string every call.
+- `bytes_obj[a:b]` allocates a new `bytes`.
+- Returning a fresh list/tuple from a C binding (`mp_obj_new_list`, `mp_obj_new_tuple`) — even an empty one is ~40 bytes.
+
+At 200 Hz (input scan rate) those add up to ~40 KB/sec, which triggers a GC sweep every ~30 s — exactly what was causing the audio crackling and the visible "frame frozen for half a second" we hunted in early 2026.
+
+**Idiom to use instead** — indexed `while` loop with cached length:
+
+```python
+# BAD — fresh iterator every call
+for i, item in enumerate(items):
+    do_something(i, item)
+
+# BAD — fresh range object + generator
+if any(x != 0 for x in items):
+    ...
+
+# GOOD — zero allocation
+n = len(items)
+i = 0
+while i < n:
+    do_something(i, items[i])
+    i += 1
+
+# GOOD — explicit early exit
+n = len(items)
+i = 0
+while i < n:
+    if items[i] != 0:
+        return True
+    i += 1
+return False
+```
+
+**For C bindings called at high rate:** accept a pre-allocated list the caller owns and clear-and-append into it. MicroPython's `list.clear()` (or setting `len = 0` from C) keeps the backing array, so once it's grown the storage is reused. See `_mcpinput.drain_events(buf)` vs `_mcpinput.get_events()` for the pattern.
+
+**For repeated strings in renders:** build them once on state transition, store as `self._foo_text = "..."`, render with the cached value. Never put `f"..."` or `.format()` in a per-frame render path.
+
+**Where the rule applies** (any of these is "hot"):
+- Async tasks polled at >= 30 Hz (`input_scan_task` at 200 Hz, `secondary_task` at 20 Hz, `primary_task` at 30 Hz).
+- Anything called from a screen's `update()` or `render()`.
+- Anything called from the audio engine's streaming feeder.
+
+**Where it does not apply:** `enter()` / `exit()`, one-time setup, error/diagnostic paths behind clearly rare conditions.
+
 ---
 
 ## 8. Logging & debugging
@@ -460,6 +517,13 @@ When generating or reviewing code, check:
 7. **Allocations**:
    - Buffers reused; no big lists created in tight loops.
    - `memoryview` used for buffer slices passed to I/O (I2S, SPI, file).
+   - **No `enumerate()` or `range()` in hot paths** (anything ≥ 30 Hz) — use
+     `n = len(seq); i = 0; while i < n: ... i += 1` to avoid per-call iterator
+     allocation. Same goes for `any(genexp)` / `all(genexp)`. See §7.1.
+   - **No `f"..."` or `.format()` in `update()` / `render()`** — build strings
+     once on state transition and cache as `self._foo_text`.
+   - C bindings called at > 30 Hz must accept a pre-allocated buffer
+     (e.g. `_mcpinput.drain_events(list)`), not return a fresh one.
 8. **MicroPython idioms**:
    - Module-level numeric constants use `const()`.
    - Hot loops / long-running coroutines cache `self.*` and module attributes as locals.

--- a/firmware/bodn/audio.py
+++ b/firmware/bodn/audio.py
@@ -57,7 +57,9 @@ CH_SFX = V_SFX_BASE
 CH_UI = V_UI
 CHANNEL_NAMES = {"music": V_MUSIC, "sfx": V_SFX_BASE, "ui": V_UI}
 
-_MONO_BUF_SIZE = const(512)  # bytes per mono read buffer (256 samples at 16-bit = 16 ms)
+_MONO_BUF_SIZE = const(
+    512
+)  # bytes per mono read buffer (256 samples at 16-bit = 16 ms)
 
 # Default gain (fixed-point 16.16) — ~70%
 _GAIN_DEFAULT = const(45875)
@@ -179,7 +181,9 @@ class ToneSource:
             return 0
         to_fill = min(len(buf), self._bytes_left)
         to_fill = (to_fill // 2) * 2
-        n, self._phase = tones.generate(buf, self.freq_hz, self.sample_rate, self.wave, self._phase)
+        n, self._phase = tones.generate(
+            buf, self.freq_hz, self.sample_rate, self.wave, self._phase
+        )
         n = min(n, to_fill)
         self._bytes_left -= n
         is_first = self._first_chunk
@@ -639,7 +643,9 @@ class AudioEngine:
         the ~40-byte-per-iter allocation that was contributing to GC
         pressure during scenarios. See PERFORMANCE_GUIDELINES.md §7.1.
         """
-        print("AudioEngine started (native, core 0, {} voices)".format(self._num_voices))
+        print(
+            "AudioEngine started (native, core 0, {} voices)".format(self._num_voices)
+        )
         sleep_ms = asyncio.sleep_ms
         _voice_active = _audiomix.voice_active
         _streaming = self._streaming

--- a/firmware/bodn/audio.py
+++ b/firmware/bodn/audio.py
@@ -415,11 +415,16 @@ class AudioEngine:
             else:
                 i += 1
 
-    def _resolve_voice(self, voice, channel):
-        """Resolve a voice= or channel= argument to a voice index."""
+    def _resolve_voice(self, voice, channel, fade=False):
+        """Resolve a voice= or channel= argument to a voice index.
+
+        ``fade=True`` skips the immediate stop on direct voice access so the
+        C mixer can do a short fade-out from the existing source before
+        activating the new one (avoids click on source swap).
+        """
         if voice is not None:
-            # Direct voice access — stop existing and return
-            self._stop_voice(voice)
+            if not fade:
+                self._stop_voice(voice)
             return voice
         return self._allocate_voice(channel or "sfx")
 
@@ -443,25 +448,47 @@ class AudioEngine:
             _audiomix.voice_stop(idx)
         return idx
 
-    def play_buffer(self, data, loop=False, channel="sfx", voice=None):
-        """Play pre-loaded PCM data (bytearray).  Returns the voice index used."""
-        idx = self._resolve_voice(voice, channel)
+    def play_buffer(self, data, loop=False, channel="sfx", voice=None, fade=True):
+        """Play pre-loaded PCM data (bytearray).  Returns the voice index used.
+
+        ``fade=True`` (default) lets the C mixer do a ~1 ms fade-out of the
+        existing source on this voice before the new buffer's fade-in, so the
+        seam is click-free. Pass ``fade=False`` for low-latency SFX where the
+        ~1 ms transition would feel laggy.
+        """
+        idx = self._resolve_voice(voice, channel, fade=fade)
         self._stop_streaming(idx)
         # Set the new buffer reference BEFORE telling C to play.
         # voice_play_buffer atomically swaps source_type via the
         # writing flag, so the mixer won't read the old buf_ptr
         # after this call.  Keeping _buf_refs[idx] = data ensures
-        # GC can't free the buffer while C is using it.
+        # GC can't free the buffer while C is using it. With fade=True,
+        # the mixer keeps reading the OLD buffer for ~1 ms during the
+        # fade-out tail; stash the old ref under a sentinel key so it
+        # stays alive across the swap.
+        if fade:
+            self._buf_refs[(idx, "fade")] = self._buf_refs.get(idx)
         self._buf_refs[idx] = data
-        _audiomix.voice_play_buffer(idx, data, len(data), loop)
+        _audiomix.voice_play_buffer(idx, data, len(data), loop, 1 if fade else 0)
         return idx
 
-    def tone(self, freq_hz, duration_ms=200, wave="square", channel="sfx", voice=None):
-        """Play a procedural tone.  Returns the voice index used."""
-        idx = self._resolve_voice(voice, channel)
+    def tone(
+        self,
+        freq_hz,
+        duration_ms=200,
+        wave="square",
+        channel="sfx",
+        voice=None,
+        fade=True,
+    ):
+        """Play a procedural tone.  Returns the voice index used.
+
+        ``fade`` semantics mirror play_buffer().
+        """
+        idx = self._resolve_voice(voice, channel, fade=fade)
         self._stop_streaming(idx)
         wave_id = _WAVE_MAP.get(wave, 0)
-        _audiomix.voice_tone(idx, freq_hz, duration_ms, wave_id)
+        _audiomix.voice_tone(idx, freq_hz, duration_ms, wave_id, 1 if fade else 0)
         return idx
 
     def play_sound(self, name, channel="ui", voice=None):

--- a/firmware/bodn/audio.py
+++ b/firmware/bodn/audio.py
@@ -57,9 +57,7 @@ CH_SFX = V_SFX_BASE
 CH_UI = V_UI
 CHANNEL_NAMES = {"music": V_MUSIC, "sfx": V_SFX_BASE, "ui": V_UI}
 
-_MONO_BUF_SIZE = const(
-    512
-)  # bytes per mono read buffer (256 samples at 16-bit = 16 ms)
+_MONO_BUF_SIZE = const(512)  # bytes per mono read buffer (256 samples at 16-bit = 16 ms)
 
 # Default gain (fixed-point 16.16) — ~70%
 _GAIN_DEFAULT = const(45875)
@@ -181,9 +179,7 @@ class ToneSource:
             return 0
         to_fill = min(len(buf), self._bytes_left)
         to_fill = (to_fill // 2) * 2
-        n, self._phase = tones.generate(
-            buf, self.freq_hz, self.sample_rate, self.wave, self._phase
-        )
+        n, self._phase = tones.generate(buf, self.freq_hz, self.sample_rate, self.wave, self._phase)
         n = min(n, to_fill)
         self._bytes_left -= n
         is_first = self._first_chunk
@@ -461,11 +457,12 @@ class AudioEngine:
         return idx
 
     def tone(self, freq_hz, duration_ms=200, wave="square", channel="sfx", voice=None):
-        """Play a procedural tone."""
+        """Play a procedural tone.  Returns the voice index used."""
         idx = self._resolve_voice(voice, channel)
         self._stop_streaming(idx)
         wave_id = _WAVE_MAP.get(wave, 0)
         _audiomix.voice_tone(idx, freq_hz, duration_ms, wave_id)
+        return idx
 
     def play_sound(self, name, channel="ui", voice=None):
         """Play a named sound from the sound design system."""
@@ -609,9 +606,7 @@ class AudioEngine:
 
     async def start(self):
         """Start the audio engine."""
-        print(
-            "AudioEngine started (native, core 0, {} voices)".format(self._num_voices)
-        )
+        print("AudioEngine started (native, core 0, {} voices)".format(self._num_voices))
         sleep_ms = asyncio.sleep_ms
         while True:
             if self._streaming:

--- a/firmware/bodn/audio.py
+++ b/firmware/bodn/audio.py
@@ -632,24 +632,46 @@ class AudioEngine:
     # -----------------------------------------------------------------------
 
     async def start(self):
-        """Start the audio engine."""
+        """Start the audio engine.
+
+        Hot path: when TTS or any streamed WAV is playing, this loop runs
+        every 16 ms. Reuses a single _dead list across iterations to avoid
+        the ~40-byte-per-iter allocation that was contributing to GC
+        pressure during scenarios. See PERFORMANCE_GUIDELINES.md §7.1.
+        """
         print("AudioEngine started (native, core 0, {} voices)".format(self._num_voices))
         sleep_ms = asyncio.sleep_ms
+        _voice_active = _audiomix.voice_active
+        _streaming = self._streaming
+        _dead = []  # reused; cleared each iteration
+        _buf_refs = self._buf_refs
         while True:
-            if self._streaming:
-                dead = []
-                for sv in self._streaming:
-                    if not _audiomix.voice_active(sv.idx):
-                        dead.append(sv)
-                        continue
-                    self._fill_ringbuf(sv)
-                for sv in dead:
-                    sv.close()
-                    try:
-                        self._streaming.remove(sv)
-                    except ValueError:
-                        pass  # already removed by _stop_streaming
-                    self._buf_refs.pop(sv.idx, None)
+            if _streaming:
+                # Walk active streams; collect dead ones into the reused
+                # buffer. List indexing avoids the iterator allocation
+                # that `for sv in self._streaming` would create.
+                n = len(_streaming)
+                i = 0
+                while i < n:
+                    sv = _streaming[i]
+                    if not _voice_active(sv.idx):
+                        _dead.append(sv)
+                    else:
+                        self._fill_ringbuf(sv)
+                    i += 1
+                if _dead:
+                    n = len(_dead)
+                    i = 0
+                    while i < n:
+                        sv = _dead[i]
+                        sv.close()
+                        try:
+                            _streaming.remove(sv)
+                        except ValueError:
+                            pass  # already removed by _stop_streaming
+                        _buf_refs.pop(sv.idx, None)
+                        i += 1
+                    _dead.clear()
                 await sleep_ms(16)
             else:
                 await sleep_ms(100)

--- a/firmware/bodn/tft2_diag.py
+++ b/firmware/bodn/tft2_diag.py
@@ -1,0 +1,145 @@
+# bodn/tft2_diag.py -- secondary display hardware diagnostic
+#
+# REPL usage (after boot or main.py has run):
+#
+#     from bodn.tft2_diag import test
+#     test()
+#
+# The test:
+#   1. (re)initialises _spidma slot 1 for the secondary
+#   2. resets the panel via the shared RST pin
+#   3. drives RED, GREEN, BLUE, WHITE, BLACK full-screen for 1s each
+#   4. draws a 4-quadrant pattern so you can see CS/MOSI/DC integrity
+#
+# What to expect on healthy hardware:
+#   - All five solid colours render edge-to-edge with no fringing
+#   - The quadrant pattern shows top-left RED, top-right GREEN,
+#     bottom-left BLUE, bottom-right WHITE
+#
+# Failure signatures:
+#   - Stays white / unchanged across all colours -> CS, MOSI, or DC
+#     not reaching the panel (or panel VCC/GND broken)
+#   - Random noise that does not change with each colour ->
+#     the controller never received valid init commands; check RST
+#   - Colours wrong / swapped -> MADCTL / RGB-BGR config issue, not wiring
+#   - Quadrants smeared or duplicated -> SPI signal integrity (clock too
+#     fast for the wiring, or a long unshielded jumper)
+
+import time
+
+from machine import Pin
+
+from bodn import config
+from st7735 import ST7735
+
+
+def _build_displays():
+    """Init _spidma for both slots and return (tft, tft2)."""
+    import _spidma
+
+    _spidma.init(
+        sck=config.TFT_SCK,
+        mosi=config.TFT_MOSI,
+        baudrate=config.TFT_SPI_BAUDRATE,
+    )
+    # Re-adding a slot is safe; it overwrites the existing entry.
+    _spidma.add_display(
+        slot=0,
+        cs=config.TFT_CS,
+        dc=config.TFT_DC,
+        width=config.TFT_WIDTH,
+        height=config.TFT_HEIGHT,
+        col_off=config.TFT_COL_OFFSET,
+        row_off=config.TFT_ROW_OFFSET,
+    )
+    _spidma.add_display(
+        slot=1,
+        cs=config.TFT2_CS,
+        dc=config.TFT_DC,
+        width=config.TFT2_WIDTH,
+        height=config.TFT2_HEIGHT,
+        col_off=config.TFT2_COL_OFFSET,
+        row_off=config.TFT2_ROW_OFFSET,
+    )
+    rst = Pin(config.TFT_RST, Pin.OUT)
+    tft = ST7735(
+        0,
+        rst=rst,
+        width=config.TFT_WIDTH,
+        height=config.TFT_HEIGHT,
+        col_offset=config.TFT_COL_OFFSET,
+        row_offset=config.TFT_ROW_OFFSET,
+        madctl=config.TFT_MADCTL,
+        skip_reset=False,
+    )
+    tft2 = ST7735(
+        1,
+        rst=rst,
+        width=config.TFT2_WIDTH,
+        height=config.TFT2_HEIGHT,
+        col_offset=config.TFT2_COL_OFFSET,
+        row_offset=config.TFT2_ROW_OFFSET,
+        madctl=config.TFT2_MADCTL,
+        skip_reset=True,
+    )
+    return tft, tft2
+
+
+def test(hold_ms=1000):
+    """Drive solid colour cycles on BOTH displays so they can be compared.
+
+    Reading the result:
+      - If primary cycles colours and secondary stays white -> secondary
+        is not receiving slot-1 SPI traffic. Suspect CS=GPIO39 wiring or
+        the secondary module itself.
+      - If neither display cycles -> _spidma bus is dead or shared
+        wiring (SCK/MOSI/DC) is broken.
+      - If both cycle correctly -> displays are fine, the issue is
+        elsewhere in main.py.
+    """
+    print("tft2_diag: building displays (resets shared RST)")
+    tft, tft2 = _build_displays()
+
+    rgb = ST7735.rgb
+    colours = (
+        ("RED", rgb(255, 0, 0)),
+        ("GREEN", rgb(0, 255, 0)),
+        ("BLUE", rgb(0, 0, 255)),
+        ("WHITE", rgb(255, 255, 255)),
+        ("BLACK", 0),
+    )
+    for name, c in colours:
+        print("tft2_diag:", name, "-> both displays")
+        tft.fill(c)
+        tft.show()
+        tft2.fill(c)
+        tft2.show()
+        time.sleep_ms(hold_ms)
+
+    print("tft2_diag: quadrants on tft2 (TL=R TR=G BL=B BR=W)")
+    w, h = tft2.width, tft2.height
+    hw, hh = w // 2, h // 2
+    tft2.fill(0)
+    tft2.fill_rect(0, 0, hw, hh, rgb(255, 0, 0))
+    tft2.fill_rect(hw, 0, w - hw, hh, rgb(0, 255, 0))
+    tft2.fill_rect(0, hh, hw, h - hh, rgb(0, 0, 255))
+    tft2.fill_rect(hw, hh, w - hw, h - hh, rgb(255, 255, 255))
+    tft2.show()
+    print("tft2_diag: done")
+    return tft, tft2
+
+
+def cs_toggle(count=20, period_ms=100):
+    """Toggle TFT2_CS as a plain GPIO so you can scope it.
+
+    Useful when test() leaves both displays white -- this isolates whether
+    GPIO 39 itself can drive a pin, separate from the SPI peripheral.
+    """
+    cs = Pin(config.TFT2_CS, Pin.OUT)
+    print("tft2_diag: toggling GPIO", config.TFT2_CS, "x", count)
+    for _ in range(count):
+        cs.value(0)
+        time.sleep_ms(period_ms)
+        cs.value(1)
+        time.sleep_ms(period_ms)
+    print("tft2_diag: cs_toggle done")

--- a/firmware/bodn/tts.py
+++ b/firmware/bodn/tts.py
@@ -54,6 +54,10 @@ def say(key, audio, channel="ui"):
     Returns:
         True if a WAV was found and queued, False if neither a recording nor
         generated TTS exists for this key.
+
+    A new TTS clip cancels any TTS already playing on the channel; without
+    this they would round-robin onto separate voices in the channel's pool
+    and play simultaneously.
     """
     lang = get_language()
     cache_key = (lang, key)
@@ -63,6 +67,7 @@ def say(key, audio, channel="ui"):
         _PATH_CACHE[cache_key] = resolved
     if resolved is None:
         return False
+    audio.stop(channel=channel)
     audio.play(resolved, channel=channel)
     return True
 

--- a/firmware/bodn/ui/input.py
+++ b/firmware/bodn/ui/input.py
@@ -79,7 +79,9 @@ class BrightnessControl:
     """
 
     def __init__(self, initial=128, minimum=10, maximum=255, step=20, settings=None):
-        self._acc = EncoderAccumulator(settings=settings, fast_threshold=400, fast_multiplier=3)
+        self._acc = EncoderAccumulator(
+            settings=settings, fast_threshold=400, fast_multiplier=3
+        )
         self._value = initial
         self._min = minimum
         self._max = maximum

--- a/firmware/bodn/ui/input.py
+++ b/firmware/bodn/ui/input.py
@@ -79,9 +79,7 @@ class BrightnessControl:
     """
 
     def __init__(self, initial=128, minimum=10, maximum=255, step=20, settings=None):
-        self._acc = EncoderAccumulator(
-            settings=settings, fast_threshold=400, fast_multiplier=3
-        )
+        self._acc = EncoderAccumulator(settings=settings, fast_threshold=400, fast_multiplier=3)
         self._value = initial
         self._min = minimum
         self._max = maximum
@@ -201,6 +199,9 @@ class InputState:
         Call at a fast rate (~5 ms) from the input task. Edge events
         (press/release) are OR-latched: once set, they stay True until
         consume() copies them to the public arrays and clears them.
+
+        Hot path: indexed `while` loops (no enumerate/range allocation).
+        See docs/PERFORMANCE_GUIDELINES.md §"Avoiding GC stalls".
         """
         now = self._time_ms()
 
@@ -215,9 +216,11 @@ class InputState:
         on_press = self._on_press
 
         # Buttons
-        for i, btn in enumerate(buttons):
+        n_btn = len(buttons)
+        i = 0
+        while i < n_btn:
             prev = prev_btn[i]
-            cur = btn_deb[i].update(btn.value(), now)
+            cur = btn_deb[i].update(buttons[i].value(), now)
             btn_held[i] = cur
             if cur and not prev:
                 pend_bp[i] = True
@@ -227,11 +230,16 @@ class InputState:
             if not cur and prev:
                 pend_br[i] = True
             prev_btn[i] = cur
+            i += 1
 
         # Toggle switches (no debounce — physical latching)
         sw = self.sw
-        for i, switch in enumerate(self._switches):
-            sw[i] = switch.value() == 0
+        switches = self._switches
+        n_sw = len(switches)
+        i = 0
+        while i < n_sw:
+            sw[i] = switches[i].value() == 0
+            i += 1
 
         # Arcade buttons
         arc_pins = self._arcade_pins
@@ -242,9 +250,11 @@ class InputState:
         pend_ar = self._pend_arc_release
         pend_ap_ts = self._pend_arc_press_ts
 
-        for i, pin in enumerate(arc_pins):
+        n_arc = len(arc_pins)
+        i = 0
+        while i < n_arc:
             prev = prev_arc[i]
-            cur = arc_deb[i].update(pin.value(), now)
+            cur = arc_deb[i].update(arc_pins[i].value(), now)
             arc_held[i] = cur
             if cur and not prev:
                 pend_ap[i] = True
@@ -254,6 +264,7 @@ class InputState:
             if not cur and prev:
                 pend_ar[i] = True
             prev_arc[i] = cur
+            i += 1
 
         # Encoders
         encoders = self._encoders
@@ -268,7 +279,10 @@ class InputState:
         pend_ep = self._pend_enc_btn_press
         pend_er = self._pend_enc_btn_release
 
-        for i, enc in enumerate(encoders):
+        n_enc = len(encoders)
+        i = 0
+        while i < n_enc:
+            enc = encoders[i]
             pos = enc.value
             enc_pos[i] = pos
             d = pos - prev_enc_pos[i]
@@ -291,6 +305,7 @@ class InputState:
             if not cur_btn and p_btn:
                 pend_er[i] = True
             prev_enc_btn[i] = cur_btn
+            i += 1
 
     def native_press(self, kind, index, ts_ms=None):
         """Latch a press edge from native C module events.
@@ -331,6 +346,9 @@ class InputState:
 
         MCP1 buttons/arcade are handled by native_press/native_release.
         MCP2 encoder buttons and toggle switches are still Python-polled.
+
+        Hot path: runs at ~200 Hz from input_scan_task. Use indexed `while`
+        loops (no enumerate/range allocation). See PERFORMANCE_GUIDELINES.md.
         """
         now = self._time_ms()
 
@@ -346,7 +364,10 @@ class InputState:
         pend_ep = self._pend_enc_btn_press
         pend_er = self._pend_enc_btn_release
 
-        for i, enc in enumerate(encoders):
+        n = len(encoders)
+        i = 0
+        while i < n:
+            enc = encoders[i]
             pos = enc.value
             enc_pos[i] = pos
             d = pos - prev_enc_pos[i]
@@ -369,6 +390,7 @@ class InputState:
             if not cur_btn and p_btn:
                 pend_er[i] = True
             prev_enc_btn[i] = cur_btn
+            i += 1
 
     def set_on_press(self, callback):
         """Register a callback fired from scan() on debounced press edge.
@@ -386,6 +408,9 @@ class InputState:
         Call once per display frame from ScreenManager.tick(). This ensures
         that fast scans (200 Hz) feed into the slower display loop (~30 Hz)
         without losing short button presses.
+
+        Hot path: called every render frame. Uses indexed `while` loops to
+        avoid allocating range() iterators per call.
         """
         now = self._time_ms()
         n_btn = len(self._buttons)
@@ -399,13 +424,15 @@ class InputState:
         bjp = self.btn_just_pressed
         bjr = self.btn_just_released
         bp_ts = self.btn_press_ts
-        for i in range(n_btn):
+        i = 0
+        while i < n_btn:
             bjp[i] = pend_bp[i]
             bjr[i] = pend_br[i]
             if pend_bp[i]:
                 bp_ts[i] = pend_bp_ts[i]
             pend_bp[i] = False
             pend_br[i] = False
+            i += 1
 
         # Arcade buttons
         pend_ap = self._pend_arc_press
@@ -414,13 +441,15 @@ class InputState:
         ajp = self.arc_just_pressed
         ajr = self.arc_just_released
         ap_ts = self.arc_press_ts
-        for i in range(n_arc):
+        i = 0
+        while i < n_arc:
             ajp[i] = pend_ap[i]
             ajr[i] = pend_ar[i]
             if pend_ap[i]:
                 ap_ts[i] = pend_ap_ts[i]
             pend_ap[i] = False
             pend_ar[i] = False
+            i += 1
 
         # Encoder deltas (sum across scans) and buttons
         pend_ed = self._pend_enc_delta
@@ -429,13 +458,15 @@ class InputState:
         ed = self.enc_delta
         ebp = self.enc_btn_pressed
         ebjr = self.enc_btn_just_released
-        for i in range(n_enc):
+        i = 0
+        while i < n_enc:
             ed[i] = pend_ed[i]
             pend_ed[i] = 0
             ebp[i] = pend_ep[i]
             ebjr[i] = pend_er[i]
             pend_ep[i] = False
             pend_er[i] = False
+            i += 1
 
         # Update gesture detector with consumed state
         gh = self._g_held
@@ -444,20 +475,26 @@ class InputState:
         bh = self.btn_held
         ah = self.arc_held
         ebh = self.enc_btn_held
-        for i in range(n_btn):
+        i = 0
+        while i < n_btn:
             gh[i] = bh[i]
             gp[i] = bjp[i]
             gr[i] = bjr[i]
+            i += 1
         off = n_btn
-        for i in range(n_arc):
+        i = 0
+        while i < n_arc:
             gh[off + i] = ah[i]
             gp[off + i] = ajp[i]
             gr[off + i] = ajr[i]
+            i += 1
         off += n_arc
-        for i in range(n_enc):
+        i = 0
+        while i < n_enc:
             gh[off + i] = ebh[i]
             gp[off + i] = ebp[i]
             gr[off + i] = ebjr[i]
+            i += 1
         self.gestures.update(gh, gp, gr, now)
 
     def resync_encoders(self):
@@ -475,15 +512,42 @@ class InputState:
             self.enc_velocity[i] = 0
 
     def has_activity(self):
-        """Return True if any input changed this frame (for idle tracking)."""
-        if any(self.btn_just_pressed) or any(self.btn_just_released):
-            return True
-        if any(self.arc_just_pressed) or any(self.arc_just_released):
-            return True
-        if any(d != 0 for d in self.enc_delta):
-            return True
-        if any(self.enc_btn_pressed):
-            return True
+        """Return True if any input changed this frame (for idle tracking).
+
+        Hot path: called every frame. Indexed loops avoid the genexp
+        (`any(d != 0 for d in ...)`) and the iterators that ``any(list)``
+        otherwise creates -- both are fresh allocations per call.
+        """
+        bjp = self.btn_just_pressed
+        bjr = self.btn_just_released
+        n = len(bjp)
+        i = 0
+        while i < n:
+            if bjp[i] or bjr[i]:
+                return True
+            i += 1
+        ajp = self.arc_just_pressed
+        ajr = self.arc_just_released
+        n = len(ajp)
+        i = 0
+        while i < n:
+            if ajp[i] or ajr[i]:
+                return True
+            i += 1
+        ed = self.enc_delta
+        n = len(ed)
+        i = 0
+        while i < n:
+            if ed[i]:
+                return True
+            i += 1
+        ebp = self.enc_btn_pressed
+        n = len(ebp)
+        i = 0
+        while i < n:
+            if ebp[i]:
+                return True
+            i += 1
         return False
 
     def any_btn_pressed(self):

--- a/firmware/bodn/ui/pause.py
+++ b/firmware/bodn/ui/pause.py
@@ -60,6 +60,11 @@ class PauseMenu(Screen):
         self._hold_progress = 0.0
         self._last_hold_step = -1
         self._bar_visible = False  # True when bar pixels are on screen
+        # Cached menu labels — rebuilt only on language change. Building
+        # them every render() at 30 fps was allocating ~1 KB/frame and
+        # forcing a GC sweep every ~20 s.
+        self._items = None
+        self._items_lang = None
 
     @property
     def is_open(self):
@@ -201,11 +206,25 @@ class PauseMenu(Screen):
 
         The hold bar is NOT drawn here — it's handled as a direct
         partial update in _update_hold() to avoid full-screen redraws.
+
+        Hot path: while pause is open this fires every frame at 30 fps,
+        so menu labels are cached on the instance and refreshed only
+        when the language changes (see PERFORMANCE_GUIDELINES.md §7.1).
         """
         self._dirty = False
 
         if not self._open:
             return
+
+        # Refresh cached labels if language changed since last render.
+        lang = get_language()
+        if self._items is None or self._items_lang != lang:
+            self._items = (
+                t("pause_resume"),
+                t("pause_quit"),
+                t("pause_lang", lang.upper()),
+            )
+            self._items_lang = lang
 
         w = theme.width
         h = theme.height
@@ -217,16 +236,17 @@ class PauseMenu(Screen):
         # Title
         draw_centered(tft, t("pause_title"), h // 4 + 12, theme.WHITE, w, scale=2)
 
-        # Menu items
-        items = [
-            t("pause_resume"),
-            t("pause_quit"),
-            t("pause_lang", get_language().upper()),
-        ]
-        for i, label in enumerate(items):
+        # Menu items — indexed loop, no enumerate allocation.
+        items = self._items
+        n = len(items)
+        i = 0
+        sel = self._index
+        while i < n:
             y = h // 4 + 48 + i * 24
-            selected = i == self._index
-            if selected:
+            if i == sel:
                 tft.fill_rect(w // 6 + 8, y - 2, w * 2 // 3 - 16, 20, theme.MUTED)
-            color = theme.CYAN if selected else theme.WHITE
-            draw_centered(tft, label, y + 2, color, w)
+                color = theme.CYAN
+            else:
+                color = theme.WHITE
+            draw_centered(tft, items[i], y + 2, color, w)
+            i += 1

--- a/firmware/bodn/ui/space.py
+++ b/firmware/bodn/ui/space.py
@@ -219,6 +219,11 @@ class SpaceScreen(Screen):
         self._prev_sw0 = None  # None = not yet initialised
         self._prev_sw1 = None
         self._drone_zone = -1  # current throttle zone (0/1/2), -1 = not started
+        # Pin engine drone + scenario alarm to a single music-channel voice so
+        # each new play_buffer cleanly replaces the previous one. Without this,
+        # the audio engine round-robins to a free voice and the old loop keeps
+        # playing -- alarm + drone layered, or low+high drone layered.
+        self._music_voice = None
         self._arc_led_mode = None  # track current arcade LED mode to set-once
         self._alarm_active = False
         self._bridge_next = 0  # frame when next bridge ambience can play
@@ -248,6 +253,7 @@ class SpaceScreen(Screen):
         self._prev_sw0 = None  # reset so first-frame state is read without TTS
         self._prev_sw1 = None
         self._drone_zone = -1
+        self._music_voice = None
         self._alarm_active = False
         self._bridge_next = 0
         self._arc_led_mode = None
@@ -502,9 +508,17 @@ class SpaceScreen(Screen):
             self._drone_zone = zone
             buf = self._drone_bufs[zone] if self._drone_bufs else None
             if buf:
-                self._audio.play_buffer(buf, loop=True, channel="music")
+                self._music_voice = self._audio.play_buffer(
+                    buf, loop=True, channel="music", voice=self._music_voice
+                )
             else:
-                self._audio.tone(self._DRONE_FREQS[zone], 60000, "square", channel="music")
+                self._music_voice = self._audio.tone(
+                    self._DRONE_FREQS[zone],
+                    60000,
+                    "square",
+                    channel="music",
+                    voice=self._music_voice,
+                )
 
     # Bridge ambience: plays the bridge_loop once on an SFX channel at random
     # intervals during CRUISING.  ~8–20 s between plays at 30 fps.
@@ -532,14 +546,27 @@ class SpaceScreen(Screen):
         danger = self._SC_DANGER[sc]
         buf = self._alarm_bufs[danger] if self._alarm_bufs else None
         if buf:
-            self._audio.play_buffer(buf, loop=True, channel="music")
+            self._music_voice = self._audio.play_buffer(
+                buf, loop=True, channel="music", voice=self._music_voice
+            )
         else:
-            self._audio.tone(self._ALARM_FREQS[danger], 60000, "square", channel="music")
+            self._music_voice = self._audio.tone(
+                self._ALARM_FREQS[danger],
+                60000,
+                "square",
+                channel="music",
+                voice=self._music_voice,
+            )
         self._alarm_active = True
 
     def _stop_alarm(self):
         """Stop the alarm and resume the engine drone."""
         self._alarm_active = False
+        # Silence the music voice immediately. _update_drone will reclaim the
+        # same slot on the next frame; without this, the alarm loop keeps
+        # playing until the next throttle-zone change.
+        if self._audio and self._music_voice is not None:
+            self._audio.stop(voice=self._music_voice)
         self._drone_zone = -1  # force re-trigger on next update
 
     def _play_arc_tone(self, arc):

--- a/firmware/bodn/ui/space.py
+++ b/firmware/bodn/ui/space.py
@@ -440,9 +440,7 @@ class SpaceScreen(Screen):
         elif sw1 != self._prev_sw1:
             self._prev_sw1 = sw1
             # sw1 = free-play toggle (no scenarios when on)
-            self._speak_toggle(
-                "space_freeplay_on" if sw1 else "space_freeplay_off", sw1
-            )
+            self._speak_toggle("space_freeplay_on" if sw1 else "space_freeplay_off", sw1)
             self._dirty = True
             self._full_clear = True
 
@@ -450,9 +448,7 @@ class SpaceScreen(Screen):
         self._update_arcade_leds(state, frame)
 
         # NeoPixel LEDs — animate lid ring during active states, throttled
-        if self._leds_dirty or (
-            state in (ANNOUNCE, ACTIVE, HINT, SUCCESS) and frame % 3 == 0
-        ):
+        if self._leds_dirty or (state in (ANNOUNCE, ACTIVE, HINT, SUCCESS) and frame % 3 == 0):
             self._leds_dirty = False
             self._write_leds(state, frame)
 
@@ -508,14 +504,14 @@ class SpaceScreen(Screen):
             if buf:
                 self._audio.play_buffer(buf, loop=True, channel="music")
             else:
-                self._audio.tone(
-                    self._DRONE_FREQS[zone], 60000, "square", channel="music"
-                )
+                self._audio.tone(self._DRONE_FREQS[zone], 60000, "square", channel="music")
 
     # Bridge ambience: plays the bridge_loop once on an SFX channel at random
     # intervals during CRUISING.  ~8–20 s between plays at 30 fps.
-    _BRIDGE_MIN = const(240)  # ~8 s
-    _BRIDGE_SPREAD = const(360)  # +0–12 s
+    # Plain class attrs (not const()) so they're reachable via self. — MicroPython
+    # hoists class-scope const() names to the module, breaking self._BRIDGE_*.
+    _BRIDGE_MIN = 240  # ~8 s
+    _BRIDGE_SPREAD = 360  # +0–12 s
 
     def _maybe_play_bridge(self, frame):
         """Occasionally play bridge ambience during cruising."""
@@ -538,9 +534,7 @@ class SpaceScreen(Screen):
         if buf:
             self._audio.play_buffer(buf, loop=True, channel="music")
         else:
-            self._audio.tone(
-                self._ALARM_FREQS[danger], 60000, "square", channel="music"
-            )
+            self._audio.tone(self._ALARM_FREQS[danger], 60000, "square", channel="music")
         self._alarm_active = True
 
     def _stop_alarm(self):
@@ -670,14 +664,10 @@ class SpaceScreen(Screen):
                 )
             elif sc == SC_COURSE:
                 col = self._engine.target_color or (255, 200, 0)
-                neo.zone_pattern(
-                    LR, neo.PAT_PULSE, speed=2, colour=col, brightness=lid_bright
-                )
+                neo.zone_pattern(LR, neo.PAT_PULSE, speed=2, colour=col, brightness=lid_bright)
             elif sc == SC_LANDING:
                 col = self._engine.target_color or (0, 200, 60)
-                neo.zone_pattern(
-                    LR, neo.PAT_PULSE, speed=2, colour=col, brightness=lid_bright
-                )
+                neo.zone_pattern(LR, neo.PAT_PULSE, speed=2, colour=col, brightness=lid_bright)
             else:
                 neo.zone_off(LR)
         elif state == ANNOUNCE:
@@ -779,9 +769,7 @@ class SpaceScreen(Screen):
         tft.fill_rect(0, 20, w, h - 40, theme.BLACK)
 
         # Top label: free-play vs ordinary cruise
-        label_key = (
-            "space_freeplay_label" if self._engine.stealth else "space_cruising_label"
-        )
+        label_key = "space_freeplay_label" if self._engine.stealth else "space_cruising_label"
         label_col = theme.MAGENTA if self._engine.stealth else theme.CYAN
         draw_centered(tft, t(label_key), h // 2 - 8, label_col, w)
         # Shield indicator
@@ -856,19 +844,13 @@ class SpaceScreen(Screen):
         tft.rect(8, h - 36, bar_w, 8, theme.MUTED)
         filled = int(prog * (bar_w - 2))
         if filled > 0:
-            col = (
-                theme.GREEN
-                if prog > 0.5
-                else (theme.YELLOW if prog > 0.25 else theme.RED)
-            )
+            col = theme.GREEN if prog > 0.5 else (theme.YELLOW if prog > 0.25 else theme.RED)
             tft.fill_rect(9, h - 35, filled, 6, col)
 
     def _render_success(self, tft, theme, frame, w, h):
         """Celebration screen."""
         tft.fill_rect(0, 20, w, h - 40, theme.BLACK)
-        draw_centered(
-            tft, t("space_success_label"), h // 2 - 12, theme.YELLOW, w, scale=2
-        )
+        draw_centered(tft, t("space_success_label"), h // 2 - 12, theme.YELLOW, w, scale=2)
         draw_centered(tft, t("space_success_sub"), h // 2 + 12, theme.GREEN, w)
 
     def _render_instruments(self, tft, theme, w, h, eng):
@@ -918,9 +900,5 @@ class SpaceScreen(Screen):
         tft.rect(8, h - 36, bar_w, 8, theme.MUTED)
         filled = int(prog * (bar_w - 2))
         if filled > 0:
-            col = (
-                theme.GREEN
-                if prog > 0.5
-                else (theme.YELLOW if prog > 0.25 else theme.RED)
-            )
+            col = theme.GREEN if prog > 0.5 else (theme.YELLOW if prog > 0.25 else theme.RED)
             tft.fill_rect(9, h - 35, filled, 6, col)

--- a/firmware/bodn/ui/space.py
+++ b/firmware/bodn/ui/space.py
@@ -446,7 +446,9 @@ class SpaceScreen(Screen):
         elif sw1 != self._prev_sw1:
             self._prev_sw1 = sw1
             # sw1 = free-play toggle (no scenarios when on)
-            self._speak_toggle("space_freeplay_on" if sw1 else "space_freeplay_off", sw1)
+            self._speak_toggle(
+                "space_freeplay_on" if sw1 else "space_freeplay_off", sw1
+            )
             self._dirty = True
             self._full_clear = True
 
@@ -454,7 +456,9 @@ class SpaceScreen(Screen):
         self._update_arcade_leds(state, frame)
 
         # NeoPixel LEDs — animate lid ring during active states, throttled
-        if self._leds_dirty or (state in (ANNOUNCE, ACTIVE, HINT, SUCCESS) and frame % 3 == 0):
+        if self._leds_dirty or (
+            state in (ANNOUNCE, ACTIVE, HINT, SUCCESS) and frame % 3 == 0
+        ):
             self._leds_dirty = False
             self._write_leds(state, frame)
 
@@ -691,10 +695,14 @@ class SpaceScreen(Screen):
                 )
             elif sc == SC_COURSE:
                 col = self._engine.target_color or (255, 200, 0)
-                neo.zone_pattern(LR, neo.PAT_PULSE, speed=2, colour=col, brightness=lid_bright)
+                neo.zone_pattern(
+                    LR, neo.PAT_PULSE, speed=2, colour=col, brightness=lid_bright
+                )
             elif sc == SC_LANDING:
                 col = self._engine.target_color or (0, 200, 60)
-                neo.zone_pattern(LR, neo.PAT_PULSE, speed=2, colour=col, brightness=lid_bright)
+                neo.zone_pattern(
+                    LR, neo.PAT_PULSE, speed=2, colour=col, brightness=lid_bright
+                )
             else:
                 neo.zone_off(LR)
         elif state == ANNOUNCE:
@@ -796,7 +804,9 @@ class SpaceScreen(Screen):
         tft.fill_rect(0, 20, w, h - 40, theme.BLACK)
 
         # Top label: free-play vs ordinary cruise
-        label_key = "space_freeplay_label" if self._engine.stealth else "space_cruising_label"
+        label_key = (
+            "space_freeplay_label" if self._engine.stealth else "space_cruising_label"
+        )
         label_col = theme.MAGENTA if self._engine.stealth else theme.CYAN
         draw_centered(tft, t(label_key), h // 2 - 8, label_col, w)
         # Shield indicator
@@ -871,13 +881,19 @@ class SpaceScreen(Screen):
         tft.rect(8, h - 36, bar_w, 8, theme.MUTED)
         filled = int(prog * (bar_w - 2))
         if filled > 0:
-            col = theme.GREEN if prog > 0.5 else (theme.YELLOW if prog > 0.25 else theme.RED)
+            col = (
+                theme.GREEN
+                if prog > 0.5
+                else (theme.YELLOW if prog > 0.25 else theme.RED)
+            )
             tft.fill_rect(9, h - 35, filled, 6, col)
 
     def _render_success(self, tft, theme, frame, w, h):
         """Celebration screen."""
         tft.fill_rect(0, 20, w, h - 40, theme.BLACK)
-        draw_centered(tft, t("space_success_label"), h // 2 - 12, theme.YELLOW, w, scale=2)
+        draw_centered(
+            tft, t("space_success_label"), h // 2 - 12, theme.YELLOW, w, scale=2
+        )
         draw_centered(tft, t("space_success_sub"), h // 2 + 12, theme.GREEN, w)
 
     def _render_instruments(self, tft, theme, w, h, eng):
@@ -927,5 +943,9 @@ class SpaceScreen(Screen):
         tft.rect(8, h - 36, bar_w, 8, theme.MUTED)
         filled = int(prog * (bar_w - 2))
         if filled > 0:
-            col = theme.GREEN if prog > 0.5 else (theme.YELLOW if prog > 0.25 else theme.RED)
+            col = (
+                theme.GREEN
+                if prog > 0.5
+                else (theme.YELLOW if prog > 0.25 else theme.RED)
+            )
             tft.fill_rect(9, h - 35, filled, 6, col)

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -227,7 +227,11 @@ def create_hardware():
         # Append extra toggle switches from MCP2 (sw[2] = SW_L, sw[3] = SW_R)
         switches.append(mcp2.pin(config.MCP2_SW_LEFT))
         switches.append(mcp2.pin(config.MCP2_SW_RIGHT))
-        print("MCP2 (0x{:02X}) initialised — encoder switches + 2 toggles".format(config.MCP2_ADDR))
+        print(
+            "MCP2 (0x{:02X}) initialised — encoder switches + 2 toggles".format(
+                config.MCP2_ADDR
+            )
+        )
     except Exception as e:
         print(
             "MCP2 (0x{:02X}) not found, encoder buttons via fallback: {}".format(
@@ -242,10 +246,14 @@ def create_hardware():
         # Restore backlight — PCA9685.reset() turned all channels off
         pwm.set_duty(config.PWM_CH_BACKLIGHT, 4095)
         hw_status["pca"] = True
-        print("PCA9685 (0x{:02X}) initialised — PWM @ 1 kHz".format(config.PCA9685_ADDR))
+        print(
+            "PCA9685 (0x{:02X}) initialised — PWM @ 1 kHz".format(config.PCA9685_ADDR)
+        )
     except Exception as e:
         print(
-            "PCA9685 (0x{:02X}) not found, PWM dimming disabled: {}".format(config.PCA9685_ADDR, e)
+            "PCA9685 (0x{:02X}) not found, PWM dimming disabled: {}".format(
+                config.PCA9685_ADDR, e
+            )
         )
 
     # PN532 NFC reader (shared I2C bus)
@@ -362,7 +370,9 @@ def create_ui(
     theme = Theme(config.TFT_WIDTH, config.TFT_HEIGHT, ST7735.rgb)
     theme2 = Theme(config.TFT2_WIDTH, config.TFT2_HEIGHT, ST7735.rgb)
     arcade_pins = arcade.pins if arcade else []
-    inp = InputState(buttons, switches, encoders, time.ticks_ms, arcade_pins=arcade_pins)
+    inp = InputState(
+        buttons, switches, encoders, time.ticks_ms, arcade_pins=arcade_pins
+    )
     overlay = SessionOverlay(session_mgr, settings=settings)
 
     # Primary display — full screen manager with navigation
@@ -744,7 +754,9 @@ async def input_scan_task(mcp, mcp2, inp, switches=None):
         await asyncio.sleep_ms(5)
 
 
-async def primary_task(manager, settings, inp, encoders, mcp, mcp2, idle_tracker, power_mgr):
+async def primary_task(
+    manager, settings, inp, encoders, mcp, mcp2, idle_tracker, power_mgr
+):
     """Display update + power management with frame-skip budgeting.
 
     update() always runs (game logic, timing accumulators).
@@ -929,7 +941,9 @@ async def primary_task(manager, settings, inp, encoders, mcp, mcp2, idle_tracker
             idle_tracker.timeout_s = settings.get("sleep_timeout_s", 300)
 
         if settings.get("debug_input") and frame % 15 == 0:
-            btns = "".join("1" if inp.btn_held[i] else "." for i in range(len(inp.btn_held)))
+            btns = "".join(
+                "1" if inp.btn_held[i] else "." for i in range(len(inp.btn_held))
+            )
             sws = "".join("1" if inp.sw[i] else "." for i in range(len(inp.sw)))
             n_enc = len(encoders)
             enc_vals = " ".join("{}".format(inp.enc_pos[i]) for i in range(n_enc))
@@ -941,7 +955,11 @@ async def primary_task(manager, settings, inp, encoders, mcp, mcp2, idle_tracker
                 )
                 for i in range(n_enc)
             )
-            print("INP btn[{}] sw[{}] enc[{}] raw[{}]".format(btns, sws, enc_vals, enc_raw))
+            print(
+                "INP btn[{}] sw[{}] enc[{}] raw[{}]".format(
+                    btns, sws, enc_vals, enc_raw
+                )
+            )
 
         # ── Perf stats ───────────────────────────────────────
         if _perf and frame > 0 and frame % _PERF_INTERVAL == 0:
@@ -1146,7 +1164,9 @@ async def housekeeping_task(session_mgr, settings, audio=None, pwm=None):
             elif bat_status == "critical" and _prev_bat != "critical":
                 mv = battery.voltage_mv()
                 print(
-                    "BAT CRITICAL ({}mV <= {}mV): killing NeoPixels".format(mv, config.BAT_CRIT_MV)
+                    "BAT CRITICAL ({}mV <= {}mV): killing NeoPixels".format(
+                        mv, config.BAT_CRIT_MV
+                    )
                 )
                 neo.set_override(neo.OVERRIDE_BLACK)
 
@@ -1286,7 +1306,11 @@ async def nfc_scan_task(manager, mode_screens, session_mgr, audio, settings):
                             on_progress = make_launch_splash(manager, mode)
                             on_progress(0, 1)
                         try:
-                            screen = factory(on_progress=on_progress) if on_progress else factory()
+                            screen = (
+                                factory(on_progress=on_progress)
+                                if on_progress
+                                else factory()
+                            )
                         except TypeError:
                             screen = factory()
                         if mode != "settings":
@@ -1334,7 +1358,9 @@ async def main():
         except Exception as e:
             print("Failed to save session:", e)
 
-    session_mgr = SessionManager(settings, get_time, get_date, on_session_end=on_session_end)
+    session_mgr = SessionManager(
+        settings, get_time, get_date, on_session_end=on_session_end
+    )
     wifi_ctrl = WiFiController(settings)
 
     # Create IdleTracker up front and expose it via settings so the HTTP

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -758,6 +758,16 @@ async def primary_task(manager, settings, inp, encoders, mcp, mcp2, idle_tracker
     ticks_diff = time.ticks_diff
     prev_render_ms = 0
     tft = manager.tft
+    # Slow-frame watchdog — only enabled when debug_perf is on. When active
+    # it logs any frame that crosses _SLOW_FRAME_MS, with the gc.mem_free
+    # delta so GC sweeps stand out from SD/I/O stalls. Off by default to
+    # keep the print() out of the hot path during normal play.
+    _slow_watchdog = settings.get("debug_perf", False)
+    if _slow_watchdog:
+        import gc as _gc
+
+        _gc_mem_free = _gc.mem_free
+    _SLOW_FRAME_MS = 80
     _dma = getattr(tft, "_native", False)
     # vsync=True (default): skip frame if DMA busy (tear-free)
     # vsync=False: draw over buffer during DMA (may tear, higher FPS)
@@ -814,6 +824,8 @@ async def primary_task(manager, settings, inp, encoders, mcp, mcp2, idle_tracker
             manager.invalidate()
 
         t0 = ticks_ms()
+        if _slow_watchdog:
+            _wd_free0 = _gc_mem_free()
 
         # ── Input + game logic (always runs) ──────────────────
         try:
@@ -829,6 +841,8 @@ async def primary_task(manager, settings, inp, encoders, mcp, mcp2, idle_tracker
                 sys.print_exception(e)
             else:
                 print("primary_task update error #{}: {}".format(errors, e))
+        if _slow_watchdog:
+            _wd_t_update = ticks_ms()
 
         # ── Graphics — DMA-aware or predictive budget ─────────
         if _dma:
@@ -864,6 +878,23 @@ async def primary_task(manager, settings, inp, encoders, mcp, mcp2, idle_tracker
             prev_render_ms = 0  # reset predictor after a skip
             if _perf:
                 _perf_skips += 1
+
+        if _slow_watchdog:
+            _wd_total = ticks_diff(ticks_ms(), t0)
+            if _wd_total > _SLOW_FRAME_MS:
+                _wd_update = ticks_diff(_wd_t_update, t0)
+                _wd_render = _wd_total - _wd_update
+                _wd_free1 = _gc_mem_free()
+                print(
+                    "slow frame: total={}ms (upd={}, ren={}) free {}->{} (Δ{:+d})".format(
+                        _wd_total,
+                        _wd_update,
+                        _wd_render,
+                        _wd_free0,
+                        _wd_free1,
+                        _wd_free1 - _wd_free0,
+                    )
+                )
 
         # ── Power management ──────────────────────────────────
         if inp.has_activity():

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -227,11 +227,7 @@ def create_hardware():
         # Append extra toggle switches from MCP2 (sw[2] = SW_L, sw[3] = SW_R)
         switches.append(mcp2.pin(config.MCP2_SW_LEFT))
         switches.append(mcp2.pin(config.MCP2_SW_RIGHT))
-        print(
-            "MCP2 (0x{:02X}) initialised — encoder switches + 2 toggles".format(
-                config.MCP2_ADDR
-            )
-        )
+        print("MCP2 (0x{:02X}) initialised — encoder switches + 2 toggles".format(config.MCP2_ADDR))
     except Exception as e:
         print(
             "MCP2 (0x{:02X}) not found, encoder buttons via fallback: {}".format(
@@ -246,14 +242,10 @@ def create_hardware():
         # Restore backlight — PCA9685.reset() turned all channels off
         pwm.set_duty(config.PWM_CH_BACKLIGHT, 4095)
         hw_status["pca"] = True
-        print(
-            "PCA9685 (0x{:02X}) initialised — PWM @ 1 kHz".format(config.PCA9685_ADDR)
-        )
+        print("PCA9685 (0x{:02X}) initialised — PWM @ 1 kHz".format(config.PCA9685_ADDR))
     except Exception as e:
         print(
-            "PCA9685 (0x{:02X}) not found, PWM dimming disabled: {}".format(
-                config.PCA9685_ADDR, e
-            )
+            "PCA9685 (0x{:02X}) not found, PWM dimming disabled: {}".format(config.PCA9685_ADDR, e)
         )
 
     # PN532 NFC reader (shared I2C bus)
@@ -370,9 +362,7 @@ def create_ui(
     theme = Theme(config.TFT_WIDTH, config.TFT_HEIGHT, ST7735.rgb)
     theme2 = Theme(config.TFT2_WIDTH, config.TFT2_HEIGHT, ST7735.rgb)
     arcade_pins = arcade.pins if arcade else []
-    inp = InputState(
-        buttons, switches, encoders, time.ticks_ms, arcade_pins=arcade_pins
-    )
+    inp = InputState(buttons, switches, encoders, time.ticks_ms, arcade_pins=arcade_pins)
     overlay = SessionOverlay(session_mgr, settings=settings)
 
     # Primary display — full screen manager with navigation
@@ -673,57 +663,88 @@ async def input_scan_task(mcp, mcp2, inp, switches=None):
     Python drains events and scans MCP2 + encoders only.
 
     Edges are latched until the display task calls inp.consume().
+
+    Hot-path allocation discipline: this loop runs 200 times per second, so
+    allocations here are the dominant pressure on MicroPython's GC. We:
+      - reuse `_event_buf` across calls via _mcpinput.drain_events()
+      - cache len() results outside loops
+      - use indexed `while` loops instead of enumerate()/range()/genexps
+    See docs/PERFORMANCE_GUIDELINES.md §"Avoiding GC stalls".
     """
     import _mcpinput
 
-    # Build MCP1 pin → (kind, index) lookup from config
+    # Build MCP1 pin → (kind, index) lookup from config (one-time)
     _pin_map = {}
-    for i, p in enumerate(config.MCP_BTN_PINS):
-        _pin_map[p] = ("btn", i)
-    for i, p in enumerate(config.MCP_ARC_PINS):
-        _pin_map[p] = ("arc", i)
+    _btn_pins = config.MCP_BTN_PINS
+    _arc_pins = config.MCP_ARC_PINS
+    n = len(_btn_pins)
+    i = 0
+    while i < n:
+        _pin_map[_btn_pins[i]] = ("btn", i)
+        i += 1
+    n = len(_arc_pins)
+    i = 0
+    while i < n:
+        _pin_map[_arc_pins[i]] = ("arc", i)
+        i += 1
     # MCP1 toggle switch pins (read from bitmask, not events)
     _sw_pins = config.MCP_SW_PINS
-    # Number of MCP1 switches (sw[0], sw[1])
     _n_mcp1_sw = len(_sw_pins)
     _sw = switches or []
+    _n_sw = len(_sw)
+
+    # Pre-allocated event buffer reused across drain calls. List clear()
+    # keeps the backing array, so once it's grown to handle a typical burst
+    # the storage is reused indefinitely with zero allocation steady-state.
+    _event_buf = []
+    _PRESS = _mcpinput.PRESS
+    _drain = _mcpinput.drain_events
+    _read_state = _mcpinput.read_state
+    _native_press = inp.native_press
+    _native_release = inp.native_release
+    _scan_encoders = inp.scan_encoders
+    _inp_sw = inp.sw
 
     while True:
         try:
-            # Drain debounced events from C module
-            events = _mcpinput.get_events()
-            for ev_type, pin, ts in events:
-                mapping = _pin_map.get(pin)
+            # Drain debounced events from C module into our reused buffer.
+            n_ev = _drain(_event_buf)
+            ev_i = 0
+            while ev_i < n_ev:
+                ev = _event_buf[ev_i]
+                mapping = _pin_map.get(ev[1])
                 if mapping:
-                    kind, idx = mapping
-                    if ev_type == _mcpinput.PRESS:
-                        inp.native_press(kind, idx, ts)
+                    if ev[0] == _PRESS:
+                        _native_press(mapping[0], mapping[1], ev[2])
                     else:
-                        inp.native_release(kind, idx)
+                        _native_release(mapping[0], mapping[1])
+                ev_i += 1
 
             # Read MCP1 toggle switch state from bitmask
-            port_state = _mcpinput.read_state()
-            for i in range(_n_mcp1_sw):
-                inp.sw[i] = bool(port_state & (1 << _sw_pins[i]))
+            port_state = _read_state()
+            i = 0
+            while i < _n_mcp1_sw:
+                _inp_sw[i] = bool(port_state & (1 << _sw_pins[i]))
+                i += 1
 
             # Read MCP2 toggle switches (sw[2], sw[3], etc.) via Python
-            for i in range(_n_mcp1_sw, len(_sw)):
-                inp.sw[i] = _sw[i].value() == 0
+            i = _n_mcp1_sw
+            while i < _n_sw:
+                _inp_sw[i] = _sw[i].value() == 0
+                i += 1
 
             # MCP2 refresh for encoder buttons
             if mcp2:
                 mcp2.refresh()
 
             # Encoders + encoder buttons (PCNT + MCP2)
-            inp.scan_encoders()
+            _scan_encoders()
         except Exception:
             pass
         await asyncio.sleep_ms(5)
 
 
-async def primary_task(
-    manager, settings, inp, encoders, mcp, mcp2, idle_tracker, power_mgr
-):
+async def primary_task(manager, settings, inp, encoders, mcp, mcp2, idle_tracker, power_mgr):
     """Display update + power management with frame-skip budgeting.
 
     update() always runs (game logic, timing accumulators).
@@ -877,9 +898,7 @@ async def primary_task(
             idle_tracker.timeout_s = settings.get("sleep_timeout_s", 300)
 
         if settings.get("debug_input") and frame % 15 == 0:
-            btns = "".join(
-                "1" if inp.btn_held[i] else "." for i in range(len(inp.btn_held))
-            )
+            btns = "".join("1" if inp.btn_held[i] else "." for i in range(len(inp.btn_held)))
             sws = "".join("1" if inp.sw[i] else "." for i in range(len(inp.sw)))
             n_enc = len(encoders)
             enc_vals = " ".join("{}".format(inp.enc_pos[i]) for i in range(n_enc))
@@ -891,11 +910,7 @@ async def primary_task(
                 )
                 for i in range(n_enc)
             )
-            print(
-                "INP btn[{}] sw[{}] enc[{}] raw[{}]".format(
-                    btns, sws, enc_vals, enc_raw
-                )
-            )
+            print("INP btn[{}] sw[{}] enc[{}] raw[{}]".format(btns, sws, enc_vals, enc_raw))
 
         # ── Perf stats ───────────────────────────────────────
         if _perf and frame > 0 and frame % _PERF_INTERVAL == 0:
@@ -1025,8 +1040,7 @@ async def housekeeping_task(session_mgr, settings, audio=None, pwm=None):
 
             elif temp_status == "critical" and _prev_temp != "critical":
                 print(
-                    "TEMP CRITICAL ({}C >= {}C): "
-                    "killing NeoPixels, dimming backlight".format(
+                    "TEMP CRITICAL ({}C >= {}C): killing NeoPixels, dimming backlight".format(
                         int(t_max), config.TEMP_CRIT_C
                     )
                 )
@@ -1101,9 +1115,7 @@ async def housekeeping_task(session_mgr, settings, audio=None, pwm=None):
             elif bat_status == "critical" and _prev_bat != "critical":
                 mv = battery.voltage_mv()
                 print(
-                    "BAT CRITICAL ({}mV <= {}mV): killing NeoPixels".format(
-                        mv, config.BAT_CRIT_MV
-                    )
+                    "BAT CRITICAL ({}mV <= {}mV): killing NeoPixels".format(mv, config.BAT_CRIT_MV)
                 )
                 neo.set_override(neo.OVERRIDE_BLACK)
 
@@ -1243,11 +1255,7 @@ async def nfc_scan_task(manager, mode_screens, session_mgr, audio, settings):
                             on_progress = make_launch_splash(manager, mode)
                             on_progress(0, 1)
                         try:
-                            screen = (
-                                factory(on_progress=on_progress)
-                                if on_progress
-                                else factory()
-                            )
+                            screen = factory(on_progress=on_progress) if on_progress else factory()
                         except TypeError:
                             screen = factory()
                         if mode != "settings":
@@ -1295,9 +1303,7 @@ async def main():
         except Exception as e:
             print("Failed to save session:", e)
 
-    session_mgr = SessionManager(
-        settings, get_time, get_date, on_session_end=on_session_end
-    )
+    session_mgr = SessionManager(settings, get_time, get_date, on_session_end=on_session_end)
     wifi_ctrl = WiFiController(settings)
 
     # Create IdleTracker up front and expose it via settings so the HTTP

--- a/firmware/st7735.py
+++ b/firmware/st7735.py
@@ -50,6 +50,9 @@ class ST7735(framebuf.FrameBuffer):
         skip_reset=False,
     ):
         self._slot = slot
+        # main.py inspects this flag to pick the DMA-aware render gate
+        # (vsync on tft.busy()) over the legacy 33ms predictive budget.
+        self._native = True
         self.rst = rst
         self.width = width
         self.height = height

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,13 @@ dependencies = [
 [tool.black]
 target-version = ["py312"]
 
+# Empty [tool.ruff] section on purpose. Without it, ruff walks up the
+# directory tree looking for config and picks up a parent pyproject.toml
+# (e.g. ~/work/pyproject.toml) which silently changes line-length and
+# produces diffs that disagree with CI. This stops the walk; defaults
+# (line-length=88) match what CI uses.
+[tool.ruff]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["firmware"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -429,7 +429,7 @@ class _FakeAudiomix:
         if idx in self._voices:
             self._voices[idx]["active"] = False
 
-    def voice_tone(self, idx, freq, duration_ms, wave_id):
+    def voice_tone(self, idx, freq, duration_ms, wave_id, fade=0):
         self._voices[idx] = {"active": True, "type": "tone", "freq": freq}
 
     def voice_tone_sustained(self, idx, freq, wave_id):
@@ -479,7 +479,7 @@ class _FakeAudiomix:
             dst[i] = 0
         return len(dst) // 2
 
-    def voice_play_buffer(self, idx, data, length, loop):
+    def voice_play_buffer(self, idx, data, length, loop, fade=0):
         self._voices[idx] = {"active": True, "type": "buffer"}
 
     def voice_start_stream(self, idx, loop):

--- a/tools/convert_audio.py
+++ b/tools/convert_audio.py
@@ -38,8 +38,10 @@ import argparse
 import json
 import re
 import shutil
+import struct
 import subprocess
 import sys
+import wave
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -81,9 +83,57 @@ def check_ffmpeg():
         sys.exit("ERROR: ffmpeg not found. Install it: brew install ffmpeg")
 
 
-def _convert_file(
-    src: Path, dst: Path, dry_run: bool, force: bool, normalize: bool
-) -> str:
+# Loop files are trimmed to zero crossings within this many samples of each
+# edge so seam wraps don't click. 160 samples = 10 ms at 16 kHz — long enough
+# to find a crossing in any musical signal, short enough to be inaudible.
+_LOOP_TRIM_WINDOW_SAMPLES = 160
+
+
+def _zero_cross_trim_loop(path: Path) -> tuple[int, int] | None:
+    """In-place trim a 16 kHz mono 16-bit PCM WAV to its nearest zero crossings.
+
+    Looks within _LOOP_TRIM_WINDOW_SAMPLES at each edge for a sample whose
+    absolute value is small AND whose sign matches the opposite edge's sign,
+    so the wrap-around step is minimal.
+
+    Returns (start_idx, end_idx) on success, None if the file isn't a format
+    we can trim (will be left untouched and the caller continues).
+    """
+    try:
+        with wave.open(str(path), "rb") as wav:
+            if wav.getnchannels() != 1 or wav.getsampwidth() != 2:
+                return None
+            n_frames = wav.getnframes()
+            if n_frames < 2 * _LOOP_TRIM_WINDOW_SAMPLES:
+                return None
+            framerate = wav.getframerate()
+            raw = wav.readframes(n_frames)
+    except (wave.Error, OSError):
+        return None
+
+    samples = struct.unpack("<{}h".format(n_frames), raw)
+    window = min(_LOOP_TRIM_WINDOW_SAMPLES, n_frames // 4)
+
+    # Find sample with smallest |value| in each edge window.
+    start = min(range(window), key=lambda i: abs(samples[i]))
+    end_off = min(range(window), key=lambda i: abs(samples[n_frames - 1 - i]))
+    end = n_frames - end_off
+
+    # Already at zero — skip rewrite.
+    if start == 0 and end == n_frames:
+        return start, end
+
+    trimmed = samples[start:end]
+    raw_out = struct.pack("<{}h".format(len(trimmed)), *trimmed)
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(framerate)
+        wav.writeframes(raw_out)
+    return start, end
+
+
+def _convert_file(src: Path, dst: Path, dry_run: bool, force: bool, normalize: bool) -> str:
     """
     Convert src → dst.  Returns 'converted', 'skipped', 'missing', or 'error'.
     """
@@ -121,6 +171,10 @@ def _convert_file(
         print(f"  ERROR  {src.name}: {err}", file=sys.stderr)
         _errors += 1
         return "error"
+
+    # Loop files: trim to zero crossings so the wrap-around doesn't click.
+    if dst.suffix == ".wav" and dst.stem.endswith("_loop"):
+        _zero_cross_trim_loop(dst)
 
     kib = dst.stat().st_size // 1024
     print(f"  converted  {rel_src}  →  {rel_dst}  ({kib} KiB)")
@@ -301,9 +355,7 @@ def process_story_tts(dry_run: bool, force: bool, normalize: bool):
         else:
             print(f"  no WAV files in build/story_tts_raw/")
     else:
-        print(
-            f"  build/story_tts_raw/ not found — run tools/generate_story_tts.py first."
-        )
+        print(f"  build/story_tts_raw/ not found — run tools/generate_story_tts.py first.")
 
     # Stage story scripts into build/stories/
     _stage_story_scripts(dry_run, force)
@@ -329,9 +381,7 @@ def process_story_recordings(dry_run: bool, force: bool, normalize: bool):
         if not rec_root.is_dir():
             continue
         sources = sorted(
-            f
-            for f in rec_root.rglob("*")
-            if f.is_file() and f.suffix.lower() in AUDIO_EXTS
+            f for f in rec_root.rglob("*") if f.is_file() and f.suffix.lower() in AUDIO_EXTS
         )
         if not sources:
             continue
@@ -362,15 +412,11 @@ def _stage_story_scripts(dry_run: bool, force: bool):
         if not force and dst.exists() and dst.stat().st_mtime >= src.stat().st_mtime:
             continue
         if dry_run:
-            print(
-                f"  would copy  {src.relative_to(REPO_ROOT)}  →  {dst.relative_to(REPO_ROOT)}"
-            )
+            print(f"  would copy  {src.relative_to(REPO_ROOT)}  →  {dst.relative_to(REPO_ROOT)}")
         else:
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dst)
-            print(
-                f"  copied  {src.relative_to(REPO_ROOT)}  →  {dst.relative_to(REPO_ROOT)}"
-            )
+            print(f"  copied  {src.relative_to(REPO_ROOT)}  →  {dst.relative_to(REPO_ROOT)}")
 
 
 def process_kits(dry_run: bool, force: bool, normalize: bool):
@@ -402,11 +448,7 @@ def process_kits(dry_run: bool, force: bool, normalize: bool):
             src = SOURCE_DIR / src_rel
             dst = BUILD_SOUNDS / "kits" / kit_name / f"{drum_name}.wav"
             status = _convert_file(src, dst, dry_run, force, normalize)
-            label = (
-                drum_val.get("en", drum_name)
-                if isinstance(drum_val, dict)
-                else drum_name
-            )
+            label = drum_val.get("en", drum_name) if isinstance(drum_val, dict) else drum_name
             print(f"    {label}: {status}")
 
 


### PR DESCRIPTION
## Summary

Follow-up to #200 covering the entire audio + perf debugging session. Twelve commits, several distinct bugs, all surfacing as Spaceship-mode crackling and the occasional half-second UI hang.

## What landed

- **Display gate restored** (`f6247b3`). `ST7735._native` was dropped in the DMA-only refactor, so `main.py` was silently using the legacy 33 ms predictive budget — frames got skipped frame-after-frame whenever the predictor latched high. Restored, frames now go through the DMA `tft.busy()` gate.
- **MicroPython class-scope `const()` bug** (`a1fa401`). `self._BRIDGE_SPREAD` raised `AttributeError` every CRUISING frame; the exception was swallowed as a generic update error and skipped render.
- **Music-pool voice pinning** (`e9cb60f`). `audio._allocate_voice` round-robins to a free slot; drone and alarm were landing on different voices and layering. Now pinned to one slot.
- **Click-free source swaps** (`57b4421`). New `pending_*` fields + a `fade=True` default on `play_buffer`/`tone`. Sequential fade-out → fade-in across a source change.
- **Equal-power crossfade for BUFFER → BUFFER** (`ef752c7`). Replaces the V-shaped sequential fade with a true cos²/sin² overlap. Drone-zone changes are now click-free in the common case.
- **Per-frame allocations on the 200 Hz input scan** (`551c2fd`). Was the dominant GC pressure: `enumerate()`, `range()`, generator expressions, and `_mcpinput.get_events()` returning a fresh list per call. Replaced with indexed `while` loops and a new `_mcpinput.drain_events(buf)` that reuses a caller-owned list.
- **TTS layering, ringbuf, pause menu** (`38233cf`). TTS clips were stacking on top of each other (UI pool round-robin); now `tts.say()` stops the channel first. `AUDIOMIX_RINGBUF_SIZE` 2 KB → 8 KB (64 ms → 256 ms) — covered the slow-frame budget that was causing TTS-only crackling. Pause menu items cached, audio streaming feeder reuses its `_dead` list.
- **Crossfade in-flight retarget** (`8e4b1e8`). The mid-flight substitution path was producing clicks on rapid throttle spin. Retargets are now queued via `next_pending_*` and applied after the current crossfade completes — chains cleanly through any number of rapid zone changes.
- **`_native` flag, ringbuf size, xfade length, secondary-display diagnostic, performance docs section §7.1**, and a saved memory codifying \"hot Python at ≥30 Hz must not allocate\".

## Test plan

- [ ] Pull, build custom firmware (`./tools/build-firmware.sh flash`), and re-run sd-sync (`uv run python tools/convert_audio.py --force && uv run python tools/sd-sync.py`) so loop WAVs are zero-cross-trimmed.
- [ ] Spaceship: encoder bars track encoders during cruise.
- [ ] Spaceship: drone goes up *and* down through zones cleanly.
- [ ] Spaceship: alarm dies at scenario resolve, doesn't continue into cruise.
- [ ] Spaceship: TTS plays without crackling during scenario announcements.
- [ ] Spaceship: no overlapping TTS narration when two scenarios fire close together.
- [ ] Spaceship: pause menu doesn't allocate per frame (no GC sweeps from sitting in pause).
- [ ] All other modes still work — the audio engine and input scan changes are global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)